### PR TITLE
add dsh-island: bridge DSH status to CodeIsland macOS notch panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git)  — Structured safe Git tools: status/diff/log/branch/stage/commit/stash/show with a destructive-command guard. (✅ active)
 - [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search)  — Per-agent on-demand tool discovery and progressive schema disclosure. (✅ active)
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index)  — Turn-index sidebar: one entry per user turn, click to jump with scroll-spy highlighting. (✅ active)
+- [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny.
 
 ### Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -311,6 +311,7 @@ dsh web
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git)  — 结构化安全 Git 工具：status/diff/log/branch/stage/commit/stash/show，带破坏性命令防护。（✅ 活跃）
 - [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search)  — 按 Agent 按需工具发现与渐进式 schema 披露。（✅ 活跃）
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index)  — 回合索引侧栏：每个用户回合一条，点击跳转，滚动监听高亮。（✅ 活跃）
+- [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - 通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。
 
 ### Skills
 


### PR DESCRIPTION
Adds dsh-island under Plugins.