### PR TITLE
Add dsh-smooth-stream to plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,157 +159,213 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [petdex](https://github.com/crafter-station/petdex) | ⭐3,777 | A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. | ✅ active |
-| 2 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | ⭐1,697 | Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. | ✅ active |
-| 3 | [modlens](https://github.com/liustack/modlens) | ⭐1,158 | The first vision plugin for DeepSeek Harness and the vision bridge for every text-only coding agent: paste an image and it works. | ✅ active |
-| 4 | [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | ⭐684 | Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. | ✅ active |
-| 5 | [museai](https://github.com/yejiming/MuseAI) | ⭐538 | 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） | ✅ active |
-| 6 | [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | ⭐506 | Whale-girl skin series for DSH Web (CC BY-NC-SA 4.0). | ✅ active |
-| 7 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐309 | Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. | ✅ active |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐302 | Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. | ✅ active |
-| 9 | [whale-girl](https://github.com/vlln/whale-girl) | ⭐118 | Desktop pet plugin (QQ-pet style) floating at the bottom-right of the DSH Web GUI: draggable, feedable and playable. | ✅ active |
-| 10 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | ⭐116 | Codex-style @file mentions inside the DSH composer: search workspace files and attach their contents to prompts. | ✅ active |
+| 1 | [petdex](https://github.com/crafter-station/petdex) | ⭐3,825 | A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. | ✅ active |
+| 2 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | ⭐2,484 | Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. | ✅ active |
+| 3 | [dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) | ⭐1,831 | Two-phase DeepSeek Harness preset: Minimal-aligned bootstrap, then full Standard tools (Project2 98/99) | ✅ active |
+| 4 | [modlens](https://github.com/liustack/modlens) | ⭐1,736 | The first vision plugin for DeepSeek Harness and the vision bridge for every text-only coding agent: paste an image and it works. | ✅ active |
+| 5 | [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | ⭐1,065 | Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. | ✅ active |
+| 6 | [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | ⭐834 | Whale-girl skin series for DSH Web (CC BY-NC-SA 4.0). | ✅ active |
+| 7 | [museai](https://github.com/yejiming/MuseAI) | ⭐556 | 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） | ✅ active |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐409 | Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. | ✅ active |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐396 | Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. | ✅ active |
+| 10 | [dsh-market](https://github.com/dsh-market/dsh-market) | ⭐218 | Visual plugin market inside DeepSeek Harness: browse, search and one-click install. | ✅ active |
 
-#### Complete list (138)
+#### Complete list (194)
 
-- [petdex](https://github.com/crafter-station/petdex) ⭐3,777 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. (✅ active)
-- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐1,697 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
-- [modlens](https://github.com/liustack/modlens) ⭐1,158 — The first vision plugin for DeepSeek Harness and the vision bridge for every text-only coding agent: paste an image and it works. (✅ active)
-- [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) ⭐684 — Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. (✅ active)
-- [museai](https://github.com/yejiming/MuseAI) ⭐538 — 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） (✅ active)
-- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) ⭐506 — Whale-girl skin series for DSH Web (CC BY-NC-SA 4.0). (✅ active)
-- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) ⭐309 — Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. (✅ active)
-- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) ⭐302 — Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. (✅ active)
-- [whale-girl](https://github.com/vlln/whale-girl) ⭐118 — Desktop pet plugin (QQ-pet style) floating at the bottom-right of the DSH Web GUI: draggable, feedable and playable. (✅ active)
-- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) ⭐116 — Codex-style @file mentions inside the DSH composer: search workspace files and attach their contents to prompts. (✅ active)
-- [modsearch](https://github.com/liustack/modsearch) ⭐85 — Web plugin for DSH and the search bridge for every model without native web access. (✅ active)
-- [dsh-browser](https://github.com/Lum1104/dsh-browser) ⭐78 — Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required. (✅ active)
-- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐74 — Interactive HTML UI rendered directly in conversation with streaming preview and sandbox rendering. (✅ active)
-- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐71 — Generative UI inside conversations: layouts, charts, forms, quizzes, Mermaid and interactive events rendered inline. (✅ active)
-- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐67 — Plugin discovery utility for the DSH ecosystem. (✅ active)
-- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐47 — Cross-session long-term memory + background self-evolution: five-track memory, git-branch awareness, in-turn self-review and skill evolution. (✅ active)
-- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) ⭐39 — Select text in DSH Web, annotate it and send the annotation with your message; replies cross-reference each annotation. (✅ active)
-- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) ⭐39 — Open DSH workspace directories/files directly in VS Code from the web GUI. (✅ active)
-- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) ⭐37 — Desktop notifications for turn completions with per-outcome controls and include/exclude keyword filters. (✅ active)
-- [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐35 — Rewind conversation and workspace state, powered by a persistent change ledger. (✅ active)
-- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) ⭐29 — Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). (✅ active)
-- [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) ⭐28 — Browse, install and update every GitHub topic:dsh-plugin plugin from the DSH Web GUI. (✅ active)
-- [ui-status-label](https://github.com/alingalingling/ui-status-label) ⭐28 — Customize the whale's 'Deep diving' status label into anything you want. (✅ active)
-- [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) ⭐27 — Hand-drawn pixel whale companion in the session title bar: blinks, wags its tail, spouts water when a turn completes. (✅ active)
-- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) ⭐22 — Create and manage sandboxed JavaScript tools for DSH with a Monaco editor and model-driven tool lists. (✅ active)
-- [dskin](https://github.com/dancingmemory/dskin) ⭐22 — Cartoon pixel skin plugin for DSH Web GUI: pixel pets that walk, blink and jump over the original interface. (✅ active)
-- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐20 — Import conversation history from Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix and OpenCode into resumable DSH sessions. (✅ active)
-- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) ⭐18 — Skin system with 21 built-in themes plus one-image custom skin generation, contrast-validated at build time. (✅ active)
-- [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) ⭐18 — 为 DeepSeek Harness 提供电脑控制插件：新鲜 Accessibility 观测、过期状态拒绝、作用域权限与安全输入（目前支持macos）｜Accessibility-first macOS Computer Use bundle for DSH with fresh observations, stale-state rejection, scoped permissions, and safe input. (✅ active)
-- [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) ⭐18 — Compact side panel with a file browser, terminal and Git review. (✅ active)
-- [anysearch-dsh](https://github.com/anysearch-team/anysearch-dsh) ⭐17 — AnySearch web search provider and advanced search tools for DeepSeek Harness. (✅ active)
-- [deepseek-harness-snowsalt](https://github.com/KYZHXL/deepseek-harness-snowsalt) ⭐17 — Snow-salt themed skin for DeepSeek Harness. (✅ active)
+- [petdex](https://github.com/crafter-station/petdex) ⭐3,825 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. (✅ active)
+- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐2,484 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
+- [dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) ⭐1,831 — Two-phase DeepSeek Harness preset: Minimal-aligned bootstrap, then full Standard tools (Project2 98/99) (✅ active)
+- [modlens](https://github.com/liustack/modlens) ⭐1,736 — The first vision plugin for DeepSeek Harness and the vision bridge for every text-only coding agent: paste an image and it works. (✅ active)
+- [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) ⭐1,065 — Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. (✅ active)
+- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) ⭐834 — Whale-girl skin series for DSH Web (CC BY-NC-SA 4.0). (✅ active)
+- [museai](https://github.com/yejiming/MuseAI) ⭐556 — 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） (✅ active)
+- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) ⭐409 — Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. (✅ active)
+- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) ⭐396 — Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. (✅ active)
+- [dsh-market](https://github.com/dsh-market/dsh-market) ⭐218 — Visual plugin market inside DeepSeek Harness: browse, search and one-click install. (✅ active)
+- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) ⭐198 — Codex-style @file mentions inside the DSH composer: search workspace files and attach their contents to prompts. (✅ active)
+- [whale-girl](https://github.com/vlln/whale-girl) ⭐160 — Desktop pet plugin (QQ-pet style) floating at the bottom-right of the DSH Web GUI: draggable, feedable and playable. (✅ active)
+- [dsh-browser](https://github.com/Lum1104/dsh-browser) ⭐140 — Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required. (✅ active)
+- [v4-flash-godmode-opencode-go](https://github.com/SheberDavid/v4-flash-godmode-opencode-go) ⭐127 — V4 Flash 神模式 (opencode-go)：让 opencode-go 的 DeepSeek V4 Flash 从鬼模式切换到神模式的 dsh agent preset (✅ active)
+- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) ⭐111 — Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). (✅ active)
+- [modsearch](https://github.com/liustack/modsearch) ⭐104 — Web plugin for DSH and the search bridge for every model without native web access. (✅ active)
+- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐100 — Interactive HTML UI rendered directly in conversation with streaming preview and sandbox rendering. (✅ active)
+- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐99 — Generative UI inside conversations: layouts, charts, forms, quizzes, Mermaid and interactive events rendered inline. (✅ active)
+- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐89 — Plugin discovery utility for the DSH ecosystem. (✅ active)
+- [dsh-gitbash-preset](https://github.com/liceses/dsh-gitbash-preset) ⭐86 — DeepSeek Harness 插件：一键安装「极简模式 (Git Bash)」agent preset —— 把 DSH 自带极简模式中的 bash 调用映射到 Git for Windows 的 bash（MSYS），让 Windows 上的极简模式真正可用。 (✅ active)
+- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐82 — Cross-session long-term memory + background self-evolution: five-track memory, git-branch awareness, in-turn self-review and skill evolution. (✅ active)
+- [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) ⭐64 — Browse, install and update every GitHub topic:dsh-plugin plugin from the DSH Web GUI. (✅ active)
+- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) ⭐50 — Select text in DSH Web, annotate it and send the annotation with your message; replies cross-reference each annotation. (✅ active)
+- [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐50 — Rewind conversation and workspace state, powered by a persistent change ledger. (✅ active)
+- [dsh-auto-mode](https://github.com/NanmiCoder/dsh-auto-mode) ⭐48 — Safe automatic permissions for DeepSeek Harness. (✅ active)
+- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) ⭐47 — Desktop notifications for turn completions with per-outcome controls and include/exclude keyword filters. (✅ active)
+- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) ⭐42 — Open DSH workspace directories/files directly in VS Code from the web GUI. (✅ active)
+- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) ⭐42 — Community plugin market in the Web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall to a profile. (✅ active)
+- [dsh-context](https://github.com/bowenliang123/dsh-context) ⭐40 — A DeepSeek Harness plugin for  Context insight dashboard — showing what the model's context window is made of and how it evolves. (✅ active)
+- [dsh-pet](https://github.com/PC2005-cloud/dsh-pet) ⭐38 — DeepSeek Harness 桌面宠物插件 + 完整素材生成链：AI 提示词 → 绿幕视频 → 透明动画 → 可安装插件，从零到宠物全流程可复现 (✅ active)
+- [dsh-plugins-store](https://github.com/ZASENJC/dsh-plugins-store) ⭐38 — Static directory site that automatically collects and categorizes GitHub dsh-plugin topic projects. (✅ active)
+- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) ⭐34 — Skin system with 21 built-in themes plus one-image custom skin generation, contrast-validated at build time. (✅ active)
+- [dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) ⭐33 — Manage plugins from the Web UI: view, live enable/disable, install/uninstall, env management and plugin market. (✅ active)
+- [ui-status-label](https://github.com/alingalingling/ui-status-label) ⭐32 — Customize the whale's 'Deep diving' status label into anything you want. (✅ active)
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) ⭐31 — DeepSeek Harness 会话费用统计插件:本会话费用、当日费用、历史记录与官方价格同步 (✅ active)
+- [anysearch-dsh](https://github.com/anysearch-team/anysearch-dsh) ⭐30 — AnySearch web search provider and advanced search tools for DeepSeek Harness. (✅ active)
+- [dsh-kun-like-pet](https://github.com/liyupi/dsh-kun-like-pet) ⭐30 — Kun Like 桌宠 —— DeepSeek Harness 桌面宠物插件：右下角小坤宠随 Agent 工作状态切换 9 种动作，任务完成播放「你干嘛~哎哟」 (✅ active)
+- [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) ⭐30 — Hand-drawn pixel whale companion in the session title bar: blinks, wags its tail, spouts water when a turn completes. (✅ active)
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐29 — Import conversation history from Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix and OpenCode into resumable DSH sessions. (✅ active)
+- [dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) ⭐29 — Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the DeepSeek Harness Web GUI (dsh web). (✅ active)
+- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) ⭐26 — Three-tier local memory: runtime hot memory, project documents and long-term memory spaces, with supervised writeback. (✅ active)
+- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) ⭐24 — Create and manage sandboxed JavaScript tools for DSH with a Monaco editor and model-driven tool lists. (✅ active)
+- [dsh-transparent-ui-plugin](https://github.com/WYH66666666/DSH-Transparent-UI-Plugin) ⭐24 — 是一层高自由度的玻璃质感主题，套在 DeepSeek Harness 网页端。顶栏、侧边栏、输入框、统计行、轨迹视图都成了磨砂玻璃片。玻璃模糊度、磨砂度、背景（流体或自定义壁纸，壁纸还能单独调模糊和磨砂）全都能在设置卡片里自由调节。关掉开关就回到原生界面，不改 DSH 任何一行源码。 (✅ active)
+- [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) ⭐23 — Agent-assisted plugin discovery: search the live GitHub dsh-plugin topic from inside DSH. (✅ active)
+- [dsh-navbar](https://github.com/vlln/dsh-navbar) ⭐23 — DSH 插件：对话节点导航条（右缘节点串快速跳转 user 消息）。官方 bundle 插件，dsh plugin --profile web add 安装 (✅ active)
+- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) ⭐23 — Plugin management panel: enable/disable installed plugins plus a GitHub dsh-plugin marketplace with one-click install. (✅ active)
+- [dsh-vision (william-jin-cmu)](https://github.com/william-jin-cmu/dsh-vision) ⭐23 — Vision bridge: view_image tool over any OpenAI-compatible VLM, defaulting to Zhipu's free tier. (✅ active)
+- [deepseek-harness-snowsalt](https://github.com/KYZHXL/deepseek-harness-snowsalt) ⭐21 — Snow-salt themed skin for DeepSeek Harness. (✅ active)
+- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) ⭐21 — Branch-based message editing, reroll, retry and version timeline. (✅ active)
+- [dskin](https://github.com/dancingmemory/dskin) ⭐21 — Cartoon pixel skin plugin for DSH Web GUI: pixel pets that walk, blink and jump over the original interface. (✅ active)
+- [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) ⭐20 — 为 DeepSeek Harness 提供电脑控制插件：新鲜 Accessibility 观测、过期状态拒绝、作用域权限与安全输入（目前支持macos）｜Accessibility-first macOS Computer Use bundle for DSH with fresh observations, stale-state rejection, scoped permissions, and safe input. (✅ active)
+- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) ⭐20 — Expose MinerU document parsing to the model: PDF/images/DOCX/PPTX/XLSX to structured Markdown/JSON. (✅ active)
+- [dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) ⭐20 — Steam Workshop-style plugin browser for the DSH Web UI: zero-server, GitHub-powered search and one-click install. (✅ active)
+- [dsh-share](https://github.com/hellodigua/dsh-share) ⭐19 — One-click conversation sharing for DSH. (✅ active)
+- [dsh-minigames](https://github.com/lhh010/dsh-minigames) ⭐18 — DSH Web UI 右侧小游戏面板：18 款离线小游戏（恐龙跳一跳 / 俄罗斯方块 / 坦克大战 / 扫雷 / 2048 / 数独 / 吃豆人 / 跟枪练习等），可扩展游戏注册表，等待模型回复或修 bug 时的摸鱼神器 (✅ active)
+- [dsh-plugin](https://github.com/Tabbit-Browser/dsh-plugin) ⭐18 — Tabbit Broser plugins for Deepseek Harness (✅ active)
+- [dsh-emoji](https://github.com/hellodigua/dsh-emoji) ⭐17 — Let AI replies add custom emoji reactions. (✅ active)
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) ⭐17 — Plugin health checks: manifest protocol, patch format, build pitfalls and hub listing status, zero-dependency read-only. (✅ active)
-- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) ⭐16 — Branch-based message editing, reroll, retry and version timeline. (✅ active)
-- [dsh-share](https://github.com/hellodigua/dsh-share) ⭐16 — One-click conversation sharing for DSH. (✅ active)
-- [dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) ⭐16 — Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the DeepSeek Harness Web GUI (dsh web). (✅ active)
-- [dsh-vision (william-jin-cmu)](https://github.com/william-jin-cmu/dsh-vision) ⭐16 — Vision bridge: view_image tool over any OpenAI-compatible VLM, defaulting to Zhipu's free tier. (✅ active)
-- [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) ⭐15 — Zero-dependency tool suite: calculator, CSV, diff, encoding, JSON, Markdown, regex and time utilities. (✅ active)
-- [dsh-group-photo](https://github.com/SenmuuuuW/dsh-group-photo) ⭐14 — DSH 内测收官合影墙：GitHub OAuth 零权限登录 + 冻结白名单校验的拍立得合影站（含 DSH Skill 包装） (✅ active)
-- [dsh-navbar](https://github.com/vlln/dsh-navbar) ⭐14 — DSH 插件：对话节点导航条（右缘节点串快速跳转 user 消息）。官方 bundle 插件，dsh plugin --profile web add 安装 (✅ active)
-- [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) ⭐13 — DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。 (✅ active)
-- [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) ⭐12 — 为 dsh 提供新的「聚焦会话」精简会话视图，更轻松易于阅读，只关注最终产出结果。 (✅ active)
-- [dsh-kun-like-pet](https://github.com/liyupi/dsh-kun-like-pet) ⭐12 — Kun Like 桌宠 —— DeepSeek Harness 桌面宠物插件：右下角小坤宠随 Agent 工作状态切换 9 种动作，任务完成播放「你干嘛~哎哟」 (✅ active)
-- [dsh-market](https://github.com/dsh-market/dsh-market) ⭐12 — Visual plugin market inside DeepSeek Harness: browse, search and one-click install. (✅ active)
-- [dsh-minigames](https://github.com/lhh010/dsh-minigames) ⭐12 — DSH Web UI 右侧小游戏面板：18 款离线小游戏（恐龙跳一跳 / 俄罗斯方块 / 坦克大战 / 扫雷 / 2048 / 数独 / 吃豆人 / 跟枪练习等），可扩展游戏注册表，等待模型回复或修 bug 时的摸鱼神器 (✅ active)
-- [dsh-plugins-store](https://github.com/ZASENJC/dsh-plugins-store) ⭐12 — Static directory site that automatically collects and categorizes GitHub dsh-plugin topic projects. (✅ active)
-- [ego-browser](https://github.com/Fisfzy/ego-browser) ⭐12 — Bring the ego-lite agent browser (Chromium for AI agents) into DSH with 13 structured tools. (✅ active)
-- [DeepSeek-Harness-Web-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Web-Tools) ⭐11 — Free, keyless web_search and web_fetch for DSH, DuckDuckGo-backed with no signup. (✅ active)
-- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) ⭐11 — DeepSeek account balance and session cost readout for the DeepSeek Harness Web GUI (✅ active)
-- [dsh-emoji](https://github.com/hellodigua/dsh-emoji) ⭐11 — Let AI replies add custom emoji reactions. (✅ active)
-- [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) ⭐11 — Agent-assisted plugin discovery: search the live GitHub dsh-plugin topic from inside DSH. (✅ active)
-- [dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) ⭐11 — Play Gomoku with AI inside DSH, or let two AIs battle to compare models. (✅ active)
-- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) ⭐11 — Three-tier local memory: runtime hot memory, project documents and long-term memory spaces, with supervised writeback. (✅ active)
+- [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) ⭐17 — Zero-dependency tool suite: calculator, CSV, diff, encoding, JSON, Markdown, regex and time utilities. (✅ active)
+- [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) ⭐16 — 为 dsh 提供新的「聚焦会话」精简会话视图，更轻松易于阅读，只关注最终产出结果。 (✅ active)
+- [dsh-group-photo](https://github.com/SenmuuuuW/dsh-group-photo) ⭐16 — DSH 内测收官合影墙：GitHub OAuth 零权限登录 + 冻结白名单校验的拍立得合影站（含 DSH Skill 包装） (✅ active)
+- [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) ⭐16 — Compact side panel with a file browser, terminal and Git review. (💤 inactive)
+- [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) ⭐16 — DSH WebUI sticker plugin for bidirectional user and agent reactions (✅ active)
+- [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) ⭐15 — DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。 (✅ active)
+- [dsh-balance](https://github.com/crazywoola/dsh-balance) ⭐14 — DeepSeek Harness balance plugin for the Settings page. (✅ active)
+- [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) ⭐14 — Git-style milestone timeline rail: hover for metadata, click to jump to any message. (✅ active)
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) ⭐13 — DeepSeek account balance and session cost readout for the DeepSeek Harness Web GUI (✅ active)
+- [dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) ⭐13 — Play Gomoku with AI inside DSH, or let two AIs battle to compare models. (✅ active)
+- [ego-browser](https://github.com/Fisfzy/ego-browser) ⭐13 — Bring the ego-lite agent browser (Chromium for AI agents) into DSH with 13 structured tools. (✅ active)
+- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) ⭐12 — Model-driven context compression (Active Context Pruning): the model decides when and what to compress. (✅ active)
+- [DeepSeek-Harness-Web-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Web-Tools) ⭐12 — Free, keyless web_search and web_fetch for DSH, DuckDuckGo-backed with no signup. (✅ active)
+- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) ⭐12 — PiUI-style Web diff viewer replacing the default diff view. (✅ active)
+- [dsh-plugin-pet-rs](https://github.com/HuanLinOTO/dsh-plugin-pet-rs) ⭐12 — Rust desktop pet: 5-state whale with dual SSE real-time push, transparent always-on-top window and system tray. (✅ active)
+- [dsh-remote](https://github.com/flymysql/dsh-remote) ⭐12 — Remote workspace: connect a host over SSH and operate a remote directory with rw_* tools. (✅ active)
+- [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) ⭐12 — Adds desktop notification reminders to DSH. (✅ active)
+- [dsh-recommend](https://github.com/zp-home/dsh-recommend) ⭐11 — Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data with an open scoring model. (✅ active)
 - [dsh-sdk-platform-rs](https://github.com/kpn-dsh/dsh-sdk-platform-rs) ⭐11 — A Rust SDK to interact with the DSH Platform. This library provides convenient building blocks for services that need to connect to DSH Kafka, fetch tokens for various protocols, manage Prometheus metrics, and more. (✅ active)
-- [dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) ⭐11 — Manage plugins from the Web UI: view, live enable/disable, install/uninstall, env management and plugin market. (✅ active)
-- [dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) ⭐10 — Steam Workshop-style plugin browser for the DSH Web UI: zero-server, GitHub-powered search and one-click install. (✅ active)
-- [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) ⭐10 — DSH 本机安全审计插件：配置/插件来源/会话/网络暴露面，只读脱敏风险报告 (✅ active)
-- [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) ⭐10 — Stock market data plugin (joke: fixes the bug where your account loses money while you code). (✅ active)
-- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) ⭐10 — Community plugin market in the Web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall to a profile. (✅ active)
-- [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) ⭐9 — Git-style milestone timeline rail: hover for metadata, click to jump to any message. (✅ active)
-- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) ⭐9 — Expose MinerU document parsing to the model: PDF/images/DOCX/PPTX/XLSX to structured Markdown/JSON. (✅ active)
+- [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) ⭐11 — DSH 本机安全审计插件：配置/插件来源/会话/网络暴露面，只读脱敏风险报告 (✅ active)
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) ⭐11 — Codex-style skin switcher plus custom translucent wallpaper with opacity/blur controls. (✅ active)
+- [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) ⭐11 — Stock market data plugin (joke: fixes the bug where your account loses money while you code). (✅ active)
+- [DeepSeek-Harness-Vision-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Vision-Tools) ⭐10 — Vision proxy for chat: give DSH eyes with any text model plus any vision model. (✅ active)
+- [dsh-mneme](https://github.com/modusensus/dsh-mneme) ⭐10 — Local cross-session memory with memory sovereignty: SQLite + human-editable Markdown mirror and background autoDream consolidation. (✅ active)
+- [touhou-hakurei](https://github.com/xiake595/touhou-hakurei) ⭐10 — 灵梦（Reimu）·博丽神社（东方Project）美化版皮肤：神社昼夜实景背景、灵梦立绘、画框侧边栏与输入框、纸白透明界面 — DeepSeek Harness Web GUI skin (✅ active)
+- [DeepSeek-Harness-billing-plugin](https://github.com/WilliamLIiii/DeepSeek-Harness-billing-plugin) ⭐9 — Account balance plus per-model remaining-task estimator with a session cost ledger. (✅ active)
+- [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) ⭐9 — 🐋 DSH 有声桌宠：悬浮桌面的 DeepSeek 小鲸鱼，不打开 DSH 也能实时感知会话状态（需要确认/工作中/完成/空闲/离线），支持音效提醒与零代码定制素材 (✅ active)
+- [dsh-plugin-better-sidebar-plugin-office](https://github.com/HuanLinOTO/dsh-plugin-better-sidebar-plugin-office) ⭐9 — Office-suite preview (.docx/.xlsx/.pptx) for the Better Sidebar, as a standalone slim bundle. (✅ active)
 - [dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) ⭐9 — Frame-level diagnostics for multi-frame zstd session files: torn/corrupted/empty session detection, zero-dependency read-only. (✅ active)
-- [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) ⭐9 — Adds desktop notification reminders to DSH. (✅ active)
 - [deepseek-harness-SupportVisionModel](https://github.com/TryDing-T/deepseek-harness-SupportVisionModel) ⭐8 — Secondary development of deepseek-harness supporting a separately configured vision model for reading images. (✅ active)
-- [DeepSeek-Harness-Vision-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Vision-Tools) ⭐8 — Vision proxy for chat: give DSH eyes with any text model plus any vision model. (✅ active)
-- [dsh-mneme](https://github.com/modusensus/dsh-mneme) ⭐8 — Local cross-session memory with memory sovereignty: SQLite + human-editable Markdown mirror and background autoDream consolidation. (✅ active)
+- [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) ⭐8 — Spreadsheet-style skin for DSH, mimicking Excel. (✅ active)
 - [dsh-paste-input](https://github.com/lhh010/dsh-paste-input) ⭐8 — WebUI file input enhancement: Ctrl+V paste, drag & drop and file picker, copied into the session workspace. (✅ active)
-- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) ⭐7 — Model-driven context compression (Active Context Pruning): the model decides when and what to compress. (✅ active)
-- [DeepSeek-Harness-billing-plugin](https://github.com/WilliamLIiii/DeepSeek-Harness-billing-plugin) ⭐7 — Account balance plus per-model remaining-task estimator with a session cost ledger. (✅ active)
+- [dsh-plugin-ya-workspace-sidebar](https://github.com/HuanLinOTO/dsh-plugin-ya-workspace-sidebar) ⭐8 — DSH Web 工作区侧栏替代，顶部全局最近会话 + Workspace→Session 二级菜单 + 面包屑 | DSH Web workspace sidebar replacement: top global recent sessions + Workspace→Session two-level menu + breadcrumbs (✅ active)
+- [dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) ⭐8 — Replaces the 'Deep diving…' turn-status label with phase-aware typewriter messages. (✅ active)
+- [dsh-undo-plugin](https://github.com/lire1131/dsh-undo-plugin) ⭐8 — DSH plugin: snapshot & rollback your plugin/skin/settings configs. Auto-save on change, undo/redo stack, snapshot manager panel, keyboard shortcuts, plus an offline PowerShell CLI & GUI that work even when DSH won't boot. (✅ active)
+- [dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) ⭐7 — DSH 自动记忆插件:三层记忆(用户级/项目笔记/每日日志)自动注入与检索、每日反思、可视化面板与设置页,支持继承其他 AI 工具的历史记忆。An auto-memory plugin for the DeepSeek Harness Web GUI: three-layer memory (user-level / project notes / daily logs) with automatic injection and retrieval, daily reflections, a visual panel and settings page, and inheritance of memories from other AI tools. (✅ active)
+- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) ⭐7 — Audits what actually enters every model request: token cost of AGENTS.md chains, skill catalogs and tool schemas, with duplicate/conflict detection. (✅ active)
 - [dsh-director-toolkit](https://github.com/lhmd/dsh-director-toolkit) ⭐7 — DSH Director Toolkit is a DeepSeek Harness plugin for 3D artists, technical designers, and creative coders. Paste a half-formed idea, a reference note, or a portfolio caption and get a compact direction pack for Blender, Three.js, Houdini, or C4D. (✅ active)
-- [dsh-plugin-better-sidebar-plugin-office](https://github.com/HuanLinOTO/dsh-plugin-better-sidebar-plugin-office) ⭐7 — Office-suite preview (.docx/.xlsx/.pptx) for the Better Sidebar, as a standalone slim bundle. (✅ active)
-- [dsh-plugin-pet-rs](https://github.com/HuanLinOTO/dsh-plugin-pet-rs) ⭐7 — Rust desktop pet: 5-state whale with dual SSE real-time push, transparent always-on-top window and system tray. (✅ active)
-- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) ⭐6 — Audits what actually enters every model request: token cost of AGENTS.md chains, skill catalogs and tool schemas, with duplicate/conflict detection. (✅ active)
-- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) ⭐6 — PiUI-style Web diff viewer replacing the default diff view. (✅ active)
-- [dsh-skin](https://github.com/KinGao294/dsh-skin) ⭐6 — Codex-style skin switcher plus custom translucent wallpaper with opacity/blur controls. (✅ active)
-- [dsh-balance](https://github.com/crazywoola/dsh-balance) ⭐5 — DeepSeek Harness balance plugin for the Settings page. (✅ active)
-- [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) ⭐5 — Spreadsheet-style skin for DSH, mimicking Excel. (✅ active)
+- [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) ⭐7 — Cross-platform drag & drop for DSH Web UI with original-path insertion, no file copying. (✅ active)
+- [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) ⭐7 — DSH 插件：git 提交固定使用环境自身作者身份（优先 gh CLI 登录账号，GitHub noreply 邮箱），GIT_AUTHOR_*/GIT_COMMITTER_* 环境变量注入压过一切 git config (✅ active)
+- [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) ⭐7 — 左下角便签：随手记点子/感想/TODO，实时保存到归档目录，清单+悬浮归档 (✅ active)
+- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) ⭐7 — Multi-engine persistent search: DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/XHS/Twitter/Reddit/RSS, with SQLite+LRU cache and Playwright rendering. (✅ active)
+- [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) ⭐6 — provider-agnostic AIGC HTTP 桥 + 无限画布 + ffmpeg 后处理，13 个工具含画布连边/reroll/媒体编辑 | Provider-agnostic AIGC HTTP bridge + infinite canvas + ffmpeg post-processing; 13 tools incl. canvas linking/reroll/media-edit (✅ active)
+- [dsh-plugin-anti-ads](https://github.com/HuanLinOTO/dsh-plugin-anti-ads) ⭐6 — DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin (✅ active)
+- [dsh-plugin-auto-blame](https://github.com/HuanLinOTO/dsh-plugin-auto-blame) ⭐6 — 模型回合结束后用 LLM 生成 3 条批判性跟进建议，点击即发送 | After a model turn, an LLM generates 3 critical follow-up suggestions shown as click-to-send chips (✅ active)
+- [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) ⭐6 — Marketplace plugin that integrates DeepSeek Harness with the GitHub plugin ecosystem. (✅ active)
+- [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) ⭐6 — Expose run_python/run_node tools that execute code via stdin and return stdout/stderr/exit code. (✅ active)
+- [dsh-token-panel](https://github.com/juhe291/dsh-token-panel) ⭐6 — A corner HUD for DeepSeek Harness that shows your session's token pressure, per-model cost, and daily/monthly usage at a glance — with an editable budget & balance that tracks spending for you. 右下角常驻的 Token 仪表盘：实时查看会话压力、按模型估算花费，预算和余额点一下就能改，每天每月用了多少都有记录。 (✅ active)
+- [dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) ⭐6 — A DeepSeek Harness Web plugin for real-time Token usage, cost estimates, per-round charts, and DeepSeek API balance. (✅ active)
+- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) ⭐6 — RMB/USD token billing for the DSH web: official-policy auto pricing with peak/off-peak hours and per-message cost ledger. (✅ active)
+- [weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) ⭐6 — Native WeShop Cordis plugin for DeepSeek Harness. Allow you to use infinite canvas with infinite creative skills. (✅ active)
+- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) ⭐5 — Human-readable catalog of official DSH Web built-ins with safe GUI toggles. (✅ active)
+- [dsh-cost-plugin](https://github.com/RoxsLee/dsh-cost-plugin) ⭐5 — DSH 费用/余额读数插件：在输入框统计行旁实时显示「本次 ≈¥x · 会话 ≈¥x · 余额 ¥x」，内置 DeepSeek 官方价目表，支持 2026-08-17 起生效的峰谷定价（按节点时间戳自动选档），余额经官方 /user/balance 实时查询，失败静默降级。 (✅ active)
+- [dsh-cue-plugin](https://github.com/unnnnoooo/dsh-cue-plugin) ⭐5 — DeepSeek Harness 的跨会话引用(cue)插件 (✅ active)
 - [dsh-ohos-patch](https://github.com/shenjackyuanjie/dsh-ohos-patch) ⭐5 — 让deepseek harness能在 ohos上跑！ (✅ active)
+- [dsh-opencode-go-usage](https://github.com/Xenia0922/dsh-opencode-go-usage) ⭐5 — DeepSeek Harness 插件:OpenCode Go 用量与花费悬浮仪表盘(配额、逐请求成本、模型/来源分布) (✅ active)
+- [dsh-plugin-anydoc](https://github.com/beancookie/dsh-plugin-anydoc) ⭐5 — Convert Word, PPT, Excel, PDF, EPUB and CSV documents to GitHub-Flavored Markdown via @firecrawl/anydoc. (✅ active)
 - [dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) ⭐5 — Mini-game menu (Wordle, match-3, 192 parameterized games) that pops up while the model generates. (✅ active)
-- [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) ⭐5 — Marketplace plugin that integrates DeepSeek Harness with the GitHub plugin ecosystem. (✅ active)
-- [dsh-plugin-ya-workspace-sidebar](https://github.com/HuanLinOTO/dsh-plugin-ya-workspace-sidebar) ⭐5 — DSH Web 工作区侧栏替代，顶部全局最近会话 + Workspace→Session 二级菜单 + 面包屑 | DSH Web workspace sidebar replacement: top global recent sessions + Workspace→Session two-level menu + breadcrumbs (✅ active)
-- [dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) ⭐5 — Replaces the 'Deep diving…' turn-status label with phase-aware typewriter messages. (✅ active)
+- [dsh-spend](https://github.com/nonewind/dsh-spend) ⭐5 — Token usage and estimated spend: floating panel with per-model/day/session stats and auto-detected billing plans. (✅ active)
+- [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) ⭐5 — Keyboard-first command palette for DeepSeek Harness Web. (✅ active)
 - [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) ⭐5 — Community plugin bundle integrating the Nowledge Mem memory service with DeepSeek Harness. (✅ active)
-- [dsh-cost-plugin](https://github.com/RoxsLee/dsh-cost-plugin) ⭐4 — DSH 费用/余额读数插件：在输入框统计行旁实时显示「本次 ≈¥x · 会话 ≈¥x · 余额 ¥x」，内置 DeepSeek 官方价目表，支持 2026-08-17 起生效的峰谷定价（按节点时间戳自动选档），余额经官方 /user/balance 实时查询，失败静默降级。 (✅ active)
-- [dsh-cue-plugin](https://github.com/unnnnoooo/dsh-cue-plugin) ⭐4 — DeepSeek Harness 的跨会话引用(cue)插件 (✅ active)
+- [zotero-harvest](https://github.com/Fisfzy/zotero-harvest) ⭐5 — Zotero 文献采集入库插件（DSH external plugin）：多源检索（OpenAlex/arXiv/Crossref/Europe PMC/Semantic Scholar）+ OA 下载链接解析（Unpaywall）+ 充分性审计 + 入库本地 Zotero + 触发 zotero-wave-rag 重建 (✅ active)
+- [codex-eyes-hands](https://github.com/651002/codex-eyes-hands) ⭐4 — 专为 DeepSeek Harness 打造：把本机 Codex CLI 变成纯文本 AI agent 的眼睛和手——看图/读文件/画图/监督执行/双通道容灾 (✅ active)
+- [context-vista](https://github.com/GooodWei/context-vista) ⭐4 — Live context/token monitor: floating panel + /context command with donut charts of token usage, allocation and estimated cost. (✅ active)
+- [deepseek-harness-zh_pro](https://github.com/magian1127/deepseek-harness-zh_pro) ⭐4 — Chinese enhancement plugin for DeepSeek Harness (DSH) - DSH 中文增强插件 (✅ active)
+- [dsh-calculator](https://github.com/bobcat848/dsh-calculator) ⭐4 — Calculate the real-time cost of DeepSeek API calls made by DeepSeek Harness. (✅ active)
 - [dsh-input-history](https://github.com/lhh010/dsh-input-history) ⭐4 — Terminal-style input history: Ctrl+Up/Ctrl+Down to recall and switch sent messages. (✅ active)
-- [dsh-pet](https://github.com/PC2005-cloud/dsh-pet) ⭐4 — DeepSeek Harness 桌面宠物插件 + 完整素材生成链：AI 提示词 → 绿幕视频 → 透明动画 → 可安装插件，从零到宠物全流程可复现 (✅ active)
-- [dsh-plugin-anti-ads](https://github.com/HuanLinOTO/dsh-plugin-anti-ads) ⭐4 — DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin (✅ active)
+- [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) ⭐4 — PDF toolbox: extract text, metadata and page ranges via pdfjs-dist, local with no API key. (✅ active)
 - [dsh-plugin-deepeye](https://github.com/Favio8/dsh-plugin-deepeye) ⭐4 — DeepEye vision plugin for DeepSeek Harness (DSH): image description, OCR, VQA, UI layout, and clipboard analysis. (✅ active)
-- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) ⭐4 — Plugin management panel: enable/disable installed plugins plus a GitHub dsh-plugin marketplace with one-click install. (✅ active)
-- [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) ⭐4 — Expose run_python/run_node tools that execute code via stdin and return stdout/stderr/exit code. (✅ active)
-- [dsh-remote](https://github.com/flymysql/dsh-remote) ⭐4 — Remote workspace: connect a host over SSH and operate a remote directory with rw_* tools. (✅ active)
-- [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) ⭐4 — Keyboard-first command palette for DeepSeek Harness Web. (✅ active)
-- [weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) ⭐4 — Native WeShop Cordis plugin for DeepSeek Harness. Allow you to use infinite canvas with infinite creative skills. (✅ active)
-- [context-vista](https://github.com/GooodWei/context-vista) ⭐3 — Live context/token monitor: floating panel + /context command with donut charts of token usage, allocation and estimated cost. (✅ active)
-- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) ⭐3 — Human-readable catalog of official DSH Web built-ins with safe GUI toggles. (✅ active)
-- [dsh-calculator](https://github.com/bobcat848/dsh-calculator) ⭐3 — Calculate the real-time cost of DeepSeek API calls made by DeepSeek Harness. (✅ active)
-- [dsh-opencode-go-usage](https://github.com/Xenia0922/dsh-opencode-go-usage) ⭐3 — DeepSeek Harness 插件:OpenCode Go 用量与花费悬浮仪表盘(配额、逐请求成本、模型/来源分布) (✅ active)
+- [dsh-prompt-enhancer](https://github.com/Fishsb/dsh-prompt-enhancer) ⭐4 — DeepSeek Harness DSH 提示词增强插件：✨ 一键优化草稿，增强提示词。 (✅ active)
+- [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) ⭐4 — 为 DeepSeek Harness 提供会话删除能力，支持侧边栏 ⋮ 菜单入口 (✅ active)
+- [dsh-split-panes](https://github.com/lehhair/dsh-split-panes) ⭐4 — Split panes. (✅ active)
+- [dsh-usage-dashboard](https://github.com/Cassius0924/dsh-usage-dashboard) ⭐4 — DeepSeek 额度与用量仪表盘 — DSH (DeepSeek Harness) 动态 Cordis 插件 (✅ active)
+- [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) ⭐4 — Privacy-minimal heuristic per-turn verification summaries for DeepSeek Harness (✅ active)
+- [dsh-weather](https://github.com/sunshine-lang/dsh-weather) ⭐4 — Weather tool: current conditions and multi-day forecasts via Open-Meteo, free with no API key. (✅ active)
+- [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) ⭐4 — Attention reminders for the DeepSeek Harness Web UI: frame badge, (N) tab title and whale-favicon recolor for sessions waiting for input or finished unopened. (✅ active)
+- [dsh-web-search-exa](https://github.com/TonyDua/dsh-web-search-exa) ⭐4 — Zero-config Exa web search provider: keyless anonymous MCP fallback plus keyed REST search. (✅ active)
+- [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐4 — Persistent common-word panel beside the composer with global/project buckets and one-click insert. (✅ active)
+- [dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) ⭐4 — VS Code-style workspace keyword search: a Search tab for the Better Sidebar ecosystem. (✅ active)
+- [deepseek-harness-plugin-manager](https://github.com/hrhgit/deepseek-harness-plugin-manager) ⭐3 — Web plugin manager for DeepSeek Harness (DSH): inspect, search, group, enable, and disable Cordis plugins. (✅ active)
+- [dsh-agentmemory](https://github.com/elementor-i/dsh-agentmemory) ⭐3 — agentmemory for DeepSeek Harness (dsh): full memory_* tools, capture hooks, and context injection over the local REST server (✅ active)
+- [dsh-browser](https://github.com/anweat/dsh-browser) ⭐3 — Self-contained browser runtime plugin for DeepSeek Harness — bundles Playwright (chromium) and OpenCLI as plugin-local dependencies, exposes a browser service and interactive browser tools. (✅ active)
+- [dsh-doctor](https://github.com/astra3294/dsh-doctor) ⭐3 — Deterministic diagnostics and recovery for DeepSeek Harness (✅ active)
+- [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) ⭐3 — File ownership/claim system for parallel agent sessions on the same project: claim/release, heartbeat stale takeover and async 3-way merge. (✅ active)
+- [dsh-file-mount](https://github.com/acefun29/dsh-file-mount) ⭐3 — Incremental file mounting with line-range deduplication: identical file contents are never re-sent to the model. (✅ active)
+- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud) ⭐3 — HUD status panel: git status, MCP servers, skills, model and token usage in a floating side panel. (✅ active)
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) ⭐3 — Bounded, layered, approval-gated and auditable cross-session memory with frozen snapshot injection. (✅ active)
+- [dsh-memory-evidence](https://github.com/LeslieWylie/dsh-memory-evidence) ⭐3 — Git-first memory navigation and bounded evidence tools for DeepSeek Harness. (💤 inactive)
+- [dsh-notebooks](https://github.com/havingautism/dsh-notebooks) ⭐3 — Notebooks plugin (cordis). (✅ active)
+- [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) ⭐3 — Windows notifications for DSH, zero dependencies. (✅ active)
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) ⭐3 — dsh-passwords: DeepSeek Harness login gateway - first-run setup, at-rest encryption, brute-force lockout, audit log, HTTPS (✅ active)
+- [dsh-plugin-diff-review](https://github.com/Civitasv/dsh-plugin-diff-review) ⭐3 — Diff Review Plugin for DeepSeek Harness (✅ active)
 - [dsh-plugins-raincode](https://github.com/rainforest888/dsh-plugins-raincode) ⭐3 — dsh plugin: DeepSeek Harness 的模型层 = raincode(模型池/缓存/重试) + /skills 浏览 (✅ active)
-- [dsh-token-panel](https://github.com/juhe291/dsh-token-panel) ⭐3 — A corner HUD for DeepSeek Harness that shows your session's token pressure, per-model cost, and daily/monthly usage at a glance — with an editable budget & balance that tracks spending for you. 右下角常驻的 Token 仪表盘：实时查看会话压力、按模型估算花费，预算和余额点一下就能改，每天每月用了多少都有记录。 (✅ active)
+- [dsh-restart](https://github.com/anweat/dsh-restart) ⭐3 — Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch. (✅ active)
+- [dsh-suggested-replies](https://github.com/Anionex/dsh-suggested-replies) ⭐3 — Predicted next-message candidates above the DSH Web composer, one click to fill the draft. (✅ active)
+- [dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) ⭐3 — Agent memory for DeepSeek Harness | DeepSeek Harness 记忆插件 (✅ active)
+- [dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) ⭐3 — Fail-closed export-copy redaction for DeepSeek Harness session telemetry (✅ active)
+- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) ⭐3 — Structured safe Git tools: status/diff/log/branch/stage/commit/stash/show with a destructive-command guard. (✅ active)
+- [dsh-ui-appearance](https://github.com/TQSY114514/dsh-ui-appearance) ⭐3 — Appearance customization plugin for DeepSeek Harness: theme color palette, background image, opacity/blur, glass effect (✅ active)
+- [dsh-ultra-ui](https://github.com/havingautism/dsh-ultra-ui) ⭐3 — Ultra UI plugin (cordis). (✅ active)
 - [dsh-usage-plugin](https://github.com/Yihong89/dsh-usage-plugin) ⭐3 — DeepSeek Harness (DSH) plugins. First: dsh-usage-report — per-session token usage & estimated cost (/usage + usage_report), priced from the DeepSeek pricing table. (✅ active)
-- [dsh-weather](https://github.com/sunshine-lang/dsh-weather) ⭐3 — Weather tool: current conditions and multi-day forecasts via Open-Meteo, free with no API key. (✅ active)
-- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) ⭐3 — Multi-engine persistent search: DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/XHS/Twitter/Reddit/RSS, with SQLite+LRU cache and Playwright rendering. (✅ active)
 - [dsh-webbridge](https://github.com/bill9109/dsh-webbridge) ⭐3 — DSH combined with Kimi WebBridge for real browser control. (✅ active)
-- [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐3 — Persistent common-word panel beside the composer with global/project buckets and one-click insert. (✅ active)
-- [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) ⭐2 — Cross-platform drag & drop for DSH Web UI with original-path insertion, no file copying. (✅ active)
-- [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) ⭐2 — File ownership/claim system for parallel agent sessions on the same project: claim/release, heartbeat stale takeover and async 3-way merge. (✅ active)
-- [dsh-file-mount](https://github.com/acefun29/dsh-file-mount) ⭐2 — Incremental file mounting with line-range deduplication: identical file contents are never re-sent to the model. (✅ active)
+- [tokenledger](https://github.com/zh667/TokenLedger) ⭐3 — Token usage accounting for DeepSeek Harness, reconciled against New API and Sub2API relay-site billing (✅ active)
+- [zotero-wave-rag](https://github.com/Fisfzy/zotero-wave-rag) ⭐3 — 面向 Zotero 论文库的浪潮式 RAG 细节检索系统 —— DSH 外部插件。移植 VCPToolBox 浪潮语义动力学思想（标签河道图传播/虫洞跳转/钟型阻尼/Ω重排），配 BM25+RRF 混合检索、claim-evidence 忠实度校验、两级增量索引 (✅ active)
+- [dsh-adb](https://github.com/SamXiaBing/dsh-adb) ⭐2 — ADB device & bench operations: device discovery, structured logcat (background streaming), apk install, file pull/push, dumpsys performance snapshots. (✅ active)
+- [dsh-deepseek-quota](https://github.com/yingjunnan/dsh-deepseek-quota) ⭐2 — DeepSeek API quota (balance) widget for the DSH web GUI: a floating bottom-right card showing remaining DeepSeek API balance. (✅ active)
+- [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) ⭐2 — Clickable file paths in DSH replies: inline open, reveal in file manager and a mentioned-files chip list. (✅ active)
 - [dsh-memory (Jesse-njx)](https://github.com/Jesse-njx/dsh-memory) ⭐2 — Cited memory over DSH's lossless session log: distilled, human-auditable facts with citations. (✅ active)
-- [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) ⭐2 — Windows notifications for DSH, zero dependencies. (✅ active)
-- [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) ⭐2 — PDF toolbox: extract text, metadata and page ranges via pdfjs-dist, local with no API key. (✅ active)
+- [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) ⭐2 — Pin assistant replies from the action strip and recall them into the next model turn (/pin /recall). (✅ active)
+- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) ⭐2 — mount one row in the composition and every plugin card on the Web Settings plugin list page gets a bilingual (zh/en) description; it also publishes the pluginDescriptions service so other plugins can register their own descriptions. (✅ active)
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) ⭐2 — Edit user and built-in system-prompt sections with live preview. (✅ active)
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) ⭐2 — Incremental diff reviewer: checkpoint-based review queue with a Web UI panel and /review command. (✅ active)
+- [dsh-scout](https://github.com/omdsh-dev/dsh-scout) ⭐2 — 面向 DeepSeek Harness 的只读环境探测插件，为智能体提供运行环境、软件版本、系统资源、端口、服务、硬件及工作区信息。 (✅ active)
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) ⭐2 — Index-free cross-agent session search for DeepSeek Harness. (✅ active)
-- [dsh-suggested-replies](https://github.com/Anionex/dsh-suggested-replies) ⭐2 — Predicted next-message candidates above the DSH Web composer, one click to fill the draft. (✅ active)
-- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) ⭐2 — RMB/USD token billing for the DSH web: official-policy auto pricing with peak/off-peak hours and per-message cost ledger. (✅ active)
+- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) ⭐2 — Structured test runner tool: auto-detect vitest/jest/pytest/node:test, run tests and parse failure summaries for the model. (✅ active)
+- [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) ⭐2 — Per-agent on-demand tool discovery and progressive schema disclosure. (✅ active)
 - [URL Manager](https://github.com/Piccolo123/url-manager) ⭐2 — Agent-first URL and knowledge collection system: auto-categorize, tag, full-text search and shared collections. (✅ active)
 - [dsh-computer-use](https://github.com/xiaoheizi1212/dsh-computer-use) ⭐1 — Model-agnostic Computer Use for DSH: isolated browser, Windows native helper and third-party bridges. (✅ active)
-- [dsh-memento](https://github.com/PerryLink/dsh-memento) ⭐1 — Bounded, layered, approval-gated and auditable cross-session memory with frozen snapshot injection. (✅ active)
+- [dsh-doctor](https://github.com/asdf17128/dsh-doctor) ⭐1 — Find what your DeepSeek Harness (dsh) patches silently broke — dead patches, config fields dropped by whole-config replacement, unmaintained plugins. Read-only, zero deps. (✅ active)
+- [dsh-news-plugin](https://github.com/canghai666x/dsh-news-plugin) ⭐1 — RSS/news ingestion returning structured title/link/source/date/summary for downstream model ranking and briefing. (✅ active)
 - [dsh-payload-capture](https://github.com/Moeblack/dsh-payload-capture) ⭐1 — Captures every upstream model API payload to JSON for debugging and observability. (✅ active)
-- [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) ⭐1 — Pin assistant replies from the action strip and recall them into the next model turn (/pin /recall). (✅ active)
-- [dsh-plugin-anydoc](https://github.com/beancookie/dsh-plugin-anydoc) ⭐1 — Convert Word, PPT, Excel, PDF, EPUB and CSV documents to GitHub-Flavored Markdown via @firecrawl/anydoc. (✅ active)
-- [dsh-spend](https://github.com/nonewind/dsh-spend) ⭐1 — Token usage and estimated spend: floating panel with per-model/day/session stats and auto-detected billing plans. (✅ active)
-- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) ⭐1 — Structured test runner tool: auto-detect vitest/jest/pytest/node:test, run tests and parse failure summaries for the model. (✅ active)
+- [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) ⭐1 — @dsh-pm/registry — discover dsh plugins by merging the awesome-dsh-plugin list, GitHub dsh-plugin-topic search, and npm keyword search into one deduped, offline-tolerant registry (the discovery engine of dsh pm) (✅ active)
+- [dsh-plugin-quote-reply](https://github.com/yangYzc/dsh-plugin-quote-reply) ⭐1 — DSH plugin: select text in a conversation, then quote it into the composer or reply in a new window. / DeepSeek Harness 划词引用插件：选中文字一键引用回复或新窗口回复。 (✅ active)
+- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) ⭐1 — Turn-index sidebar: one entry per user turn, click to jump with scroll-spy highlighting. (✅ active)
+- [dsh-turn-navigator](https://github.com/vibeinging/dsh-turn-navigator) ⭐1 — Private DSH Web turn navigation plugin (✅ active)
 - [dsh-view-modes](https://github.com/NigelYao/dsh-view-modes) ⭐1 — Output modes with Verbose, Normal and Summary views plus semantic grouping for tool calls and thinking. (✅ active)
-- [dsh-web-search-exa](https://github.com/TonyDua/dsh-web-search-exa) ⭐1 — Zero-config Exa web search provider: keyless anonymous MCP fallback plus keyed REST search. (✅ active)
-- [dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) ⭐1 — VS Code-style workspace keyword search: a Search tab for the Better Sidebar ecosystem. (✅ active)
-- [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions)  — Clickable file paths in DSH replies: inline open, reveal in file manager and a mentioned-files chip list. (✅ active)
+- [dshp](https://github.com/asdf17128/dshp) ⭐1 — Manage DeepSeek Harness profiles — list, create, clone, diff, and share a whole dsh setup as one portable file. (✅ active)
+- [dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter)  — dsh plugin: per-turn USD cost badge in the Web UI (session total + per-message footer, hover breakdown) from token usage x a configurable pricing table. (✅ active)
 - [dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads)  — Upload arbitrary local files from the Web composer with pending cards, managed in Settings. (✅ active)
 - [dsh-git-branch-switcher](https://github.com/mixin-ai/dsh-git-branch-switcher)  — Session-header git branch pill: shows the workspace branch and switches it from the Web UI. (✅ active)
-- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud)  — HUD status panel: git status, MCP servers, skills, model and token usage in a floating side panel. (✅ active)
 - [dsh-memoria](https://github.com/jiayan-xu/dsh-memoria)  — Vector + graph memory backend with namespace isolation, automatic observation, recall, importance handling and hot reload. (🧪 experimental)
 - [dsh-memory](https://github.com/flymysql/dsh-memory)  — Cross-session memory vault: memory_remember / memory_recall / memory_forget tools with a Settings page. (🧪 experimental)
-- [dsh-news-plugin](https://github.com/canghai666x/dsh-news-plugin)  — RSS/news ingestion returning structured title/link/source/date/summary for downstream model ranking and briefing. (✅ active)
-- [dsh-recommend](https://github.com/zp-home/dsh-recommend)  — Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data with an open scoring model. (✅ active)
-- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git)  — Structured safe Git tools: status/diff/log/branch/stage/commit/stash/show with a destructive-command guard. (✅ active)
-- [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search)  — Per-agent on-demand tool discovery and progressive schema disclosure. (✅ active)
-- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index)  — Turn-index sidebar: one entry per user turn, click to jump with scroll-spy highlighting. (✅ active)
+- [dsh-plugin-cost](https://github.com/yweilai77-dev/dsh-plugin-cost)  — Session cost estimate in the DSH Web composer dock (tokenUsage × configurable price table, one-click official-price refresh). (✅ active)
+- [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces. (✅ active)
+- [dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream)  — Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and respects prefers-reduced-motion. (✅ active)
+- [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech)  — Browser Web Speech API voice input for DSH: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech). (✅ active)
 
 ### Skills
 
@@ -318,33 +374,40 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) | ⭐12 | DSH Web UI plugin: Skills settings section with hot enable/disable, delete and add. | ✅ active |
-| 2 | [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) | ⭐9 | Field-tested plugin development playbook (skill + docs): cordis dual copies, tsconfig triplets, Windows junctions and multi-frame zstd. | ✅ active |
-| 3 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | ⭐7 | Agent skills for building and testing DeepSeek Harness plugins, from scaffolding a package to publishing. | ✅ active |
-| 4 | [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | ⭐3 | Book-to-skill plugin: a 5-stage long task that fetches, parses, understands, generates and installs a skill. | ✅ active |
-| 5 | [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) | ⭐2 | Godot Engine 4.x full-stack game development skill plugin for DSH. | ✅ active |
-| 6 | [dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) | ⭐2 | Code review skill pack for DeepSeek Harness. | ✅ active |
-| 7 | [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) | ⭐1 | Bridges the vercel-labs/skills ecosystem: LLM-driven skill search, install and management. | ✅ active |
-| 8 | [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | ⭐1 | Security-audit skill pack: 5 agent skills covering secret scan, dependency audit and more. | ✅ active |
-| 9 | [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) | ⭐1 | Every skill you already have — Claude Code, Codex, Cursor, Gemini CLI — works in DSH. | ✅ active |
-| 10 | [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) | ⭐1 | Scans session-visible skills and ranks them by relevance to the recent conversation. | ✅ active |
+| 1 | [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) | ⭐224 | EasyEDA Pro automation: Go daemon + in-app connector + agent skill + stdio MCP server for typed schematic/PCB actions, workflow gates, and DRC. | ✅ active |
+| 2 | [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) | ⭐34 | DSH Web UI plugin: Skills settings section with hot enable/disable, delete and add. | ✅ active |
+| 3 | [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | ⭐12 | Complete reverse-skill (85 SKILL.md) as a DeepSeek Harness (dsh) Cordis plugin — reverse engineering, authorized pentesting and security research skill pack. | ✅ active |
+| 4 | [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) | ⭐10 | Field-tested plugin development playbook (skill + docs): cordis dual copies, tsconfig triplets, Windows junctions and multi-frame zstd. | ✅ active |
+| 5 | [dsh-science](https://github.com/biociao/dsh-science) | ⭐10 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ active |
+| 6 | [dsh-plugin-development](https://github.com/w2112515/dsh-plugin-development) | ⭐8 | Portable Agent Skill for developing and auditing DeepSeek Harness plugins, with an optional profile-installable DSH bundle adapter. | ✅ active |
+| 7 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | ⭐7 | Agent skills for building and testing DeepSeek Harness plugins, from scaffolding a package to publishing. | ✅ active |
+| 8 | [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | ⭐4 | Book-to-skill plugin: a 5-stage long task that fetches, parses, understands, generates and installs a skill. | ✅ active |
+| 9 | [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) | ⭐4 | Godot Engine 4.x full-stack game development skill plugin for DSH. | ✅ active |
+| 10 | [dsh-humanize](https://github.com/zevorn/dsh-humanize) | ⭐3 | De-AI writing skill: rewrite agent output to sound more human. | ✅ active |
 
-#### Complete list (14)
+#### Complete list (21)
 
-- [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) ⭐12 — DSH Web UI plugin: Skills settings section with hot enable/disable, delete and add. (✅ active)
-- [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) ⭐9 — Field-tested plugin development playbook (skill + docs): cordis dual copies, tsconfig triplets, Windows junctions and multi-frame zstd. (✅ active)
+- [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) ⭐224 — EasyEDA Pro automation: Go daemon + in-app connector + agent skill + stdio MCP server for typed schematic/PCB actions, workflow gates, and DRC. (✅ active)
+- [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) ⭐34 — DSH Web UI plugin: Skills settings section with hot enable/disable, delete and add. (✅ active)
+- [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) ⭐12 — Complete reverse-skill (85 SKILL.md) as a DeepSeek Harness (dsh) Cordis plugin — reverse engineering, authorized pentesting and security research skill pack. (✅ active)
+- [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) ⭐10 — Field-tested plugin development playbook (skill + docs): cordis dual copies, tsconfig triplets, Windows junctions and multi-frame zstd. (✅ active)
+- [dsh-science](https://github.com/biociao/dsh-science) ⭐10 — Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. (✅ active)
+- [dsh-plugin-development](https://github.com/w2112515/dsh-plugin-development) ⭐8 — Portable Agent Skill for developing and auditing DeepSeek Harness plugins, with an optional profile-installable DSH bundle adapter. (✅ active)
 - [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) ⭐7 — Agent skills for building and testing DeepSeek Harness plugins, from scaffolding a package to publishing. (✅ active)
-- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) ⭐3 — Book-to-skill plugin: a 5-stage long task that fetches, parses, understands, generates and installs a skill. (✅ active)
-- [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) ⭐2 — Godot Engine 4.x full-stack game development skill plugin for DSH. (✅ active)
+- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) ⭐4 — Book-to-skill plugin: a 5-stage long task that fetches, parses, understands, generates and installs a skill. (✅ active)
+- [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) ⭐4 — Godot Engine 4.x full-stack game development skill plugin for DSH. (✅ active)
+- [dsh-humanize](https://github.com/zevorn/dsh-humanize) ⭐3 — De-AI writing skill: rewrite agent output to sound more human. (✅ active)
+- [dsh-memoryhub](https://github.com/solknight48/dsh-memoryhub) ⭐3 — MemoryHub (mh) plugin for DeepSeek Harness (dsh): auto-loads checkpoint memory on session start, adds mh_* tools and the mh skill, and a Memory tab in the web UI (✅ active)
+- [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) ⭐3 — Scans session-visible skills and ranks them by relevance to the recent conversation. (✅ active)
+- [deepseek-harness-skillx](https://github.com/drowned-fish1/deepseek-harness-skillx) ⭐2 — Skill collection for DeepSeek Harness workflows. (✅ active)
+- [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) ⭐2 — Bridges the vercel-labs/skills ecosystem: LLM-driven skill search, install and management. (✅ active)
+- [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) ⭐2 — DSH knowledge-base plugin: build audit-able KB packs (references + SQLite FTS5) from md/txt/docx/pdf, deterministic retrieval (kb_query) and original-text reading (kb_read), zero-script generated skills. Apache-2.0. (✅ active)
 - [dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) ⭐2 — Code review skill pack for DeepSeek Harness. (✅ active)
-- [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) ⭐1 — Bridges the vercel-labs/skills ecosystem: LLM-driven skill search, install and management. (✅ active)
-- [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) ⭐1 — Security-audit skill pack: 5 agent skills covering secret scan, dependency audit and more. (✅ active)
-- [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) ⭐1 — Every skill you already have — Claude Code, Codex, Cursor, Gemini CLI — works in DSH. (✅ active)
-- [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) ⭐1 — Scans session-visible skills and ranks them by relevance to the recent conversation. (✅ active)
-- [deepseek-harness-skillx](https://github.com/drowned-fish1/deepseek-harness-skillx)  — Skill collection for DeepSeek Harness workflows. (✅ active)
-- [dsh-humanize](https://github.com/zevorn/dsh-humanize)  — De-AI writing skill: rewrite agent output to sound more human. (✅ active)
+- [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) ⭐2 — Security-audit skill pack: 5 agent skills covering secret scan, dependency audit and more. (✅ active)
+- [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) ⭐2 — Every skill you already have — Claude Code, Codex, Cursor, Gemini CLI — works in DSH. (✅ active)
+- [dsh-web-novel-research](https://github.com/canghai666x/dsh-web-novel-research) ⭐1 — Chinese web-novel plot lookup skill: free mirror-site workflow with GBK decoding and duplicate-chapter disambiguation. (✅ active)
 - [dsh-news-briefing](https://github.com/canghai666x/dsh-news-briefing)  — News briefing skill: multi-dimensional story scoring, anti-clickbait rules, content prioritization and Chinese editorial style. (✅ active)
-- [dsh-web-novel-research](https://github.com/canghai666x/dsh-web-novel-research)  — Chinese web-novel plot lookup skill: free mirror-site workflow with GBK decoding and duplicate-chapter disambiguation. (✅ active)
+- [mstar-workflow](https://github.com/btspoony/mstar-workflow)  — A Skill-driven Harness/Loop Engineering Workflow Agent Plugin (💤 inactive)
 
 ### Workflows & Automation
 
@@ -353,38 +416,39 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | ⭐54 | Brings Claude Code's UltraCode mode to DSH: upgrade one-shot multi-agent dispatch into a generatable, saveable, governable, observable, recoverable workflow layer. | ✅ active |
-| 2 | [mstar-harness](https://github.com/btspoony/mstar-harness) | ⭐42 | Skill-driven harness/loop engineering workflow agent: tune agent loops as a first-class workflow. | ✅ active |
-| 3 | [dsh-automation](https://github.com/titanwings/dsh-automation) | ⭐27 | Run coding tasks on a schedule in fresh Agent sessions, managed by the user or the agent itself. | ✅ active |
-| 4 | [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | ⭐9 | Auto-resumes interrupted DSH Web requests: failure classification, adaptive retry, configurable continue message and browser notifications. | ✅ active |
-| 5 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | ⭐9 | Adaptive deep-research orchestrator built on the official workflow engine. | ✅ active |
-| 6 | [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) | ⭐7 | Ops toolbox: A/B dual-slot daily snapshot rotation with atomic switch and one-click rollback, plus a 10s watchdog. | ✅ active |
-| 7 | [dsh-track](https://github.com/fakechris/dsh-track) | ⭐5 | Embedded task-management engine: decision-point protocol, thought-capture wall and Linear-style issue storage. | ✅ active |
-| 8 | [engineer-software](https://github.com/KirschBluteX/engineer-software) | ⭐5 | Runtime-neutral, evidence-driven software engineering workflow for Codex and DeepSeek Harness. | ✅ active |
-| 9 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | ⭐4 | Resident desktop assistant: global hotkey, scheduled automation, quick replies and a plugin market. | ✅ active |
-| 10 | [dsh-plans](https://github.com/Optim-Agent/dsh-plans) | ⭐4 | Human-in-the-loop planning preset adapted from prime-plans: researched, reviewed, executed. | ✅ active |
+| 1 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | ⭐56 | Brings Claude Code's UltraCode mode to DSH: upgrade one-shot multi-agent dispatch into a generatable, saveable, governable, observable, recoverable workflow layer. | ✅ active |
+| 2 | [mstar-harness](https://github.com/btspoony/mstar-harness) | ⭐46 | Skill-driven harness/loop engineering workflow agent: tune agent loops as a first-class workflow. | ✅ active |
+| 3 | [dsh-automation](https://github.com/titanwings/dsh-automation) | ⭐39 | Run coding tasks on a schedule in fresh Agent sessions, managed by the user or the agent itself. | ✅ active |
+| 4 | [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | ⭐15 | Auto-resumes interrupted DSH Web requests: failure classification, adaptive retry, configurable continue message and browser notifications. | ✅ active |
+| 5 | [dsh-plans](https://github.com/Optim-Agent/dsh-plans) | ⭐13 | Human-in-the-loop planning preset adapted from prime-plans: researched, reviewed, executed. | ✅ active |
+| 6 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | ⭐12 | Adaptive deep-research orchestrator built on the official workflow engine. | ✅ active |
+| 7 | [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) | ⭐9 | Ops toolbox: A/B dual-slot daily snapshot rotation with atomic switch and one-click rollback, plus a 10s watchdog. | ✅ active |
+| 8 | [dsh-track](https://github.com/fakechris/dsh-track) | ⭐6 | Embedded task-management engine: decision-point protocol, thought-capture wall and Linear-style issue storage. | ✅ active |
+| 9 | [engineer-software](https://github.com/KirschBluteX/engineer-software) | ⭐6 | Runtime-neutral, evidence-driven software engineering workflow for Codex and DeepSeek Harness. | ✅ active |
+| 10 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | ⭐5 | Resident desktop assistant: global hotkey, scheduled automation, quick replies and a plugin market. | ✅ active |
 
-#### Complete list (20)
+#### Complete list (21)
 
-- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐54 — Brings Claude Code's UltraCode mode to DSH: upgrade one-shot multi-agent dispatch into a generatable, saveable, governable, observable, recoverable workflow layer. (✅ active)
-- [mstar-harness](https://github.com/btspoony/mstar-harness) ⭐42 — Skill-driven harness/loop engineering workflow agent: tune agent loops as a first-class workflow. (✅ active)
-- [dsh-automation](https://github.com/titanwings/dsh-automation) ⭐27 — Run coding tasks on a schedule in fresh Agent sessions, managed by the user or the agent itself. (✅ active)
-- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) ⭐9 — Auto-resumes interrupted DSH Web requests: failure classification, adaptive retry, configurable continue message and browser notifications. (✅ active)
-- [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) ⭐9 — Adaptive deep-research orchestrator built on the official workflow engine. (✅ active)
-- [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) ⭐7 — Ops toolbox: A/B dual-slot daily snapshot rotation with atomic switch and one-click rollback, plus a 10s watchdog. (✅ active)
-- [dsh-track](https://github.com/fakechris/dsh-track) ⭐5 — Embedded task-management engine: decision-point protocol, thought-capture wall and Linear-style issue storage. (✅ active)
-- [engineer-software](https://github.com/KirschBluteX/engineer-software) ⭐5 — Runtime-neutral, evidence-driven software engineering workflow for Codex and DeepSeek Harness. (✅ active)
-- [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) ⭐4 — Resident desktop assistant: global hotkey, scheduled automation, quick replies and a plugin market. (✅ active)
-- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) ⭐4 — Human-in-the-loop planning preset adapted from prime-plans: researched, reviewed, executed. (✅ active)
-- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) ⭐3 — DeepResearch plugin (cordis) for the Harness. (🧪 experimental)
-- [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) ⭐3 — Adversarial checkup → fix → review loop built on the official workflow engine. (✅ active)
+- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐56 — Brings Claude Code's UltraCode mode to DSH: upgrade one-shot multi-agent dispatch into a generatable, saveable, governable, observable, recoverable workflow layer. (✅ active)
+- [mstar-harness](https://github.com/btspoony/mstar-harness) ⭐46 — Skill-driven harness/loop engineering workflow agent: tune agent loops as a first-class workflow. (✅ active)
+- [dsh-automation](https://github.com/titanwings/dsh-automation) ⭐39 — Run coding tasks on a schedule in fresh Agent sessions, managed by the user or the agent itself. (✅ active)
+- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) ⭐15 — Auto-resumes interrupted DSH Web requests: failure classification, adaptive retry, configurable continue message and browser notifications. (✅ active)
+- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) ⭐13 — Human-in-the-loop planning preset adapted from prime-plans: researched, reviewed, executed. (✅ active)
+- [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) ⭐12 — Adaptive deep-research orchestrator built on the official workflow engine. (✅ active)
+- [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) ⭐9 — Ops toolbox: A/B dual-slot daily snapshot rotation with atomic switch and one-click rollback, plus a 10s watchdog. (✅ active)
+- [dsh-track](https://github.com/fakechris/dsh-track) ⭐6 — Embedded task-management engine: decision-point protocol, thought-capture wall and Linear-style issue storage. (✅ active)
+- [engineer-software](https://github.com/KirschBluteX/engineer-software) ⭐6 — Runtime-neutral, evidence-driven software engineering workflow for Codex and DeepSeek Harness. (✅ active)
+- [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) ⭐5 — Resident desktop assistant: global hotkey, scheduled automation, quick replies and a plugin market. (✅ active)
+- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) ⭐5 — DeepResearch plugin (cordis) for the Harness. (🧪 experimental)
+- [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) ⭐5 — Adversarial checkup → fix → review loop built on the official workflow engine. (✅ active)
+- [dsh-agent-orchestration](https://github.com/LeslieWylie/dsh-agent-orchestration) ⭐3 — Evidence-first multi-agent workflow planning, handoff validation, and Loop Guard skills for DeepSeek Harness. (💤 inactive)
 - [dsh-plugin-spur](https://github.com/HuanLinOTO/dsh-plugin-spur) ⭐3 — Hang a whip in the chat stream: flick it (>2.0 px/ms) to send the agent a 'go work' message. (✅ active)
 - [dsh-prime-agent](https://github.com/yoke233/dsh-prime-agent) ⭐3 — Prime Agent-inspired persistent RLM control plane for DSH Code Mode. (✅ active)
-- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) ⭐1 — Engineering-discipline loop: requirement grilling before edits, red/green test-evidence gates and adversarial delivery review. (✅ active)
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) ⭐2 — Engineering-discipline loop: requirement grilling before edits, red/green test-evidence gates and adversarial delivery review. (✅ active)
+- [dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) ⭐2 — Persistent live DAG visualization of workflow runs, subagents, status and dependencies. (✅ active)
 - [dsh-governance](https://github.com/tappass/dsh-governance) ⭐1 — Authority layer for agentic AI as a DSH plugin: governs every tool call against your policies. (✅ active)
+- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) ⭐1 — Turn a DSH session into deliverable work reports (daily/weekly/handoff/article) with verifiable receipts. (✅ active)
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval)  — Agent evaluation platform: benchmark YAML, headless dsh runs, trace-based metrics, scripted grading and run comparison. (✅ active)
-- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio)  — Turn a DSH session into deliverable work reports (daily/weekly/handoff/article) with verifiable receipts. (✅ active)
-- [dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag)  — Persistent live DAG visualization of workflow runs, subagents, status and dependencies. (✅ active)
 - [dsh-trajectory-debug](https://github.com/devmom/dsh-trajectory-debug)  — Trajectory waterfall, deterministic replay, breakpoints, edit-and-rerun, fork compare and performance analytics. (✅ active)
 
 ### Agents & Multi-Agent
@@ -394,41 +458,41 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) | ⭐2,324 | 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） | ✅ active |
-| 2 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | ⭐222 | Multi-agent team-oriented extensions for DSH. | ✅ active |
-| 3 | [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) | ⭐101 | SillyTavern migration and next-generation Agent roleplay for DSH. | ✅ active |
-| 4 | [allinluna](https://github.com/zenx0x/allinluna) | ⭐25 | Resource-aware multi-agent orchestration for Codex and DeepSeek Harness (All in Flash DSH plugin). | ✅ active |
-| 5 | [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | ⭐24 | Cross-instance message/event handoff plugins (interconnect service + tools). | ✅ active |
-| 6 | [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) | ⭐19 | OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 | ✅ active |
-| 7 | [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) | ⭐19 | DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 | ✅ active |
-| 8 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | ⭐17 | Session-scoped database connections with a dedicated data agent: let the model connect to databases and write SQL. | ✅ active |
-| 9 | [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | ⭐12 | Bridge DeepSeek Harness into Claude Code for review, critique, delegation and session import. | ✅ active |
-| 10 | [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) | ⭐8 | Role-based Codex/Claude Code/ACP subagent providers: continuable children with durable state. | ✅ active |
+| 1 | [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) | ⭐2,493 | 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） | ✅ active |
+| 2 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | ⭐312 | Multi-agent team-oriented extensions for DSH. | ✅ active |
+| 3 | [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) | ⭐121 | SillyTavern migration and next-generation Agent roleplay for DSH. | ✅ active |
+| 4 | [allinluna](https://github.com/zenx0x/allinluna) | ⭐28 | Resource-aware multi-agent orchestration for Codex and DeepSeek Harness (All in Flash DSH plugin). | ✅ active |
+| 5 | [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | ⭐27 | Cross-instance message/event handoff plugins (interconnect service + tools). | ✅ active |
+| 6 | [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) | ⭐26 | OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 | ✅ active |
+| 7 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | ⭐25 | Session-scoped database connections with a dedicated data agent: let the model connect to databases and write SQL. | ✅ active |
+| 8 | [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) | ⭐23 | DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 | ✅ active |
+| 9 | [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | ⭐15 | Bridge DeepSeek Harness into Claude Code for review, critique, delegation and session import. | ✅ active |
+| 10 | [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) | ⭐9 | Pair a second model that passively reviews each turn and injects notes. | ✅ active |
 
 #### Complete list (23)
 
-- [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) ⭐2,324 — 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） (✅ active)
-- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) ⭐222 — Multi-agent team-oriented extensions for DSH. (✅ active)
-- [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) ⭐101 — SillyTavern migration and next-generation Agent roleplay for DSH. (✅ active)
-- [allinluna](https://github.com/zenx0x/allinluna) ⭐25 — Resource-aware multi-agent orchestration for Codex and DeepSeek Harness (All in Flash DSH plugin). (✅ active)
-- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) ⭐24 — Cross-instance message/event handoff plugins (interconnect service + tools). (✅ active)
-- [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) ⭐19 — OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 (✅ active)
-- [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) ⭐19 — DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 (✅ active)
-- [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) ⭐17 — Session-scoped database connections with a dedicated data agent: let the model connect to databases and write SQL. (✅ active)
-- [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) ⭐12 — Bridge DeepSeek Harness into Claude Code for review, critique, delegation and session import. (✅ active)
-- [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) ⭐8 — Role-based Codex/Claude Code/ACP subagent providers: continuable children with durable state. (✅ active)
-- [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) ⭐5 — Pair a second model that passively reviews each turn and injects notes. (✅ active)
+- [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) ⭐2,493 — 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） (✅ active)
+- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) ⭐312 — Multi-agent team-oriented extensions for DSH. (✅ active)
+- [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) ⭐121 — SillyTavern migration and next-generation Agent roleplay for DSH. (✅ active)
+- [allinluna](https://github.com/zenx0x/allinluna) ⭐28 — Resource-aware multi-agent orchestration for Codex and DeepSeek Harness (All in Flash DSH plugin). (✅ active)
+- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) ⭐27 — Cross-instance message/event handoff plugins (interconnect service + tools). (✅ active)
+- [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) ⭐26 — OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 (✅ active)
+- [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) ⭐25 — Session-scoped database connections with a dedicated data agent: let the model connect to databases and write SQL. (✅ active)
+- [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) ⭐23 — DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 (✅ active)
+- [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) ⭐15 — Bridge DeepSeek Harness into Claude Code for review, critique, delegation and session import. (✅ active)
+- [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) ⭐9 — Pair a second model that passively reviews each turn and injects notes. (✅ active)
+- [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) ⭐9 — Role-based Codex/Claude Code/ACP subagent providers: continuable children with durable state. (✅ active)
+- [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) ⭐7 — Configurable subagent profile system: a single subagent tool with profile parameters, Web UI settings and live progress. (✅ active)
+- [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) ⭐7 — Side sessions: persistent /side sessions (Codex style) and one-off /btw questions (Claude style) in temporary forks. (✅ active)
 - [dsh-plugin-claude-bridge](https://github.com/YYTbit/dsh-plugin-claude-bridge) ⭐5 — Bridge Claude Code memory, skills and config into DeepSeek Harness. (✅ active)
-- [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) ⭐5 — Configurable subagent profile system: a single subagent tool with profile parameters, Web UI settings and live progress. (✅ active)
 - [Task Passport](https://github.com/dongsheng123132/task-passport) ⭐5 — Open task handoff protocol for DeepSeek Harness, WorkBuddy, Claude Code and Codex: verified state, not chat logs. (✅ active)
+- [dsh-a2a](https://github.com/dpskh/dsh-a2a) ⭐4 — Agent2Agent mesh for the Harness. (✅ active)
 - [dsh-agent-messaging](https://github.com/happyren/dsh-agent-messaging) ⭐4 — Cross-session agent-to-agent messaging: address another session by name. (✅ active)
-- [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) ⭐4 — Side sessions: persistent /side sessions (Codex style) and one-off /btw questions (Claude style) in temporary forks. (✅ active)
-- [dsh-a2a](https://github.com/dpskh/dsh-a2a) ⭐2 — Agent2Agent mesh for the Harness. (✅ active)
-- [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) ⭐2 — Role-based LLM retry and fallback strategy plugin. (✅ active)
+- [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) ⭐4 — Role-based LLM retry and fallback strategy plugin. (✅ active)
+- [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) ⭐2 — Cross-session messaging: DSH sessions on the same machine can discover, message and coordinate with each other. (✅ active)
+- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) ⭐2 — Per-call model/provider/persona/toolFilter overrides for subagent delegation with @preset references. (✅ active)
 - [dsh-cross-session](https://github.com/Wha1eChai/dsh-cross-session) ⭐1 — Same-runtime cross-session discovery and communication for DeepSeek Harness. (✅ active)
-- [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) ⭐1 — Cross-session messaging: DSH sessions on the same machine can discover, message and coordinate with each other. (✅ active)
 - [dsh-slice-agent-loop](https://github.com/TT-Wang/dsh-slice-agent-loop) ⭐1 — Drop-in agent loop whose context engine is a bounded slice instead of a growing transcript. (✅ active)
-- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) ⭐1 — Per-call model/provider/persona/toolFilter overrides for subagent delegation with @preset references. (✅ active)
 - [dsh-supervisor](https://github.com/Wha1eChai/dsh-supervisor) ⭐1 — Same-runtime cross-session discovery and communication for DeepSeek Harness. (✅ active)
 
 ### Clients (Desktop & TUI)
@@ -438,54 +502,70 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) | ⭐962 | Modern desktop experience built for the DeepSeek Harness ecosystem (plugin). | ✅ active |
-| 2 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | ⭐793 | Claude Code-style full-screen terminal plugin: pixel-whale top bar, live status line, streaming thoughts, double-Esc rollback, context progress bar and TPS meter. | ✅ active |
-| 3 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | ⭐160 | One-stop community distribution: TUI, desktop and Web UI in a unified experience with layered installation. | ✅ active |
-| 4 | [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) | ⭐140 | Desktop app for DeepSeek Harness. | ✅ active |
-| 5 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | ⭐125 | Interactive terminal UI plugin for DSH with added TDD, evidence gates and vision modules. | ✅ active |
-| 6 | [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) | ⭐104 | Minimal cross-platform desktop wrapper: no config, out of the box. | ✅ active |
-| 7 | [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) | ⭐74 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch | ✅ active |
-| 8 | [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) | ⭐67 | Desktop wrapper for DeepSeek Harness. | ✅ active |
-| 9 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | ⭐65 | Lightweight Windows launcher: silent autostart at logon plus a minimal WebView2 window. | ✅ active |
-| 10 | [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) | ⭐63 | One-click desktop app: fully local with self-healing core updates, zero environment setup. Windows/macOS/Linux. | ✅ active |
+| 1 | [open-design](https://github.com/nexu-io/open-design) | ⭐86,741 | 🎨 The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode / Hermes & 20+ CLIs via BYOK. | ✅ active |
+| 2 | [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) | ⭐4,667 | Modern desktop experience built for the DeepSeek Harness ecosystem (plugin). | ✅ active |
+| 3 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | ⭐1,156 | Claude Code-style full-screen terminal plugin: pixel-whale top bar, live status line, streaming thoughts, double-Esc rollback, context progress bar and TPS meter. | ✅ active |
+| 4 | [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) | ⭐227 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch | ✅ active |
+| 5 | [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) | ⭐221 | Desktop app for DeepSeek Harness. | ✅ active |
+| 6 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | ⭐184 | One-stop community distribution: TUI, desktop and Web UI in a unified experience with layered installation. | ✅ active |
+| 7 | [deepseek-harness-eac](https://github.com/zouyuxuan122/Deepseek-Harness-EAC) | ⭐158 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch, 10 built-in UI skins. EAC: Embracing All Creation 揽尽万象 | ✅ active |
+| 8 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | ⭐153 | Interactive terminal UI plugin for DSH with added TDD, evidence gates and vision modules. | ✅ active |
+| 9 | [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) | ⭐143 | One-click desktop app: fully local with self-healing core updates, zero environment setup. Windows/macOS/Linux. | ✅ active |
+| 10 | [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) | ⭐139 | Minimal cross-platform desktop wrapper: no config, out of the box. | ✅ active |
 
-#### Complete list (35)
+#### Complete list (51)
 
-- [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) ⭐962 — Modern desktop experience built for the DeepSeek Harness ecosystem (plugin). (✅ active)
-- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) ⭐793 — Claude Code-style full-screen terminal plugin: pixel-whale top bar, live status line, streaming thoughts, double-Esc rollback, context progress bar and TPS meter. (✅ active)
-- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) ⭐160 — One-stop community distribution: TUI, desktop and Web UI in a unified experience with layered installation. (✅ active)
-- [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) ⭐140 — Desktop app for DeepSeek Harness. (✅ active)
-- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) ⭐125 — Interactive terminal UI plugin for DSH with added TDD, evidence gates and vision modules. (✅ active)
-- [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) ⭐104 — Minimal cross-platform desktop wrapper: no config, out of the box. (✅ active)
-- [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) ⭐74 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch (✅ active)
-- [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) ⭐67 — Desktop wrapper for DeepSeek Harness. (✅ active)
-- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) ⭐65 — Lightweight Windows launcher: silent autostart at logon plus a minimal WebView2 window. (✅ active)
-- [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) ⭐63 — One-click desktop app: fully local with self-healing core updates, zero environment setup. Windows/macOS/Linux. (✅ active)
-- [deepseek-harness-desktop (xiincs)](https://github.com/xiincs/deepseek-harness-desktop) ⭐53 — Native desktop built on Tauri 2 with bundled Node.js runtime, tray residency and auto-update. (✅ active)
-- [Deepseek-Harness-Desktop (ChisaAlter)](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) ⭐50 — Electron desktop shell with theme and background-image customization. (✅ active)
-- [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) ⭐27 — Support the dsh runtime on Multica. (✅ active)
-- [dsh-work](https://github.com/vibeinging/dsh-work) ⭐25 — Local-first AI workbench for DSH Plugins, combining Agent sessions, project files, data analysis, web research, MCP, and Office artifacts in an Electron desktop app. (✅ active)
-- [deepseek-harness-app (ipfred)](https://github.com/ipfred/deepseek-harness-app) ⭐23 — Desktop app for DeepSeek Harness. (✅ active)
-- [deepseek-harness-desktop (hongfeiyucode)](https://github.com/hongfeiyucode/deepseek-harness-desktop) ⭐23 — Desktop wrapper for DeepSeek Harness. (✅ active)
-- [deepseek-harness-desktop (ningbainb)](https://github.com/ningbainb/deepseek-harness-desktop) ⭐21 — Lossless Windows desktop app with the complete DSH Web UI, plugins, skins and skill dock. (✅ active)
-- [DeepSeekHarnessDesktop (wess09)](https://github.com/wess09/DeepSeekHarnessDesktop) ⭐20 — Desktop packaging for DeepSeek Harness. (✅ active)
-- [dsh-desktop (bruc3van)](https://github.com/bruc3van/dsh-desktop) ⭐20 — Third-party desktop client loading the official Web UI: reuses a running official instance or a bundled dsh runtime. (✅ active)
-- [DeepSeek Harness TUI (openma-ai)](https://github.com/openma-ai/deepseek-harness-tui) ⭐15 — Rust/Ratatui terminal client speaking the DSH SDK JSON-RPC protocol directly; runs standalone or as a profile bundle. (✅ active)
-- [deepseek-harness-desktop (cc1252)](https://github.com/cc1252/deepseek-harness-desktop) ⭐14 — Unofficial open-source Windows Electron wrapper for DeepSeek Harness. (✅ active)
-- [DeepSeek-Harness-Desktop (sleep2agi)](https://github.com/sleep2agi/DeepSeek-Harness-Desktop) ⭐11 — Unofficial community desktop shell for the public dsh runtime. (✅ active)
-- [awesome-deepseek-harness-desktop (ADHD)](https://github.com/omdsh-dev/awesome-deepseek-harness-desktop) ⭐10 — ADHD — out-of-the-box Electron desktop wrapper for DeepSeek Harness. (✅ active)
+- [open-design](https://github.com/nexu-io/open-design) ⭐86,741 — 🎨 The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode / Hermes & 20+ CLIs via BYOK. (✅ active)
+- [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) ⭐4,667 — Modern desktop experience built for the DeepSeek Harness ecosystem (plugin). (✅ active)
+- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) ⭐1,156 — Claude Code-style full-screen terminal plugin: pixel-whale top bar, live status line, streaming thoughts, double-Esc rollback, context progress bar and TPS meter. (✅ active)
+- [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) ⭐227 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch (✅ active)
+- [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) ⭐221 — Desktop app for DeepSeek Harness. (✅ active)
+- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) ⭐184 — One-stop community distribution: TUI, desktop and Web UI in a unified experience with layered installation. (✅ active)
+- [deepseek-harness-eac](https://github.com/zouyuxuan122/Deepseek-Harness-EAC) ⭐158 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch, 10 built-in UI skins. EAC: Embracing All Creation 揽尽万象 (✅ active)
+- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) ⭐153 — Interactive terminal UI plugin for DSH with added TDD, evidence gates and vision modules. (✅ active)
+- [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) ⭐143 — One-click desktop app: fully local with self-healing core updates, zero environment setup. Windows/macOS/Linux. (✅ active)
+- [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) ⭐139 — Minimal cross-platform desktop wrapper: no config, out of the box. (✅ active)
+- [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) ⭐115 — DeepSeek Harness Desktop App: a local AI desktop workspace for DSH Sessions, projects, files, web research, plugins, and Office artifacts. (✅ active)
+- [dsh-work](https://github.com/vibeinging/dsh-work) ⭐115 — Local-first AI workbench for DSH Plugins, combining Agent sessions, project files, data analysis, web research, MCP, and Office artifacts in an Electron desktop app. (✅ active)
+- [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) ⭐94 — Desktop wrapper for DeepSeek Harness. (✅ active)
+- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) ⭐92 — Lightweight Windows launcher: silent autostart at logon plus a minimal WebView2 window. (✅ active)
+- [Deepseek-Harness-Desktop (ChisaAlter)](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) ⭐81 — Electron desktop shell with theme and background-image customization. (✅ active)
+- [deepseek-harness-desktop (ningbainb)](https://github.com/ningbainb/deepseek-harness-desktop) ⭐44 — Lossless Windows desktop app with the complete DSH Web UI, plugins, skins and skill dock. (✅ active)
+- [deepseek-harness-desktop (hongfeiyucode)](https://github.com/hongfeiyucode/deepseek-harness-desktop) ⭐37 — Desktop wrapper for DeepSeek Harness. (✅ active)
+- [DeepSeekHarnessDesktop (wess09)](https://github.com/wess09/DeepSeekHarnessDesktop) ⭐37 — Desktop packaging for DeepSeek Harness. (✅ active)
+- [deepseek-harness-desktop (xiincs)](https://github.com/xiincs/deepseek-harness-desktop) ⭐36 — Native desktop built on Tauri 2 with bundled Node.js runtime, tray residency and auto-update. (✅ active)
+- [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) ⭐34 — Support the dsh runtime on Multica. (✅ active)
+- [dsh-desktop (bruc3van)](https://github.com/bruc3van/dsh-desktop) ⭐29 — Third-party desktop client loading the official Web UI: reuses a running official instance or a bundled dsh runtime. (✅ active)
+- [deepseek-harness-app (ipfred)](https://github.com/ipfred/deepseek-harness-app) ⭐26 — Desktop app for DeepSeek Harness. (✅ active)
+- [DeepSeek Harness TUI (openma-ai)](https://github.com/openma-ai/deepseek-harness-tui) ⭐25 — Rust/Ratatui terminal client speaking the DSH SDK JSON-RPC protocol directly; runs standalone or as a profile bundle. (✅ active)
+- [deepseek-harness-desktop (cc1252)](https://github.com/cc1252/deepseek-harness-desktop) ⭐17 — Unofficial open-source Windows Electron wrapper for DeepSeek Harness. (✅ active)
+- [deepseek-harness-termux](https://github.com/Vengisk/deepseek-harness-termux) ⭐15 — Run @deepseek-ai/dsh on Android/Termux. (✅ active)
+- [dsh-plugin-session-delete](https://github.com/lsz-asd/dsh-plugin-session-delete) ⭐15 — Delete DeepSeek Harness sessions from the UI: header danger button + sidebar session-row menu item (no conversation jump), risk-consent dialog with session name/id, stops running agents first, in-place list refresh without page reload. Works in web and the desktop client. (✅ active)
+- [DeepSeek-Harness-Desktop (sleep2agi)](https://github.com/sleep2agi/DeepSeek-Harness-Desktop) ⭐14 — Unofficial community desktop shell for the public dsh runtime. (✅ active)
+- [dsh-usage-plugin](https://github.com/feiyang-dev/dsh-usage-plugin) ⭐14 — DeepSeek Harness 用量与消耗插件（dsh-usage）—— 每次调用的 token 用量/缓存命中统计、峰谷计费、余额查询、CSV/JSON/PNG 导出，可经桌面端一键安装或命令行 dsh plugin add 安装。 (✅ active)
+- [dsh-mobile](https://github.com/lehhair/dsh-mobile) ⭐12 — Mobile client plugin (cordis + dsh.plugin.json). (✅ active)
+- [awesome-deepseek-harness-desktop (ADHD)](https://github.com/omdsh-dev/awesome-deepseek-harness-desktop) ⭐11 — ADHD — out-of-the-box Electron desktop wrapper for DeepSeek Harness. (✅ active)
 - [deepseek-harness-desktop (chyra-moon)](https://github.com/chyra-moon/deepseek-harness-desktop) ⭐10 — Native Windows desktop shell: 1:1 official web UI with embedded server, tray and auto-recovery. (✅ active)
-- [deepseek-harness-termux](https://github.com/Vengisk/deepseek-harness-termux) ⭐9 — Run @deepseek-ai/dsh on Android/Termux. (✅ active)
-- [deepseek-harness-desktop](https://github.com/omdsh-dev/deepseek-harness-desktop) ⭐7 — DSH 桌面应用打包器 (✅ active)
-- [deepseek-harness-desktop](https://github.com/qyqy-1109/deepseek-harness-desktop) ⭐6 — DeepSeek Harness Desktop: self-contained Windows desktop shell (Electron) that auto-starts dsh web, plus a subtle Codex-flavored theme plugin. (✅ active)
-- [deepseek-harness-tui (gxinxing)](https://github.com/gxinxing/deepseek-harness-tui) ⭐6 — Terminal-native interactive TUI built with Ink (React for terminals). (✅ active)
+- [deepseek-harness-desktop](https://github.com/qyqy-1109/deepseek-harness-desktop) ⭐9 — DeepSeek Harness Desktop: self-contained Windows desktop shell (Electron) that auto-starts dsh web, plus a subtle Codex-flavored theme plugin. (✅ active)
+- [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) ⭐9 — TUI built with grok-build. (✅ active)
+- [deepseek-harness-desktop](https://github.com/omdsh-dev/deepseek-harness-desktop) ⭐8 — DSH 桌面应用打包器 (✅ active)
+- [deepseek-harness-fnos](https://github.com/techysy/deepseek-harness-fnos) ⭐8 — DeepSeek Harness (DeepSeek 官方 agent 浏览器 UI) fnOS 应用 — 本地常驻服务, 官方统一网关接入 (✅ active)
+- [dsh-melody-launcher](https://github.com/rirko/dsh-melody-launcher) ⭐8 — dsh-旋律启动器：DeepSeek Harness 桌面启动器与插件管理器 (✅ active)
+- [dsh-mobile-for-android](https://github.com/Hongtwenfive1226/DSH-Mobile-for-Android) ⭐8 — The Android mobile version of DeepSeek Harness that relies on Tailscale. (✅ active)
+- [deepseek-harness-tui (gxinxing)](https://github.com/gxinxing/deepseek-harness-tui) ⭐7 — Terminal-native interactive TUI built with Ink (React for terminals). (✅ active)
+- [dsh-desktop](https://github.com/foolgry/dsh-desktop) ⭐7 — Download-and-run desktop build of DeepSeek Harness — Electron shell with embedded Node, no npm required. (✅ active)
+- [deepseek-harness-desktop](https://github.com/RZX00/deepseek-harness-desktop) ⭐6 — DeepSeek Harness with a Windows desktop build: an Electron shell over the dsh web profile, packaged as an installer (✅ active)
+- [deepseek-harness-tui (boxeryao)](https://github.com/boxeryao/deepseek-harness-tui) ⭐6 — Lightweight fast terminal plugin connected directly to the DSH runtime. (✅ active)
 - [deepseek-harness-cli](https://github.com/Richard-Yang0130/deepseek-harness-cli) ⭐5 — Claude Code-style terminal interface for DeepSeek Harness (✅ active)
-- [deepseek-harness-desktop](https://github.com/RZX00/deepseek-harness-desktop) ⭐5 — DeepSeek Harness with a Windows desktop build: an Electron shell over the dsh web profile, packaged as an installer (✅ active)
-- [deepseek-harness-tui (boxeryao)](https://github.com/boxeryao/deepseek-harness-tui) ⭐5 — Lightweight fast terminal plugin connected directly to the DSH runtime. (✅ active)
-- [deepseek-harness-fnos](https://github.com/techysy/deepseek-harness-fnos) ⭐4 — DeepSeek Harness (DeepSeek 官方 agent 浏览器 UI) fnOS 应用 — 本地常驻服务, 官方统一网关接入 (✅ active)
+- [deepseek-harness-desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) ⭐4 — Windows desktop app for DeepSeek Harness: installer, themes, in-app plugin marketplace, model routing, and updates. (✅ active)
 - [dsh-desktop-electron](https://github.com/Void0312Aurora/dsh-desktop-electron) ⭐4 — Cross-platform Electron shell for the DSH Web GUI: tray-resident standalone window. (✅ active)
+- [dshcockpit](https://github.com/Lxiayu/DshCockpit) ⭐4 — DshCockpit — DeepSeek Harness 桌面驾驶舱 (desktop cockpit)：运行时自动更新、成本控制、全局快捷问询、定时任务、会话全文检索、数据安全。自动更新 / 成本中心 / Quick Ask / 定时任务 / 会话搜索 (✅ active)
+- [deepseek-harness-workbench](https://github.com/xuan-ao-1/deepseek-harness-workbench) ⭐3 — DeepSeek Harness 官方架构的 Windows 桌面发行版 (Desktop distribution of the official DeepSeek Harness) (✅ active)
+- [dsh-portable-launcher](https://github.com/15828148/dsh-portable-launcher) ⭐2 — One-click portable launcher for DeepSeek Harness (dsh) Web UI on Windows. Auto-installs Node.js and dsh with China mirror fallback, 3-stage progress with retries and resume, zero-download fast path when ready. No admin needed. (✅ active)
+- [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop-windows) ⭐1 — Unofficial in-process desktop app for DeepSeek Harness: the host composition boots inside the Electron main process with zero ports and an IPC bridge. Not affiliated with DeepSeek. (✅ active)
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) ⭐1 — Pi TUI front end: streaming markdown, thinking collapse, tool cards, slash commands and approval overlays. (✅ active)
-- [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui)  — TUI built with grok-build. (✅ active)
+- [dsh-desktop-launcher](https://github.com/becomeless/dsh-desktop-launcher)  — Windows/macOS desktop launcher for DeepSeek Harness: double-click to launch, zero console windows, auto-stop on close | 双击图标一键启动 DeepSeek Harness 的桌面启动器（Windows / macOS） (✅ active)
+- [dsh-quickstart](https://github.com/qzhqzh/dsh-quickstart)  — Desktop launcher for DeepSeek Harness - start dsh web with no console window and auto-open the browser. Tested on Windows; macOS/Linux in progress. (✅ active)
 
 ### MCP & Integrations
 
@@ -494,42 +574,52 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) | ⭐758 | Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. | ✅ active |
-| 2 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | ⭐64 | OpenPencil design preview and editing integration. | ✅ active |
-| 3 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | ⭐14 | Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 | ✅ active |
-| 4 | [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) | ⭐6 | ACP server implementation for DeepSeek Harness: exposes the full DSH agent to ACP clients while reusing credentials and sessions. | ✅ active |
-| 5 | [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) | ⭐6 | Community Docker and Kubernetes packaging for @deepseek-ai/dsh with a hardened image. | ✅ active |
-| 6 | [dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | ⭐6 | OAuth 2.1 Streamable HTTP MCP client plugin for DeepSeek Harness. | ✅ active |
-| 7 | [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) | ⭐5 | Community GitHub Action: AI code review, CI diagnosis, auto-fix and issue-to-PR implementation. | ✅ active |
-| 8 | [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) | ⭐5 | MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth. | ✅ active |
-| 9 | [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) | ⭐4 | DeepSeek Harness for VS Code as extension | ✅ active |
-| 10 | [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) | ⭐4 | Relay that turns Telegram into a remote conversation channel for DSH with notifications. | ✅ active |
+| 1 | [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) | ⭐787 | Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. | ✅ active |
+| 2 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | ⭐74 | OpenPencil design preview and editing integration. | ✅ active |
+| 3 | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | ⭐48 | Super-injector plugin (cordis) for context injection. | ✅ active |
+| 4 | [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot) | ⭐32 | 让 QQ 机器人接入 DeepSeek Harness（dsh）的官方插件 | ✅ active |
+| 5 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | ⭐16 | Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 | ✅ active |
+| 6 | [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) | ⭐11 | Community GitHub Action: AI code review, CI diagnosis, auto-fix and issue-to-PR implementation. | ✅ active |
+| 7 | [ikanban](https://github.com/isomoes/ikanban) | ⭐10 | Monorepo for the iKanban browser-surface fork for DeepSeek Harness. | ✅ active |
+| 8 | [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) | ⭐8 | Community Docker and Kubernetes packaging for @deepseek-ai/dsh with a hardened image. | ✅ active |
+| 9 | [dsh-git-graph](https://github.com/1841220388zzzcccxxx-star/dsh-git-graph) | ⭐8 | Embedded git repository graph visualizer for the DeepSeek Harness Web GUI | 嵌入式 Git 仓库图谱可视化插件（提交历史图 / 分支过滤 / 文件 diff / VSCode 式未提交改动） | ✅ active |
+| 10 | [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) | ⭐8 | Replace DSH's built-in web search with search MCP servers (Tavily/Brave/Exa/Perplexity/DuckDuckGo). | ✅ active |
 
-#### Complete list (25)
+#### Complete list (35)
 
-- [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐758 — Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. (✅ active)
-- [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) ⭐64 — OpenPencil design preview and editing integration. (✅ active)
-- [dsh-lark](https://github.com/omdsh-dev/dsh-lark) ⭐14 — Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 (✅ active)
-- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) ⭐6 — ACP server implementation for DeepSeek Harness: exposes the full DSH agent to ACP clients while reusing credentials and sessions. (✅ active)
-- [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) ⭐6 — Community Docker and Kubernetes packaging for @deepseek-ai/dsh with a hardened image. (✅ active)
+- [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐787 — Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. (✅ active)
+- [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) ⭐74 — OpenPencil design preview and editing integration. (✅ active)
+- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) ⭐48 — Super-injector plugin (cordis) for context injection. (✅ active)
+- [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot) ⭐32 — 让 QQ 机器人接入 DeepSeek Harness（dsh）的官方插件 (✅ active)
+- [dsh-lark](https://github.com/omdsh-dev/dsh-lark) ⭐16 — Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 (✅ active)
+- [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) ⭐11 — Community GitHub Action: AI code review, CI diagnosis, auto-fix and issue-to-PR implementation. (✅ active)
+- [ikanban](https://github.com/isomoes/ikanban) ⭐10 — Monorepo for the iKanban browser-surface fork for DeepSeek Harness. (✅ active)
+- [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) ⭐8 — Community Docker and Kubernetes packaging for @deepseek-ai/dsh with a hardened image. (✅ active)
+- [dsh-git-graph](https://github.com/1841220388zzzcccxxx-star/dsh-git-graph) ⭐8 — Embedded git repository graph visualizer for the DeepSeek Harness Web GUI | 嵌入式 Git 仓库图谱可视化插件（提交历史图 / 分支过滤 / 文件 diff / VSCode 式未提交改动） (✅ active)
+- [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) ⭐8 — Replace DSH's built-in web search with search MCP servers (Tavily/Brave/Exa/Perplexity/DuckDuckGo). (✅ active)
+- [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) ⭐8 — DeepSeek Harness 插件：DeepSeek 大脑 + 自动识图。GUI 附加图片自动经 OpenAI 兼容 VLM 转译成文字后交给 DeepSeek 作答；支持百炼/智谱/OpenRouter 等任意 OpenAI 兼容端点（默认 qwen3.7-flash），无 key 自动探测本地 Ollama（图片不出本机）；安装时有一问式确认 (✅ active)
+- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) ⭐7 — ACP server implementation for DeepSeek Harness: exposes the full DSH agent to ACP clients while reusing credentials and sessions. (✅ active)
+- [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) ⭐7 — DeepSeek Harness for VS Code as extension (✅ active)
+- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) ⭐6 — MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth. (✅ active)
 - [dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) ⭐6 — OAuth 2.1 Streamable HTTP MCP client plugin for DeepSeek Harness. (✅ active)
-- [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) ⭐5 — Community GitHub Action: AI code review, CI diagnosis, auto-fix and issue-to-PR implementation. (✅ active)
-- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) ⭐5 — MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth. (✅ active)
-- [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) ⭐4 — DeepSeek Harness for VS Code as extension (✅ active)
-- [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) ⭐4 — Relay that turns Telegram into a remote conversation channel for DSH with notifications. (✅ active)
-- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) ⭐4 — Telegram mobile remote for live DSH Web sessions: session picker, bind/unbind, same trajectory as desktop. (✅ active)
+- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) ⭐6 — Telegram mobile remote for live DSH Web sessions: session picker, bind/unbind, same trajectory as desktop. (✅ active)
+- [telegram](https://github.com/LoserFox/telegram) ⭐6 — Telegram Bot API 桥接插件：长轮询、per-chat 会话、HTML 格式化 (✅ active)
+- [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) ⭐5 — Relay that turns Telegram into a remote conversation channel for DSH with notifications. (✅ active)
+- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) ⭐5 — Expose DeepSeek Harness agent capabilities as an MCP server (brain=Hermes, arms=Harness). (✅ active)
+- [dsh-browser](https://github.com/xylt369/dsh-browser) ⭐4 — Browser capability for DeepSeek Harness: headed Edge/Playwright provider, SSRF-safe navigation, a11y-ref clicking, permission gate with auto-remember, gated evaluate (✅ active)
+- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) ⭐4 — LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure contexts. (✅ active)
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) ⭐4 — Read-only runtime management panel for the official DSH MCP client: /mcp command and a Settings tab. (✅ active)
+- [dsh-subscription-auth](https://github.com/Khellendros97/dsh-subscription-auth) ⭐4 — dsh对接openai、grok、anthropic、kimi订阅渠道 (✅ active)
 - [PicGo DSH Plugin](https://github.com/PicGo/dsh-plugin) ⭐4 — Official PicGo plugin: upload images/files to your image host from DSH and get public URLs. (✅ active)
-- [dsh-browser](https://github.com/xylt369/dsh-browser) ⭐3 — Browser capability for DeepSeek Harness: headed Edge/Playwright provider, SSRF-safe navigation, a11y-ref clicking, permission gate with auto-remember, gated evaluate (✅ active)
-- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) ⭐3 — Read-only runtime management panel for the official DSH MCP client: /mcp command and a Settings tab. (✅ active)
-- [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) ⭐3 — Replace DSH's built-in web search with search MCP servers (Tavily/Brave/Exa/Perplexity/DuckDuckGo). (✅ active)
-- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) ⭐2 — Expose DeepSeek Harness agent capabilities as an MCP server (brain=Hermes, arms=Harness). (✅ active)
+- [dsh-agentlink](https://github.com/hootandy321/dsh-Agentlink) ⭐3 — Caller-side bridge from Codex and other agent frameworks to DeepSeek Harness, with observable sessions, follow-up, cancellation, and human-gated approvals. (✅ active)
+- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) ⭐3 — DeepSeek Harness subagent delegation enhancement (✅ active)
+- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode) ⭐3 — VS Code chat windows backed by the DSH agent: OpenCode-style independent sessions with model auto-routing. (✅ active)
+- [dsh-github-integration](https://github.com/omdsh-dev/dsh-github-integration) ⭐2 — GitHub integration plugin for DSH. (✅ active)
+- [dsh-plugin-acn](https://github.com/acnlabs/dsh-plugin-acn) ⭐2 — DeepSeek Harness plugin: join ACN so this agent can discover, message, and collaborate with other agents. Defaults to the China region. (✅ active)
+- [vscode-deepseek-harness](https://github.com/kalynnka/vscode-deepseek-harness) ⭐2 — Unofficial: drive your own dsh as a native VS Code chat agent. (✅ active)
+- [deepseek-harness-rs](https://github.com/Tokimorphling/deepseek-harness-rs) ⭐1 — A Rust port of DeepSeek Harness. (🧪 experimental)
 - [dsh-chrome](https://github.com/YJSoooooo/dsh-chrome) ⭐1 — Chrome profile bridge: control an existing signed-in Chrome profile through Chrome DevTools Protocol. (✅ active)
-- [vscode-deepseek-harness](https://github.com/kalynnka/vscode-deepseek-harness) ⭐1 — Unofficial: drive your own dsh as a native VS Code chat agent. (✅ active)
-- [deepseek-harness-rs](https://github.com/Tokimorphling/deepseek-harness-rs)  — A Rust port of DeepSeek Harness. (🧪 experimental)
-- [dsh-github-integration](https://github.com/omdsh-dev/dsh-github-integration)  — GitHub integration plugin for DSH. (✅ active)
-- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access)  — LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure contexts. (✅ active)
-- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector)  — Super-injector plugin (cordis) for context injection. (✅ active)
-- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode)  — VS Code chat windows backed by the DSH agent: OpenCode-style independent sessions with model auto-routing. (✅ active)
+- [dsh-plugin-vision](https://github.com/tdf1995/dsh-plugin-vision)  — Vision for text-only LLMs in DeepSeek Harness (DSH): describe images / OCR / VQA via free Gemini & GLM vision APIs (✅ active)
 - [opendsh](https://github.com/TheChengXi/opendsh)  — Open the DeepSeek Harness Web UI inside VS Code with one-command start/stop. (✅ active)
 - [URL Manager MCP](https://github.com/Piccolo123/url-manager-mcp)  — MCP companion for URL Manager: 21 tools for save/search/categorize/share with magic-link delivery. (✅ active)
 
@@ -540,23 +630,23 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [hello-dsh](https://github.com/pingfanfan/hello-dsh) | ⭐37 | Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. | ✅ active |
+| 1 | [hello-dsh](https://github.com/pingfanfan/hello-dsh) | ⭐48 | Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. | ✅ active |
 | 2 | [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) | ⭐16 | Template for DeepSeek Harness plugin development. | ✅ active |
 | 3 | [turtle-ui](https://github.com/turtle1999/turtle-ui) | ⭐6 | Official UI plugin reference implementation. | ✅ active |
-| 4 | [dsh-101](https://github.com/bill9109/dsh-101) | ⭐2 | DSH documentation reading mode. | ✅ active |
-| 5 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐2 | Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. | ✅ active |
-| 6 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world style starter plugin for DSH. | ✅ active |
-| 7 | [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) |  | Plugin template repository derived from the original turtle-ui official repo. | ✅ active |
+| 4 | [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) | ⭐5 | Plugin template repository derived from the original turtle-ui official repo. | ✅ active |
+| 5 | [dsh-101](https://github.com/bill9109/dsh-101) | ⭐3 | DSH documentation reading mode. | ✅ active |
+| 6 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐3 | Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. | ✅ active |
+| 7 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world style starter plugin for DSH. | ✅ active |
 
 #### Complete list (7)
 
-- [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐37 — Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. (✅ active)
+- [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐48 — Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. (✅ active)
 - [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) ⭐16 — Template for DeepSeek Harness plugin development. (✅ active)
 - [turtle-ui](https://github.com/turtle1999/turtle-ui) ⭐6 — Official UI plugin reference implementation. (✅ active)
-- [dsh-101](https://github.com/bill9109/dsh-101) ⭐2 — DSH documentation reading mode. (✅ active)
-- [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐2 — Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. (✅ active)
+- [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) ⭐5 — Plugin template repository derived from the original turtle-ui official repo. (✅ active)
+- [dsh-101](https://github.com/bill9109/dsh-101) ⭐3 — DSH documentation reading mode. (✅ active)
+- [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐3 — Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. (✅ active)
 - [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello)  — Hello-world style starter plugin for DSH. (✅ active)
-- [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template)  — Plugin template repository derived from the original turtle-ui official repo. (✅ active)
 
 ### Tutorials & Learning
 
@@ -565,30 +655,31 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) | ⭐465 | Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. | ✅ active |
-| 2 | [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) | ⭐167 | From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). | ✅ active |
-| 3 | [dshfind](https://github.com/hikariming/dshfind) | ⭐56 | Learn DSH principles, plugin marketplace and best practices — from chapter-by-chapter Cordis paper reading to an auto-aggregated plugin market. | ✅ active |
-| 4 | [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) | ⭐32 | DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） | ✅ active |
-| 5 | [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) | ⭐17 | Detailed Chinese learning tutorial for DeepSeek Harness. | ✅ active |
-| 6 | [dsh-explain](https://github.com/yuezengwu/dsh-explain) | ⭐9 | Local-first learning mode: cross-session global learning threads, explain-by-source, ExplainContext and compression. | ✅ active |
-| 7 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | DeepSeek Harness prompts for different modes. | ✅ active |
-| 8 | [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) | ⭐5 | Learning website built from a systematic breakdown of the deepseek-harness repository, for developers curious how AI agent frameworks work. | ✅ active |
-| 9 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐5 | 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. | ✅ active |
-| 10 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | ⭐3 | Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. | ✅ active |
+| 1 | [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) | ⭐706 | Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. | ✅ active |
+| 2 | [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) | ⭐273 | From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). | ✅ active |
+| 3 | [dshfind](https://github.com/hikariming/dshfind) | ⭐80 | Learn DSH principles, plugin marketplace and best practices — from chapter-by-chapter Cordis paper reading to an auto-aggregated plugin market. | ✅ active |
+| 4 | [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) | ⭐43 | Detailed Chinese learning tutorial for DeepSeek Harness. | ✅ active |
+| 5 | [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) | ⭐40 | DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） | ✅ active |
+| 6 | [dsh-explain](https://github.com/yuezengwu/dsh-explain) | ⭐11 | Local-first learning mode: cross-session global learning threads, explain-by-source, ExplainContext and compression. | ✅ active |
+| 7 | [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) | ⭐7 | Learning website built from a systematic breakdown of the deepseek-harness repository, for developers curious how AI agent frameworks work. | ✅ active |
+| 8 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | DeepSeek Harness prompts for different modes. | ✅ active |
+| 9 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐6 | 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. | ✅ active |
+| 10 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | ⭐4 | Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. | ✅ active |
 
-#### Complete list (11)
+#### Complete list (12)
 
-- [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐465 — Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. (✅ active)
-- [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐167 — From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). (✅ active)
-- [dshfind](https://github.com/hikariming/dshfind) ⭐56 — Learn DSH principles, plugin marketplace and best practices — from chapter-by-chapter Cordis paper reading to an auto-aggregated plugin market. (✅ active)
-- [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) ⭐32 — DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） (✅ active)
-- [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) ⭐17 — Detailed Chinese learning tutorial for DeepSeek Harness. (✅ active)
-- [dsh-explain](https://github.com/yuezengwu/dsh-explain) ⭐9 — Local-first learning mode: cross-session global learning threads, explain-by-source, ExplainContext and compression. (✅ active)
+- [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐706 — Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. (✅ active)
+- [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐273 — From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). (✅ active)
+- [dshfind](https://github.com/hikariming/dshfind) ⭐80 — Learn DSH principles, plugin marketplace and best practices — from chapter-by-chapter Cordis paper reading to an auto-aggregated plugin market. (✅ active)
+- [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) ⭐43 — Detailed Chinese learning tutorial for DeepSeek Harness. (✅ active)
+- [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) ⭐40 — DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） (✅ active)
+- [dsh-explain](https://github.com/yuezengwu/dsh-explain) ⭐11 — Local-first learning mode: cross-session global learning threads, explain-by-source, ExplainContext and compression. (✅ active)
+- [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) ⭐7 — Learning website built from a systematic breakdown of the deepseek-harness repository, for developers curious how AI agent frameworks work. (✅ active)
 - [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) ⭐6 — DeepSeek Harness prompts for different modes. (✅ active)
-- [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) ⭐5 — Learning website built from a systematic breakdown of the deepseek-harness repository, for developers curious how AI agent frameworks work. (✅ active)
-- [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) ⭐5 — 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. (✅ active)
-- [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐3 — Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. (✅ active)
-- [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐1 — Checks DeepSeek tool loops, reasoning_content, strict schemas and captured SSE; also works as a DSH plugin. (✅ active)
+- [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) ⭐6 — 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. (✅ active)
+- [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐4 — Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. (✅ active)
+- [gitlearnos](https://github.com/Guojiz/gitlearnos) ⭐3 — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory. (✅ active)
+- [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐2 — Checks DeepSeek tool loops, reasoning_content, strict schemas and captured SSE; also works as a DSH plugin. (✅ active)
 
 ### Awesome Lists & Registries
 
@@ -597,44 +688,53 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | ⭐751 | Large curated list of installable DSH plugins (bilingual). | ✅ active |
-| 2 | [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) | ⭐751 | Radar index repo: auto-scanning all discovered dsh plugin candidates with an evidence-based compatibility matrix. | ✅ active |
-| 3 | [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) | ⭐360 | Curated DSH ecosystem directory: plugins, tools and infrastructure from dsh-external/hub and the public dsh-plugin topic. | ✅ active |
-| 4 | [notes (zhaoolee)](https://github.com/zhaoolee/notes) | ⭐138 | Open-source Smartisan Notes clone: Docker private deployment, skill invocation, dsh plugin support and one-click WeChat-format export. | ✅ active |
-| 5 | [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) | ⭐86 | Find the right DSH plugin in 30 seconds: what problem each plugin solves, who it is for and where to start. | ✅ active |
-| 6 | [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) | ⭐47 | Curated list of DeepSeek Harness plugins. | ✅ active |
-| 7 | [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | ⭐47 | Meticulously curated list of plugins, extensions, tools and development resources for DSH. | ✅ active |
-| 8 | [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | ⭐43 | Plugin ecosystem for DSH: 700+ plugins registered only through extension seams, without modifying the agent-loop skeleton. | ✅ active |
-| 9 | [plugin-registry](https://github.com/vlln/plugin-registry) | ⭐31 | DSH plugin ecosystem infrastructure: thin console to manage official repository plugins (0 patch) plus the make-dsh-plugin skill. | ✅ active |
-| 10 | [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) | ⭐30 | Curated list of plugins, skills, MCP servers, patch/profile layers, orchestrators and UIs for DeepSeek Harness. | ✅ active |
+| 1 | [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent) | ⭐5,853 | Official curated guides for integrating DeepSeek models into agent/coding-assistant tools (AstrBot, Cherry Studio, Claude Code, Codex, DeepSeek-TUI, Reasonix and more). | ✅ active |
+| 2 | [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | ⭐2,516 | Large curated list of installable DSH plugins (bilingual). | ✅ active |
+| 3 | [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) | ⭐942 | Radar index repo: auto-scanning all discovered dsh plugin candidates with an evidence-based compatibility matrix. | ✅ active |
+| 4 | [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) | ⭐465 | Curated DSH ecosystem directory: plugins, tools and infrastructure from dsh-external/hub and the public dsh-plugin topic. | ✅ active |
+| 5 | [notes (zhaoolee)](https://github.com/zhaoolee/notes) | ⭐142 | Open-source Smartisan Notes clone: Docker private deployment, skill invocation, dsh plugin support and one-click WeChat-format export. | ✅ active |
+| 6 | [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) | ⭐139 | Find the right DSH plugin in 30 seconds: what problem each plugin solves, who it is for and where to start. | ✅ active |
+| 7 | [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) | ⭐62 | Ultimate guide: quick start, resources, curated plugins and practical tools. | ✅ active |
+| 8 | [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | ⭐62 | Meticulously curated list of plugins, extensions, tools and development resources for DSH. | ✅ active |
+| 9 | [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) | ⭐61 | Curated list of DeepSeek Harness plugins. | ✅ active |
+| 10 | [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) | ⭐47 | Curated list of plugins, skills, MCP servers, patch/profile layers, orchestrators and UIs for DeepSeek Harness. | ✅ active |
 
-#### Complete list (25)
+#### Complete list (34)
 
-- [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐751 — Large curated list of installable DSH plugins (bilingual). (✅ active)
-- [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐751 — Radar index repo: auto-scanning all discovered dsh plugin candidates with an evidence-based compatibility matrix. (✅ active)
-- [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) ⭐360 — Curated DSH ecosystem directory: plugins, tools and infrastructure from dsh-external/hub and the public dsh-plugin topic. (✅ active)
-- [notes (zhaoolee)](https://github.com/zhaoolee/notes) ⭐138 — Open-source Smartisan Notes clone: Docker private deployment, skill invocation, dsh plugin support and one-click WeChat-format export. (✅ active)
-- [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) ⭐86 — Find the right DSH plugin in 30 seconds: what problem each plugin solves, who it is for and where to start. (✅ active)
-- [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) ⭐47 — Curated list of DeepSeek Harness plugins. (✅ active)
-- [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) ⭐47 — Meticulously curated list of plugins, extensions, tools and development resources for DSH. (✅ active)
-- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) ⭐43 — Plugin ecosystem for DSH: 700+ plugins registered only through extension seams, without modifying the agent-loop skeleton. (✅ active)
-- [plugin-registry](https://github.com/vlln/plugin-registry) ⭐31 — DSH plugin ecosystem infrastructure: thin console to manage official repository plugins (0 patch) plus the make-dsh-plugin skill. (✅ active)
-- [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) ⭐30 — Curated list of plugins, skills, MCP servers, patch/profile layers, orchestrators and UIs for DeepSeek Harness. (✅ active)
-- [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) ⭐29 — Ultimate guide: quick start, resources, curated plugins and practical tools. (✅ active)
-- [oh-my-dsh](https://github.com/like-study1/Oh-My-DSH) ⭐21 — 🐳 DeepSeek Harness 插件聚合社区 — 自动同步 dsh-plugin 生态 · 精选目录 · 每 8 小时自动维护 | Oh-My-DSH: a community-maintained catalog of DeepSeek Harness plugins, auto-synced from the dsh-plugin topic (✅ active)
-- [deepseek-plugin-store](https://github.com/Ericwong5021/deepseek-plugin-store) ⭐12 — DeepSeek Harness 独立社区插件商店：发现、安装并提交经过验证的插件、工具与扩展。 | Independent community plugin directory. (✅ active)
-- [dsh-suite](https://github.com/whyihaveyou/dsh-suite) ⭐11 — Living DSH plugin directory (785+ plugins, refreshed hourly) with daily compatibility CI, a bilingual catalog site and an in-app plugin store. (✅ active)
-- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) ⭐9 — Curated navigation of community meme plugins (skins, desktop pets, mini-games), bilingual. (✅ active)
-- [awesome-dsh-plugins (white0dew)](https://github.com/white0dew/awesome-dsh-plugins) ⭐7 — Public GitHub directory for DSH plugins with install commands. (✅ active)
-- [awesome-deepseek-harness (jiji262)](https://github.com/jiji262/awesome-deepseek-harness) ⭐6 — Curated DeepSeek Harness resources. (✅ active)
-- [awesome-dsh-plugin (billLiao)](https://github.com/billLiao/awesome-dsh-plugin) ⭐5 — Curated list of plugins for DeepSeek Harness. (✅ active)
-- [awesome-dsh-plugins (kejixiaoliang)](https://github.com/kejixiaoliang/awesome-dsh-plugins) ⭐5 — Curated DSH plugin catalog: 14 categories, 280+ community plugins covering MCP/Skill/TUI/multi-agent/context memory/UI skins. (✅ active)
-- [dsh-plugin-marketplace](https://github.com/YELEBAI/dsh-plugin-marketplace) ⭐4 — Verified plugin marketplace and autonomous registry for DeepSeek Harness (✅ active)
-- [dsh-plugins](https://github.com/HackSing/dsh-plugins) ⭐4 — A bilingual, continuously maintained directory of plugins for DeepSeek Harness (DSH). (✅ active)
-- [zat-dsh-engine](https://github.com/mishibeikejie/zat-dsh-engine) ⭐4 — Visual plugin marketplace for DeepSeek Harness — browse, search and install community plugins (✅ active)
-- [dsh-market](https://github.com/2BingLing/dsh-market) ⭐3 — DeepSeek Harness 插件市场 · 持续收录 500+ DSH 插件：中文搜索 + 实用五维评分 + 一键安装。Web 版与 DSH 侧边栏插件双形态。Plugin marketplace for DeepSeek Harness: 500+ plugins, Chinese search, 5-dim scoring, one-click install. (✅ active)
+- [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent) ⭐5,853 — Official curated guides for integrating DeepSeek models into agent/coding-assistant tools (AstrBot, Cherry Studio, Claude Code, Codex, DeepSeek-TUI, Reasonix and more). (✅ active)
+- [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐2,516 — Large curated list of installable DSH plugins (bilingual). (✅ active)
+- [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐942 — Radar index repo: auto-scanning all discovered dsh plugin candidates with an evidence-based compatibility matrix. (✅ active)
+- [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) ⭐465 — Curated DSH ecosystem directory: plugins, tools and infrastructure from dsh-external/hub and the public dsh-plugin topic. (✅ active)
+- [notes (zhaoolee)](https://github.com/zhaoolee/notes) ⭐142 — Open-source Smartisan Notes clone: Docker private deployment, skill invocation, dsh plugin support and one-click WeChat-format export. (✅ active)
+- [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) ⭐139 — Find the right DSH plugin in 30 seconds: what problem each plugin solves, who it is for and where to start. (✅ active)
+- [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) ⭐62 — Ultimate guide: quick start, resources, curated plugins and practical tools. (✅ active)
+- [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) ⭐62 — Meticulously curated list of plugins, extensions, tools and development resources for DSH. (✅ active)
+- [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) ⭐61 — Curated list of DeepSeek Harness plugins. (✅ active)
+- [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) ⭐47 — Curated list of plugins, skills, MCP servers, patch/profile layers, orchestrators and UIs for DeepSeek Harness. (✅ active)
+- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) ⭐47 — Plugin ecosystem for DSH: 700+ plugins registered only through extension seams, without modifying the agent-loop skeleton. (✅ active)
+- [plugin-registry](https://github.com/vlln/plugin-registry) ⭐40 — DSH plugin ecosystem infrastructure: thin console to manage official repository plugins (0 patch) plus the make-dsh-plugin skill. (✅ active)
+- [oh-my-dsh](https://github.com/like-study1/Oh-My-DSH) ⭐31 — 🐳 DeepSeek Harness 插件聚合社区 — 自动同步 dsh-plugin 生态 · 精选目录 · 每 8 小时自动维护 | Oh-My-DSH: a community-maintained catalog of DeepSeek Harness plugins, auto-synced from the dsh-plugin topic (✅ active)
+- [zat-dsh-engine](https://github.com/mishibeikejie/zat-dsh-engine) ⭐29 — Visual plugin marketplace for DeepSeek Harness — browse, search and install community plugins (✅ active)
+- [awesome-dsh-plugin](https://github.com/beancookie/awesome-dsh-plugin) ⭐25 — Awesome DeepSeek Harness (DSH) Plugin (✅ active)
+- [dsh-suite](https://github.com/whyihaveyou/dsh-suite) ⭐23 — Living DSH plugin directory (785+ plugins, refreshed hourly) with daily compatibility CI, a bilingual catalog site and an in-app plugin store. (✅ active)
+- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) ⭐20 — Curated navigation of community meme plugins (skins, desktop pets, mini-games), bilingual. (✅ active)
+- [dsh-plugin-marketplace](https://github.com/YELEBAI/dsh-plugin-marketplace) ⭐17 — Verified plugin marketplace and autonomous registry for DeepSeek Harness (✅ active)
+- [dsh-plugin-hub](https://github.com/cclank/dsh-plugin-hub) ⭐15 — DeepSeek Harness community plugin registry with evidence-based screening (✅ active)
+- [deepseek-plugin-store](https://github.com/Ericwong5021/deepseek-plugin-store) ⭐13 — DeepSeek Harness 独立社区插件商店：发现、安装并提交经过验证的插件、工具与扩展。 | Independent community plugin directory. (✅ active)
+- [dsh-plugin-marketplace](https://github.com/AwesomeHou/dsh-plugin-marketplace) ⭐13 — Plugin marketplace for DeepSeek Harness — live-syncs the GitHub dsh-plugin topic (1800+ repos) into a searchable, paginated settings tab with one-click install and agent tools (market_search / market_install). (✅ active)
+- [awesome-dsh-plugins (kejixiaoliang)](https://github.com/kejixiaoliang/awesome-dsh-plugins) ⭐12 — Curated DSH plugin catalog: 14 categories, 280+ community plugins covering MCP/Skill/TUI/multi-agent/context memory/UI skins. (✅ active)
+- [dsh-market](https://github.com/2BingLing/dsh-market) ⭐11 — DeepSeek Harness 插件市场 · 持续收录 500+ DSH 插件：中文搜索 + 实用五维评分 + 一键安装。Web 版与 DSH 侧边栏插件双形态。Plugin marketplace for DeepSeek Harness: 500+ plugins, Chinese search, 5-dim scoring, one-click install. (✅ active)
+- [awesome-deepseek-harness (jiji262)](https://github.com/jiji262/awesome-deepseek-harness) ⭐10 — Curated DeepSeek Harness resources. (✅ active)
+- [awesome-deepseek-harness-plugins](https://github.com/imsai-sh/awesome-deepseek-harness-plugins) ⭐9 — Curated community plugin directory and live marketplace for DeepSeek Harness. (✅ active)
+- [awesome-dsh-plugins (white0dew)](https://github.com/white0dew/awesome-dsh-plugins) ⭐9 — Public GitHub directory for DSH plugins with install commands. (✅ active)
+- [awesome-dsh-plugin (billLiao)](https://github.com/billLiao/awesome-dsh-plugin) ⭐7 — Curated list of plugins for DeepSeek Harness. (✅ active)
+- [dsh-plugins](https://github.com/HackSing/dsh-plugins) ⭐5 — A bilingual, continuously maintained directory of plugins for DeepSeek Harness (DSH). (✅ active)
+- [awesome-deepseek-harness-plugins](https://github.com/walkinglabs/awesome-deepseek-harness-plugins) ⭐4 — A curated, bilingual list of verified plugins, tools, design workflows, and learning resources for DeepSeek Harness (DSH). (✅ active)
+- [dsh-marketplace](https://github.com/ouyangyipeng/dsh-marketplace) ⭐3 — A safe, live plugin marketplace for DeepSeek Harness (✅ active)
+- [dsh-plugin-market](https://github.com/chnjames/dsh-plugin-market) ⭐3 — DSH 插件市场 — DeepSeek Harness 设置内一键安装社区插件，并提供公开目录站（浏览 / 复制安装命令） (✅ active)
+- [dsh-plugin-market](https://github.com/TheYoungChen/dsh-plugin-market) ⭐3 — DeepSeek Harness plugin market - browse, search & install dsh-plugin topic plugins (dsh 插件市场：浏览/搜索/安装插件) (✅ active)
 - [dsh-plugins](https://github.com/lwmxiaobei/dsh-plugins) ⭐3 — DeepSeek Harness 社区插件目录，自动汇总并基础校验 GitHub 插件，支持搜索、筛选、双语详情与最新版本安装命令复制。Community directory for DeepSeek Harness plugins with automated discovery, basic validation, search, filters, bilingual details, and latest version install commands. (✅ active)
-- [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent)  — Official curated guides for integrating DeepSeek models into agent/coding-assistant tools (AstrBot, Cherry Studio, Claude Code, Codex, DeepSeek-TUI, Reasonix and more). (✅ active)
+- [sandbase-skills](https://github.com/sandbaseai/sandbase-skills) ⭐3 — 88 installable open-source Agent Skills for research, social intelligence, marketing, and business workflows—compatible with Codex, Claude Code, Cursor, Gemini CLI, and DeepSeek Harness. (✅ active)
 
 ### Related Agent Harnesses
 
@@ -643,24 +743,24 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [DeerFlow](https://github.com/bytedance/deer-flow) | ⭐80,001 | Open-source long-horizon SuperAgent harness by ByteDance: skills, memory, sandboxes, subagents, tools and a message gateway. | ✅ active |
-| 2 | [Cordis](https://github.com/cordiverse/cordis) | ⭐3,182 | Meta-Framework of Spatiotemporal Composability — the plugin runtime DeepSeek Harness is built on. | ✅ active |
-| 3 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐573 | Open-source CMA-compatible agent runtime for any model: MCP tools, sandboxed sessions, audit, replay. | ✅ active |
-| 4 | [mnemon](https://github.com/mnemon-dev/mnemon) | ⭐430 | LLM-supervised persistent memory for AI agents: graph-based recall and cross-session knowledge in a single binary. | ✅ active |
-| 5 | [claude-paper](https://github.com/alaliqing/claude-paper) | ⭐294 | Cross-agent research paper toolkit for Claude Code, Codex, OpenCode and DeepSeek Harness: quick summaries and deep dives. | ✅ active |
-| 6 | [Axern](https://github.com/cofy-x/axern) | ⭐272 | Open-source sandboxes for AI agents: untrusted code execution and durable services. | ✅ active |
-| 7 | [open-managed-agents](https://github.com/openma-ai/open-managed-agents) | ⭐235 | Open-source Claude Managed Agents API implementation and self-hosted Claude Tag-style agent runtime. | ✅ active |
+| 1 | [DeerFlow](https://github.com/bytedance/deer-flow) | ⭐80,038 | Open-source long-horizon SuperAgent harness by ByteDance: skills, memory, sandboxes, subagents, tools and a message gateway. | ✅ active |
+| 2 | [Cordis](https://github.com/cordiverse/cordis) | ⭐3,780 | Meta-Framework of Spatiotemporal Composability — the plugin runtime DeepSeek Harness is built on. | ✅ active |
+| 3 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐586 | Open-source CMA-compatible agent runtime for any model: MCP tools, sandboxed sessions, audit, replay. | ✅ active |
+| 4 | [mnemon](https://github.com/mnemon-dev/mnemon) | ⭐449 | LLM-supervised persistent memory for AI agents: graph-based recall and cross-session knowledge in a single binary. | ✅ active |
+| 5 | [claude-paper](https://github.com/alaliqing/claude-paper) | ⭐301 | Cross-agent research paper toolkit for Claude Code, Codex, OpenCode and DeepSeek Harness: quick summaries and deep dives. | ✅ active |
+| 6 | [open-managed-agents](https://github.com/openma-ai/open-managed-agents) | ⭐236 | Open-source Claude Managed Agents API implementation and self-hosted Claude Tag-style agent runtime. | ✅ active |
+| 7 | [Axern](https://github.com/cofy-x/axern) | ⭐167 | Open-source sandboxes for AI agents: untrusted code execution and durable services. | ✅ active |
 | 8 | [deepseek-auto-evolving-harness](https://github.com/liuchen6667/deepseek-auto-evolving-harness) | ⭐28 | Auto-evolving LLM agent harness: benchmark-driven evolution via Claude Code and a self_evolution.md guide. | ✅ active |
 
 #### Complete list (8)
 
-- [DeerFlow](https://github.com/bytedance/deer-flow) ⭐80,001 — Open-source long-horizon SuperAgent harness by ByteDance: skills, memory, sandboxes, subagents, tools and a message gateway. (✅ active)
-- [Cordis](https://github.com/cordiverse/cordis) ⭐3,182 — Meta-Framework of Spatiotemporal Composability — the plugin runtime DeepSeek Harness is built on. (✅ active)
-- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) ⭐573 — Open-source CMA-compatible agent runtime for any model: MCP tools, sandboxed sessions, audit, replay. (✅ active)
-- [mnemon](https://github.com/mnemon-dev/mnemon) ⭐430 — LLM-supervised persistent memory for AI agents: graph-based recall and cross-session knowledge in a single binary. (✅ active)
-- [claude-paper](https://github.com/alaliqing/claude-paper) ⭐294 — Cross-agent research paper toolkit for Claude Code, Codex, OpenCode and DeepSeek Harness: quick summaries and deep dives. (✅ active)
-- [Axern](https://github.com/cofy-x/axern) ⭐272 — Open-source sandboxes for AI agents: untrusted code execution and durable services. (✅ active)
-- [open-managed-agents](https://github.com/openma-ai/open-managed-agents) ⭐235 — Open-source Claude Managed Agents API implementation and self-hosted Claude Tag-style agent runtime. (✅ active)
+- [DeerFlow](https://github.com/bytedance/deer-flow) ⭐80,038 — Open-source long-horizon SuperAgent harness by ByteDance: skills, memory, sandboxes, subagents, tools and a message gateway. (✅ active)
+- [Cordis](https://github.com/cordiverse/cordis) ⭐3,780 — Meta-Framework of Spatiotemporal Composability — the plugin runtime DeepSeek Harness is built on. (✅ active)
+- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) ⭐586 — Open-source CMA-compatible agent runtime for any model: MCP tools, sandboxed sessions, audit, replay. (✅ active)
+- [mnemon](https://github.com/mnemon-dev/mnemon) ⭐449 — LLM-supervised persistent memory for AI agents: graph-based recall and cross-session knowledge in a single binary. (✅ active)
+- [claude-paper](https://github.com/alaliqing/claude-paper) ⭐301 — Cross-agent research paper toolkit for Claude Code, Codex, OpenCode and DeepSeek Harness: quick summaries and deep dives. (✅ active)
+- [open-managed-agents](https://github.com/openma-ai/open-managed-agents) ⭐236 — Open-source Claude Managed Agents API implementation and self-hosted Claude Tag-style agent runtime. (✅ active)
+- [Axern](https://github.com/cofy-x/axern) ⭐167 — Open-source sandboxes for AI agents: untrusted code execution and durable services. (✅ active)
 - [deepseek-auto-evolving-harness](https://github.com/liuchen6667/deepseek-auto-evolving-harness) ⭐28 — Auto-evolving LLM agent harness: benchmark-driven evolution via Claude Code and a self_evolution.md guide. (✅ active)
 <!-- AUTO:resources:END -->
 
@@ -766,157 +866,213 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [petdex](https://github.com/crafter-station/petdex) | ⭐3,777 | A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. | ✅ active |
-| 2 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | ⭐1,697 | Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. | ✅ active |
-| 3 | [modlens](https://github.com/liustack/modlens) | ⭐1,158 | The first vision plugin for DeepSeek Harness and the vision bridge for every text-only coding agent: paste an image and it works. | ✅ active |
-| 4 | [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | ⭐684 | Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. | ✅ active |
-| 5 | [museai](https://github.com/yejiming/MuseAI) | ⭐538 | 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） | ✅ active |
-| 6 | [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | ⭐506 | Whale-girl skin series for DSH Web (CC BY-NC-SA 4.0). | ✅ active |
-| 7 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐309 | Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. | ✅ active |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐302 | Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. | ✅ active |
-| 9 | [whale-girl](https://github.com/vlln/whale-girl) | ⭐118 | Desktop pet plugin (QQ-pet style) floating at the bottom-right of the DSH Web GUI: draggable, feedable and playable. | ✅ active |
-| 10 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | ⭐116 | Codex-style @file mentions inside the DSH composer: search workspace files and attach their contents to prompts. | ✅ active |
+| 1 | [petdex](https://github.com/crafter-station/petdex) | ⭐3,825 | A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. | ✅ active |
+| 2 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | ⭐2,484 | Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. | ✅ active |
+| 3 | [dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) | ⭐1,831 | Two-phase DeepSeek Harness preset: Minimal-aligned bootstrap, then full Standard tools (Project2 98/99) | ✅ active |
+| 4 | [modlens](https://github.com/liustack/modlens) | ⭐1,736 | The first vision plugin for DeepSeek Harness and the vision bridge for every text-only coding agent: paste an image and it works. | ✅ active |
+| 5 | [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | ⭐1,065 | Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. | ✅ active |
+| 6 | [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | ⭐834 | Whale-girl skin series for DSH Web (CC BY-NC-SA 4.0). | ✅ active |
+| 7 | [museai](https://github.com/yejiming/MuseAI) | ⭐556 | 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） | ✅ active |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐409 | Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. | ✅ active |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐396 | Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. | ✅ active |
+| 10 | [dsh-market](https://github.com/dsh-market/dsh-market) | ⭐218 | Visual plugin market inside DeepSeek Harness: browse, search and one-click install. | ✅ active |
 
-#### Complete list (138)
+#### Complete list (194)
 
-- [petdex](https://github.com/crafter-station/petdex) ⭐3,777 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. (✅ active)
-- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐1,697 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
-- [modlens](https://github.com/liustack/modlens) ⭐1,158 — The first vision plugin for DeepSeek Harness and the vision bridge for every text-only coding agent: paste an image and it works. (✅ active)
-- [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) ⭐684 — Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. (✅ active)
-- [museai](https://github.com/yejiming/MuseAI) ⭐538 — 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） (✅ active)
-- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) ⭐506 — Whale-girl skin series for DSH Web (CC BY-NC-SA 4.0). (✅ active)
-- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) ⭐309 — Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. (✅ active)
-- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) ⭐302 — Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. (✅ active)
-- [whale-girl](https://github.com/vlln/whale-girl) ⭐118 — Desktop pet plugin (QQ-pet style) floating at the bottom-right of the DSH Web GUI: draggable, feedable and playable. (✅ active)
-- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) ⭐116 — Codex-style @file mentions inside the DSH composer: search workspace files and attach their contents to prompts. (✅ active)
-- [modsearch](https://github.com/liustack/modsearch) ⭐85 — Web plugin for DSH and the search bridge for every model without native web access. (✅ active)
-- [dsh-browser](https://github.com/Lum1104/dsh-browser) ⭐78 — Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required. (✅ active)
-- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐74 — Interactive HTML UI rendered directly in conversation with streaming preview and sandbox rendering. (✅ active)
-- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐71 — Generative UI inside conversations: layouts, charts, forms, quizzes, Mermaid and interactive events rendered inline. (✅ active)
-- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐67 — Plugin discovery utility for the DSH ecosystem. (✅ active)
-- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐47 — Cross-session long-term memory + background self-evolution: five-track memory, git-branch awareness, in-turn self-review and skill evolution. (✅ active)
-- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) ⭐39 — Select text in DSH Web, annotate it and send the annotation with your message; replies cross-reference each annotation. (✅ active)
-- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) ⭐39 — Open DSH workspace directories/files directly in VS Code from the web GUI. (✅ active)
-- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) ⭐37 — Desktop notifications for turn completions with per-outcome controls and include/exclude keyword filters. (✅ active)
-- [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐35 — Rewind conversation and workspace state, powered by a persistent change ledger. (✅ active)
-- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) ⭐29 — Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). (✅ active)
-- [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) ⭐28 — Browse, install and update every GitHub topic:dsh-plugin plugin from the DSH Web GUI. (✅ active)
-- [ui-status-label](https://github.com/alingalingling/ui-status-label) ⭐28 — Customize the whale's 'Deep diving' status label into anything you want. (✅ active)
-- [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) ⭐27 — Hand-drawn pixel whale companion in the session title bar: blinks, wags its tail, spouts water when a turn completes. (✅ active)
-- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) ⭐22 — Create and manage sandboxed JavaScript tools for DSH with a Monaco editor and model-driven tool lists. (✅ active)
-- [dskin](https://github.com/dancingmemory/dskin) ⭐22 — Cartoon pixel skin plugin for DSH Web GUI: pixel pets that walk, blink and jump over the original interface. (✅ active)
-- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐20 — Import conversation history from Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix and OpenCode into resumable DSH sessions. (✅ active)
-- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) ⭐18 — Skin system with 21 built-in themes plus one-image custom skin generation, contrast-validated at build time. (✅ active)
-- [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) ⭐18 — 为 DeepSeek Harness 提供电脑控制插件：新鲜 Accessibility 观测、过期状态拒绝、作用域权限与安全输入（目前支持macos）｜Accessibility-first macOS Computer Use bundle for DSH with fresh observations, stale-state rejection, scoped permissions, and safe input. (✅ active)
-- [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) ⭐18 — Compact side panel with a file browser, terminal and Git review. (✅ active)
-- [anysearch-dsh](https://github.com/anysearch-team/anysearch-dsh) ⭐17 — AnySearch web search provider and advanced search tools for DeepSeek Harness. (✅ active)
-- [deepseek-harness-snowsalt](https://github.com/KYZHXL/deepseek-harness-snowsalt) ⭐17 — Snow-salt themed skin for DeepSeek Harness. (✅ active)
+- [petdex](https://github.com/crafter-station/petdex) ⭐3,825 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. (✅ active)
+- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐2,484 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
+- [dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) ⭐1,831 — Two-phase DeepSeek Harness preset: Minimal-aligned bootstrap, then full Standard tools (Project2 98/99) (✅ active)
+- [modlens](https://github.com/liustack/modlens) ⭐1,736 — The first vision plugin for DeepSeek Harness and the vision bridge for every text-only coding agent: paste an image and it works. (✅ active)
+- [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) ⭐1,065 — Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. (✅ active)
+- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) ⭐834 — Whale-girl skin series for DSH Web (CC BY-NC-SA 4.0). (✅ active)
+- [museai](https://github.com/yejiming/MuseAI) ⭐556 — 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） (✅ active)
+- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) ⭐409 — Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. (✅ active)
+- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) ⭐396 — Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. (✅ active)
+- [dsh-market](https://github.com/dsh-market/dsh-market) ⭐218 — Visual plugin market inside DeepSeek Harness: browse, search and one-click install. (✅ active)
+- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) ⭐198 — Codex-style @file mentions inside the DSH composer: search workspace files and attach their contents to prompts. (✅ active)
+- [whale-girl](https://github.com/vlln/whale-girl) ⭐160 — Desktop pet plugin (QQ-pet style) floating at the bottom-right of the DSH Web GUI: draggable, feedable and playable. (✅ active)
+- [dsh-browser](https://github.com/Lum1104/dsh-browser) ⭐140 — Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required. (✅ active)
+- [v4-flash-godmode-opencode-go](https://github.com/SheberDavid/v4-flash-godmode-opencode-go) ⭐127 — V4 Flash 神模式 (opencode-go)：让 opencode-go 的 DeepSeek V4 Flash 从鬼模式切换到神模式的 dsh agent preset (✅ active)
+- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) ⭐111 — Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). (✅ active)
+- [modsearch](https://github.com/liustack/modsearch) ⭐104 — Web plugin for DSH and the search bridge for every model without native web access. (✅ active)
+- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐100 — Interactive HTML UI rendered directly in conversation with streaming preview and sandbox rendering. (✅ active)
+- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐99 — Generative UI inside conversations: layouts, charts, forms, quizzes, Mermaid and interactive events rendered inline. (✅ active)
+- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐89 — Plugin discovery utility for the DSH ecosystem. (✅ active)
+- [dsh-gitbash-preset](https://github.com/liceses/dsh-gitbash-preset) ⭐86 — DeepSeek Harness 插件：一键安装「极简模式 (Git Bash)」agent preset —— 把 DSH 自带极简模式中的 bash 调用映射到 Git for Windows 的 bash（MSYS），让 Windows 上的极简模式真正可用。 (✅ active)
+- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐82 — Cross-session long-term memory + background self-evolution: five-track memory, git-branch awareness, in-turn self-review and skill evolution. (✅ active)
+- [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) ⭐64 — Browse, install and update every GitHub topic:dsh-plugin plugin from the DSH Web GUI. (✅ active)
+- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) ⭐50 — Select text in DSH Web, annotate it and send the annotation with your message; replies cross-reference each annotation. (✅ active)
+- [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐50 — Rewind conversation and workspace state, powered by a persistent change ledger. (✅ active)
+- [dsh-auto-mode](https://github.com/NanmiCoder/dsh-auto-mode) ⭐48 — Safe automatic permissions for DeepSeek Harness. (✅ active)
+- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) ⭐47 — Desktop notifications for turn completions with per-outcome controls and include/exclude keyword filters. (✅ active)
+- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) ⭐42 — Open DSH workspace directories/files directly in VS Code from the web GUI. (✅ active)
+- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) ⭐42 — Community plugin market in the Web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall to a profile. (✅ active)
+- [dsh-context](https://github.com/bowenliang123/dsh-context) ⭐40 — A DeepSeek Harness plugin for  Context insight dashboard — showing what the model's context window is made of and how it evolves. (✅ active)
+- [dsh-pet](https://github.com/PC2005-cloud/dsh-pet) ⭐38 — DeepSeek Harness 桌面宠物插件 + 完整素材生成链：AI 提示词 → 绿幕视频 → 透明动画 → 可安装插件，从零到宠物全流程可复现 (✅ active)
+- [dsh-plugins-store](https://github.com/ZASENJC/dsh-plugins-store) ⭐38 — Static directory site that automatically collects and categorizes GitHub dsh-plugin topic projects. (✅ active)
+- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) ⭐34 — Skin system with 21 built-in themes plus one-image custom skin generation, contrast-validated at build time. (✅ active)
+- [dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) ⭐33 — Manage plugins from the Web UI: view, live enable/disable, install/uninstall, env management and plugin market. (✅ active)
+- [ui-status-label](https://github.com/alingalingling/ui-status-label) ⭐32 — Customize the whale's 'Deep diving' status label into anything you want. (✅ active)
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) ⭐31 — DeepSeek Harness 会话费用统计插件:本会话费用、当日费用、历史记录与官方价格同步 (✅ active)
+- [anysearch-dsh](https://github.com/anysearch-team/anysearch-dsh) ⭐30 — AnySearch web search provider and advanced search tools for DeepSeek Harness. (✅ active)
+- [dsh-kun-like-pet](https://github.com/liyupi/dsh-kun-like-pet) ⭐30 — Kun Like 桌宠 —— DeepSeek Harness 桌面宠物插件：右下角小坤宠随 Agent 工作状态切换 9 种动作，任务完成播放「你干嘛~哎哟」 (✅ active)
+- [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) ⭐30 — Hand-drawn pixel whale companion in the session title bar: blinks, wags its tail, spouts water when a turn completes. (✅ active)
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐29 — Import conversation history from Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix and OpenCode into resumable DSH sessions. (✅ active)
+- [dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) ⭐29 — Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the DeepSeek Harness Web GUI (dsh web). (✅ active)
+- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) ⭐26 — Three-tier local memory: runtime hot memory, project documents and long-term memory spaces, with supervised writeback. (✅ active)
+- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) ⭐24 — Create and manage sandboxed JavaScript tools for DSH with a Monaco editor and model-driven tool lists. (✅ active)
+- [dsh-transparent-ui-plugin](https://github.com/WYH66666666/DSH-Transparent-UI-Plugin) ⭐24 — 是一层高自由度的玻璃质感主题，套在 DeepSeek Harness 网页端。顶栏、侧边栏、输入框、统计行、轨迹视图都成了磨砂玻璃片。玻璃模糊度、磨砂度、背景（流体或自定义壁纸，壁纸还能单独调模糊和磨砂）全都能在设置卡片里自由调节。关掉开关就回到原生界面，不改 DSH 任何一行源码。 (✅ active)
+- [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) ⭐23 — Agent-assisted plugin discovery: search the live GitHub dsh-plugin topic from inside DSH. (✅ active)
+- [dsh-navbar](https://github.com/vlln/dsh-navbar) ⭐23 — DSH 插件：对话节点导航条（右缘节点串快速跳转 user 消息）。官方 bundle 插件，dsh plugin --profile web add 安装 (✅ active)
+- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) ⭐23 — Plugin management panel: enable/disable installed plugins plus a GitHub dsh-plugin marketplace with one-click install. (✅ active)
+- [dsh-vision (william-jin-cmu)](https://github.com/william-jin-cmu/dsh-vision) ⭐23 — Vision bridge: view_image tool over any OpenAI-compatible VLM, defaulting to Zhipu's free tier. (✅ active)
+- [deepseek-harness-snowsalt](https://github.com/KYZHXL/deepseek-harness-snowsalt) ⭐21 — Snow-salt themed skin for DeepSeek Harness. (✅ active)
+- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) ⭐21 — Branch-based message editing, reroll, retry and version timeline. (✅ active)
+- [dskin](https://github.com/dancingmemory/dskin) ⭐21 — Cartoon pixel skin plugin for DSH Web GUI: pixel pets that walk, blink and jump over the original interface. (✅ active)
+- [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) ⭐20 — 为 DeepSeek Harness 提供电脑控制插件：新鲜 Accessibility 观测、过期状态拒绝、作用域权限与安全输入（目前支持macos）｜Accessibility-first macOS Computer Use bundle for DSH with fresh observations, stale-state rejection, scoped permissions, and safe input. (✅ active)
+- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) ⭐20 — Expose MinerU document parsing to the model: PDF/images/DOCX/PPTX/XLSX to structured Markdown/JSON. (✅ active)
+- [dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) ⭐20 — Steam Workshop-style plugin browser for the DSH Web UI: zero-server, GitHub-powered search and one-click install. (✅ active)
+- [dsh-share](https://github.com/hellodigua/dsh-share) ⭐19 — One-click conversation sharing for DSH. (✅ active)
+- [dsh-minigames](https://github.com/lhh010/dsh-minigames) ⭐18 — DSH Web UI 右侧小游戏面板：18 款离线小游戏（恐龙跳一跳 / 俄罗斯方块 / 坦克大战 / 扫雷 / 2048 / 数独 / 吃豆人 / 跟枪练习等），可扩展游戏注册表，等待模型回复或修 bug 时的摸鱼神器 (✅ active)
+- [dsh-plugin](https://github.com/Tabbit-Browser/dsh-plugin) ⭐18 — Tabbit Broser plugins for Deepseek Harness (✅ active)
+- [dsh-emoji](https://github.com/hellodigua/dsh-emoji) ⭐17 — Let AI replies add custom emoji reactions. (✅ active)
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) ⭐17 — Plugin health checks: manifest protocol, patch format, build pitfalls and hub listing status, zero-dependency read-only. (✅ active)
-- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) ⭐16 — Branch-based message editing, reroll, retry and version timeline. (✅ active)
-- [dsh-share](https://github.com/hellodigua/dsh-share) ⭐16 — One-click conversation sharing for DSH. (✅ active)
-- [dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) ⭐16 — Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the DeepSeek Harness Web GUI (dsh web). (✅ active)
-- [dsh-vision (william-jin-cmu)](https://github.com/william-jin-cmu/dsh-vision) ⭐16 — Vision bridge: view_image tool over any OpenAI-compatible VLM, defaulting to Zhipu's free tier. (✅ active)
-- [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) ⭐15 — Zero-dependency tool suite: calculator, CSV, diff, encoding, JSON, Markdown, regex and time utilities. (✅ active)
-- [dsh-group-photo](https://github.com/SenmuuuuW/dsh-group-photo) ⭐14 — DSH 内测收官合影墙：GitHub OAuth 零权限登录 + 冻结白名单校验的拍立得合影站（含 DSH Skill 包装） (✅ active)
-- [dsh-navbar](https://github.com/vlln/dsh-navbar) ⭐14 — DSH 插件：对话节点导航条（右缘节点串快速跳转 user 消息）。官方 bundle 插件，dsh plugin --profile web add 安装 (✅ active)
-- [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) ⭐13 — DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。 (✅ active)
-- [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) ⭐12 — 为 dsh 提供新的「聚焦会话」精简会话视图，更轻松易于阅读，只关注最终产出结果。 (✅ active)
-- [dsh-kun-like-pet](https://github.com/liyupi/dsh-kun-like-pet) ⭐12 — Kun Like 桌宠 —— DeepSeek Harness 桌面宠物插件：右下角小坤宠随 Agent 工作状态切换 9 种动作，任务完成播放「你干嘛~哎哟」 (✅ active)
-- [dsh-market](https://github.com/dsh-market/dsh-market) ⭐12 — Visual plugin market inside DeepSeek Harness: browse, search and one-click install. (✅ active)
-- [dsh-minigames](https://github.com/lhh010/dsh-minigames) ⭐12 — DSH Web UI 右侧小游戏面板：18 款离线小游戏（恐龙跳一跳 / 俄罗斯方块 / 坦克大战 / 扫雷 / 2048 / 数独 / 吃豆人 / 跟枪练习等），可扩展游戏注册表，等待模型回复或修 bug 时的摸鱼神器 (✅ active)
-- [dsh-plugins-store](https://github.com/ZASENJC/dsh-plugins-store) ⭐12 — Static directory site that automatically collects and categorizes GitHub dsh-plugin topic projects. (✅ active)
-- [ego-browser](https://github.com/Fisfzy/ego-browser) ⭐12 — Bring the ego-lite agent browser (Chromium for AI agents) into DSH with 13 structured tools. (✅ active)
-- [DeepSeek-Harness-Web-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Web-Tools) ⭐11 — Free, keyless web_search and web_fetch for DSH, DuckDuckGo-backed with no signup. (✅ active)
-- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) ⭐11 — DeepSeek account balance and session cost readout for the DeepSeek Harness Web GUI (✅ active)
-- [dsh-emoji](https://github.com/hellodigua/dsh-emoji) ⭐11 — Let AI replies add custom emoji reactions. (✅ active)
-- [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) ⭐11 — Agent-assisted plugin discovery: search the live GitHub dsh-plugin topic from inside DSH. (✅ active)
-- [dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) ⭐11 — Play Gomoku with AI inside DSH, or let two AIs battle to compare models. (✅ active)
-- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) ⭐11 — Three-tier local memory: runtime hot memory, project documents and long-term memory spaces, with supervised writeback. (✅ active)
+- [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) ⭐17 — Zero-dependency tool suite: calculator, CSV, diff, encoding, JSON, Markdown, regex and time utilities. (✅ active)
+- [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) ⭐16 — 为 dsh 提供新的「聚焦会话」精简会话视图，更轻松易于阅读，只关注最终产出结果。 (✅ active)
+- [dsh-group-photo](https://github.com/SenmuuuuW/dsh-group-photo) ⭐16 — DSH 内测收官合影墙：GitHub OAuth 零权限登录 + 冻结白名单校验的拍立得合影站（含 DSH Skill 包装） (✅ active)
+- [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) ⭐16 — Compact side panel with a file browser, terminal and Git review. (💤 inactive)
+- [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) ⭐16 — DSH WebUI sticker plugin for bidirectional user and agent reactions (✅ active)
+- [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) ⭐15 — DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。 (✅ active)
+- [dsh-balance](https://github.com/crazywoola/dsh-balance) ⭐14 — DeepSeek Harness balance plugin for the Settings page. (✅ active)
+- [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) ⭐14 — Git-style milestone timeline rail: hover for metadata, click to jump to any message. (✅ active)
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) ⭐13 — DeepSeek account balance and session cost readout for the DeepSeek Harness Web GUI (✅ active)
+- [dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) ⭐13 — Play Gomoku with AI inside DSH, or let two AIs battle to compare models. (✅ active)
+- [ego-browser](https://github.com/Fisfzy/ego-browser) ⭐13 — Bring the ego-lite agent browser (Chromium for AI agents) into DSH with 13 structured tools. (✅ active)
+- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) ⭐12 — Model-driven context compression (Active Context Pruning): the model decides when and what to compress. (✅ active)
+- [DeepSeek-Harness-Web-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Web-Tools) ⭐12 — Free, keyless web_search and web_fetch for DSH, DuckDuckGo-backed with no signup. (✅ active)
+- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) ⭐12 — PiUI-style Web diff viewer replacing the default diff view. (✅ active)
+- [dsh-plugin-pet-rs](https://github.com/HuanLinOTO/dsh-plugin-pet-rs) ⭐12 — Rust desktop pet: 5-state whale with dual SSE real-time push, transparent always-on-top window and system tray. (✅ active)
+- [dsh-remote](https://github.com/flymysql/dsh-remote) ⭐12 — Remote workspace: connect a host over SSH and operate a remote directory with rw_* tools. (✅ active)
+- [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) ⭐12 — Adds desktop notification reminders to DSH. (✅ active)
+- [dsh-recommend](https://github.com/zp-home/dsh-recommend) ⭐11 — Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data with an open scoring model. (✅ active)
 - [dsh-sdk-platform-rs](https://github.com/kpn-dsh/dsh-sdk-platform-rs) ⭐11 — A Rust SDK to interact with the DSH Platform. This library provides convenient building blocks for services that need to connect to DSH Kafka, fetch tokens for various protocols, manage Prometheus metrics, and more. (✅ active)
-- [dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) ⭐11 — Manage plugins from the Web UI: view, live enable/disable, install/uninstall, env management and plugin market. (✅ active)
-- [dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) ⭐10 — Steam Workshop-style plugin browser for the DSH Web UI: zero-server, GitHub-powered search and one-click install. (✅ active)
-- [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) ⭐10 — DSH 本机安全审计插件：配置/插件来源/会话/网络暴露面，只读脱敏风险报告 (✅ active)
-- [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) ⭐10 — Stock market data plugin (joke: fixes the bug where your account loses money while you code). (✅ active)
-- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) ⭐10 — Community plugin market in the Web GUI: browse the awesome-dsh-plugin.com catalog and install/uninstall to a profile. (✅ active)
-- [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) ⭐9 — Git-style milestone timeline rail: hover for metadata, click to jump to any message. (✅ active)
-- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) ⭐9 — Expose MinerU document parsing to the model: PDF/images/DOCX/PPTX/XLSX to structured Markdown/JSON. (✅ active)
+- [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) ⭐11 — DSH 本机安全审计插件：配置/插件来源/会话/网络暴露面，只读脱敏风险报告 (✅ active)
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) ⭐11 — Codex-style skin switcher plus custom translucent wallpaper with opacity/blur controls. (✅ active)
+- [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) ⭐11 — Stock market data plugin (joke: fixes the bug where your account loses money while you code). (✅ active)
+- [DeepSeek-Harness-Vision-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Vision-Tools) ⭐10 — Vision proxy for chat: give DSH eyes with any text model plus any vision model. (✅ active)
+- [dsh-mneme](https://github.com/modusensus/dsh-mneme) ⭐10 — Local cross-session memory with memory sovereignty: SQLite + human-editable Markdown mirror and background autoDream consolidation. (✅ active)
+- [touhou-hakurei](https://github.com/xiake595/touhou-hakurei) ⭐10 — 灵梦（Reimu）·博丽神社（东方Project）美化版皮肤：神社昼夜实景背景、灵梦立绘、画框侧边栏与输入框、纸白透明界面 — DeepSeek Harness Web GUI skin (✅ active)
+- [DeepSeek-Harness-billing-plugin](https://github.com/WilliamLIiii/DeepSeek-Harness-billing-plugin) ⭐9 — Account balance plus per-model remaining-task estimator with a session cost ledger. (✅ active)
+- [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) ⭐9 — 🐋 DSH 有声桌宠：悬浮桌面的 DeepSeek 小鲸鱼，不打开 DSH 也能实时感知会话状态（需要确认/工作中/完成/空闲/离线），支持音效提醒与零代码定制素材 (✅ active)
+- [dsh-plugin-better-sidebar-plugin-office](https://github.com/HuanLinOTO/dsh-plugin-better-sidebar-plugin-office) ⭐9 — Office-suite preview (.docx/.xlsx/.pptx) for the Better Sidebar, as a standalone slim bundle. (✅ active)
 - [dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) ⭐9 — Frame-level diagnostics for multi-frame zstd session files: torn/corrupted/empty session detection, zero-dependency read-only. (✅ active)
-- [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) ⭐9 — Adds desktop notification reminders to DSH. (✅ active)
 - [deepseek-harness-SupportVisionModel](https://github.com/TryDing-T/deepseek-harness-SupportVisionModel) ⭐8 — Secondary development of deepseek-harness supporting a separately configured vision model for reading images. (✅ active)
-- [DeepSeek-Harness-Vision-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Vision-Tools) ⭐8 — Vision proxy for chat: give DSH eyes with any text model plus any vision model. (✅ active)
-- [dsh-mneme](https://github.com/modusensus/dsh-mneme) ⭐8 — Local cross-session memory with memory sovereignty: SQLite + human-editable Markdown mirror and background autoDream consolidation. (✅ active)
+- [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) ⭐8 — Spreadsheet-style skin for DSH, mimicking Excel. (✅ active)
 - [dsh-paste-input](https://github.com/lhh010/dsh-paste-input) ⭐8 — WebUI file input enhancement: Ctrl+V paste, drag & drop and file picker, copied into the session workspace. (✅ active)
-- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) ⭐7 — Model-driven context compression (Active Context Pruning): the model decides when and what to compress. (✅ active)
-- [DeepSeek-Harness-billing-plugin](https://github.com/WilliamLIiii/DeepSeek-Harness-billing-plugin) ⭐7 — Account balance plus per-model remaining-task estimator with a session cost ledger. (✅ active)
+- [dsh-plugin-ya-workspace-sidebar](https://github.com/HuanLinOTO/dsh-plugin-ya-workspace-sidebar) ⭐8 — DSH Web 工作区侧栏替代，顶部全局最近会话 + Workspace→Session 二级菜单 + 面包屑 | DSH Web workspace sidebar replacement: top global recent sessions + Workspace→Session two-level menu + breadcrumbs (✅ active)
+- [dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) ⭐8 — Replaces the 'Deep diving…' turn-status label with phase-aware typewriter messages. (✅ active)
+- [dsh-undo-plugin](https://github.com/lire1131/dsh-undo-plugin) ⭐8 — DSH plugin: snapshot & rollback your plugin/skin/settings configs. Auto-save on change, undo/redo stack, snapshot manager panel, keyboard shortcuts, plus an offline PowerShell CLI & GUI that work even when DSH won't boot. (✅ active)
+- [dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) ⭐7 — DSH 自动记忆插件:三层记忆(用户级/项目笔记/每日日志)自动注入与检索、每日反思、可视化面板与设置页,支持继承其他 AI 工具的历史记忆。An auto-memory plugin for the DeepSeek Harness Web GUI: three-layer memory (user-level / project notes / daily logs) with automatic injection and retrieval, daily reflections, a visual panel and settings page, and inheritance of memories from other AI tools. (✅ active)
+- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) ⭐7 — Audits what actually enters every model request: token cost of AGENTS.md chains, skill catalogs and tool schemas, with duplicate/conflict detection. (✅ active)
 - [dsh-director-toolkit](https://github.com/lhmd/dsh-director-toolkit) ⭐7 — DSH Director Toolkit is a DeepSeek Harness plugin for 3D artists, technical designers, and creative coders. Paste a half-formed idea, a reference note, or a portfolio caption and get a compact direction pack for Blender, Three.js, Houdini, or C4D. (✅ active)
-- [dsh-plugin-better-sidebar-plugin-office](https://github.com/HuanLinOTO/dsh-plugin-better-sidebar-plugin-office) ⭐7 — Office-suite preview (.docx/.xlsx/.pptx) for the Better Sidebar, as a standalone slim bundle. (✅ active)
-- [dsh-plugin-pet-rs](https://github.com/HuanLinOTO/dsh-plugin-pet-rs) ⭐7 — Rust desktop pet: 5-state whale with dual SSE real-time push, transparent always-on-top window and system tray. (✅ active)
-- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) ⭐6 — Audits what actually enters every model request: token cost of AGENTS.md chains, skill catalogs and tool schemas, with duplicate/conflict detection. (✅ active)
-- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) ⭐6 — PiUI-style Web diff viewer replacing the default diff view. (✅ active)
-- [dsh-skin](https://github.com/KinGao294/dsh-skin) ⭐6 — Codex-style skin switcher plus custom translucent wallpaper with opacity/blur controls. (✅ active)
-- [dsh-balance](https://github.com/crazywoola/dsh-balance) ⭐5 — DeepSeek Harness balance plugin for the Settings page. (✅ active)
-- [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) ⭐5 — Spreadsheet-style skin for DSH, mimicking Excel. (✅ active)
+- [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) ⭐7 — Cross-platform drag & drop for DSH Web UI with original-path insertion, no file copying. (✅ active)
+- [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) ⭐7 — DSH 插件：git 提交固定使用环境自身作者身份（优先 gh CLI 登录账号，GitHub noreply 邮箱），GIT_AUTHOR_*/GIT_COMMITTER_* 环境变量注入压过一切 git config (✅ active)
+- [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) ⭐7 — 左下角便签：随手记点子/感想/TODO，实时保存到归档目录，清单+悬浮归档 (✅ active)
+- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) ⭐7 — Multi-engine persistent search: DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/XHS/Twitter/Reddit/RSS, with SQLite+LRU cache and Playwright rendering. (✅ active)
+- [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) ⭐6 — provider-agnostic AIGC HTTP 桥 + 无限画布 + ffmpeg 后处理，13 个工具含画布连边/reroll/媒体编辑 | Provider-agnostic AIGC HTTP bridge + infinite canvas + ffmpeg post-processing; 13 tools incl. canvas linking/reroll/media-edit (✅ active)
+- [dsh-plugin-anti-ads](https://github.com/HuanLinOTO/dsh-plugin-anti-ads) ⭐6 — DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin (✅ active)
+- [dsh-plugin-auto-blame](https://github.com/HuanLinOTO/dsh-plugin-auto-blame) ⭐6 — 模型回合结束后用 LLM 生成 3 条批判性跟进建议，点击即发送 | After a model turn, an LLM generates 3 critical follow-up suggestions shown as click-to-send chips (✅ active)
+- [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) ⭐6 — Marketplace plugin that integrates DeepSeek Harness with the GitHub plugin ecosystem. (✅ active)
+- [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) ⭐6 — Expose run_python/run_node tools that execute code via stdin and return stdout/stderr/exit code. (✅ active)
+- [dsh-token-panel](https://github.com/juhe291/dsh-token-panel) ⭐6 — A corner HUD for DeepSeek Harness that shows your session's token pressure, per-model cost, and daily/monthly usage at a glance — with an editable budget & balance that tracks spending for you. 右下角常驻的 Token 仪表盘：实时查看会话压力、按模型估算花费，预算和余额点一下就能改，每天每月用了多少都有记录。 (✅ active)
+- [dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) ⭐6 — A DeepSeek Harness Web plugin for real-time Token usage, cost estimates, per-round charts, and DeepSeek API balance. (✅ active)
+- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) ⭐6 — RMB/USD token billing for the DSH web: official-policy auto pricing with peak/off-peak hours and per-message cost ledger. (✅ active)
+- [weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) ⭐6 — Native WeShop Cordis plugin for DeepSeek Harness. Allow you to use infinite canvas with infinite creative skills. (✅ active)
+- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) ⭐5 — Human-readable catalog of official DSH Web built-ins with safe GUI toggles. (✅ active)
+- [dsh-cost-plugin](https://github.com/RoxsLee/dsh-cost-plugin) ⭐5 — DSH 费用/余额读数插件：在输入框统计行旁实时显示「本次 ≈¥x · 会话 ≈¥x · 余额 ¥x」，内置 DeepSeek 官方价目表，支持 2026-08-17 起生效的峰谷定价（按节点时间戳自动选档），余额经官方 /user/balance 实时查询，失败静默降级。 (✅ active)
+- [dsh-cue-plugin](https://github.com/unnnnoooo/dsh-cue-plugin) ⭐5 — DeepSeek Harness 的跨会话引用(cue)插件 (✅ active)
 - [dsh-ohos-patch](https://github.com/shenjackyuanjie/dsh-ohos-patch) ⭐5 — 让deepseek harness能在 ohos上跑！ (✅ active)
+- [dsh-opencode-go-usage](https://github.com/Xenia0922/dsh-opencode-go-usage) ⭐5 — DeepSeek Harness 插件:OpenCode Go 用量与花费悬浮仪表盘(配额、逐请求成本、模型/来源分布) (✅ active)
+- [dsh-plugin-anydoc](https://github.com/beancookie/dsh-plugin-anydoc) ⭐5 — Convert Word, PPT, Excel, PDF, EPUB and CSV documents to GitHub-Flavored Markdown via @firecrawl/anydoc. (✅ active)
 - [dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) ⭐5 — Mini-game menu (Wordle, match-3, 192 parameterized games) that pops up while the model generates. (✅ active)
-- [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) ⭐5 — Marketplace plugin that integrates DeepSeek Harness with the GitHub plugin ecosystem. (✅ active)
-- [dsh-plugin-ya-workspace-sidebar](https://github.com/HuanLinOTO/dsh-plugin-ya-workspace-sidebar) ⭐5 — DSH Web 工作区侧栏替代，顶部全局最近会话 + Workspace→Session 二级菜单 + 面包屑 | DSH Web workspace sidebar replacement: top global recent sessions + Workspace→Session two-level menu + breadcrumbs (✅ active)
-- [dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) ⭐5 — Replaces the 'Deep diving…' turn-status label with phase-aware typewriter messages. (✅ active)
+- [dsh-spend](https://github.com/nonewind/dsh-spend) ⭐5 — Token usage and estimated spend: floating panel with per-model/day/session stats and auto-detected billing plans. (✅ active)
+- [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) ⭐5 — Keyboard-first command palette for DeepSeek Harness Web. (✅ active)
 - [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) ⭐5 — Community plugin bundle integrating the Nowledge Mem memory service with DeepSeek Harness. (✅ active)
-- [dsh-cost-plugin](https://github.com/RoxsLee/dsh-cost-plugin) ⭐4 — DSH 费用/余额读数插件：在输入框统计行旁实时显示「本次 ≈¥x · 会话 ≈¥x · 余额 ¥x」，内置 DeepSeek 官方价目表，支持 2026-08-17 起生效的峰谷定价（按节点时间戳自动选档），余额经官方 /user/balance 实时查询，失败静默降级。 (✅ active)
-- [dsh-cue-plugin](https://github.com/unnnnoooo/dsh-cue-plugin) ⭐4 — DeepSeek Harness 的跨会话引用(cue)插件 (✅ active)
+- [zotero-harvest](https://github.com/Fisfzy/zotero-harvest) ⭐5 — Zotero 文献采集入库插件（DSH external plugin）：多源检索（OpenAlex/arXiv/Crossref/Europe PMC/Semantic Scholar）+ OA 下载链接解析（Unpaywall）+ 充分性审计 + 入库本地 Zotero + 触发 zotero-wave-rag 重建 (✅ active)
+- [codex-eyes-hands](https://github.com/651002/codex-eyes-hands) ⭐4 — 专为 DeepSeek Harness 打造：把本机 Codex CLI 变成纯文本 AI agent 的眼睛和手——看图/读文件/画图/监督执行/双通道容灾 (✅ active)
+- [context-vista](https://github.com/GooodWei/context-vista) ⭐4 — Live context/token monitor: floating panel + /context command with donut charts of token usage, allocation and estimated cost. (✅ active)
+- [deepseek-harness-zh_pro](https://github.com/magian1127/deepseek-harness-zh_pro) ⭐4 — Chinese enhancement plugin for DeepSeek Harness (DSH) - DSH 中文增强插件 (✅ active)
+- [dsh-calculator](https://github.com/bobcat848/dsh-calculator) ⭐4 — Calculate the real-time cost of DeepSeek API calls made by DeepSeek Harness. (✅ active)
 - [dsh-input-history](https://github.com/lhh010/dsh-input-history) ⭐4 — Terminal-style input history: Ctrl+Up/Ctrl+Down to recall and switch sent messages. (✅ active)
-- [dsh-pet](https://github.com/PC2005-cloud/dsh-pet) ⭐4 — DeepSeek Harness 桌面宠物插件 + 完整素材生成链：AI 提示词 → 绿幕视频 → 透明动画 → 可安装插件，从零到宠物全流程可复现 (✅ active)
-- [dsh-plugin-anti-ads](https://github.com/HuanLinOTO/dsh-plugin-anti-ads) ⭐4 — DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin (✅ active)
+- [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) ⭐4 — PDF toolbox: extract text, metadata and page ranges via pdfjs-dist, local with no API key. (✅ active)
 - [dsh-plugin-deepeye](https://github.com/Favio8/dsh-plugin-deepeye) ⭐4 — DeepEye vision plugin for DeepSeek Harness (DSH): image description, OCR, VQA, UI layout, and clipboard analysis. (✅ active)
-- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) ⭐4 — Plugin management panel: enable/disable installed plugins plus a GitHub dsh-plugin marketplace with one-click install. (✅ active)
-- [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) ⭐4 — Expose run_python/run_node tools that execute code via stdin and return stdout/stderr/exit code. (✅ active)
-- [dsh-remote](https://github.com/flymysql/dsh-remote) ⭐4 — Remote workspace: connect a host over SSH and operate a remote directory with rw_* tools. (✅ active)
-- [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) ⭐4 — Keyboard-first command palette for DeepSeek Harness Web. (✅ active)
-- [weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) ⭐4 — Native WeShop Cordis plugin for DeepSeek Harness. Allow you to use infinite canvas with infinite creative skills. (✅ active)
-- [context-vista](https://github.com/GooodWei/context-vista) ⭐3 — Live context/token monitor: floating panel + /context command with donut charts of token usage, allocation and estimated cost. (✅ active)
-- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) ⭐3 — Human-readable catalog of official DSH Web built-ins with safe GUI toggles. (✅ active)
-- [dsh-calculator](https://github.com/bobcat848/dsh-calculator) ⭐3 — Calculate the real-time cost of DeepSeek API calls made by DeepSeek Harness. (✅ active)
-- [dsh-opencode-go-usage](https://github.com/Xenia0922/dsh-opencode-go-usage) ⭐3 — DeepSeek Harness 插件:OpenCode Go 用量与花费悬浮仪表盘(配额、逐请求成本、模型/来源分布) (✅ active)
+- [dsh-prompt-enhancer](https://github.com/Fishsb/dsh-prompt-enhancer) ⭐4 — DeepSeek Harness DSH 提示词增强插件：✨ 一键优化草稿，增强提示词。 (✅ active)
+- [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) ⭐4 — 为 DeepSeek Harness 提供会话删除能力，支持侧边栏 ⋮ 菜单入口 (✅ active)
+- [dsh-split-panes](https://github.com/lehhair/dsh-split-panes) ⭐4 — Split panes. (✅ active)
+- [dsh-usage-dashboard](https://github.com/Cassius0924/dsh-usage-dashboard) ⭐4 — DeepSeek 额度与用量仪表盘 — DSH (DeepSeek Harness) 动态 Cordis 插件 (✅ active)
+- [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) ⭐4 — Privacy-minimal heuristic per-turn verification summaries for DeepSeek Harness (✅ active)
+- [dsh-weather](https://github.com/sunshine-lang/dsh-weather) ⭐4 — Weather tool: current conditions and multi-day forecasts via Open-Meteo, free with no API key. (✅ active)
+- [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) ⭐4 — Attention reminders for the DeepSeek Harness Web UI: frame badge, (N) tab title and whale-favicon recolor for sessions waiting for input or finished unopened. (✅ active)
+- [dsh-web-search-exa](https://github.com/TonyDua/dsh-web-search-exa) ⭐4 — Zero-config Exa web search provider: keyless anonymous MCP fallback plus keyed REST search. (✅ active)
+- [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐4 — Persistent common-word panel beside the composer with global/project buckets and one-click insert. (✅ active)
+- [dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) ⭐4 — VS Code-style workspace keyword search: a Search tab for the Better Sidebar ecosystem. (✅ active)
+- [deepseek-harness-plugin-manager](https://github.com/hrhgit/deepseek-harness-plugin-manager) ⭐3 — Web plugin manager for DeepSeek Harness (DSH): inspect, search, group, enable, and disable Cordis plugins. (✅ active)
+- [dsh-agentmemory](https://github.com/elementor-i/dsh-agentmemory) ⭐3 — agentmemory for DeepSeek Harness (dsh): full memory_* tools, capture hooks, and context injection over the local REST server (✅ active)
+- [dsh-browser](https://github.com/anweat/dsh-browser) ⭐3 — Self-contained browser runtime plugin for DeepSeek Harness — bundles Playwright (chromium) and OpenCLI as plugin-local dependencies, exposes a browser service and interactive browser tools. (✅ active)
+- [dsh-doctor](https://github.com/astra3294/dsh-doctor) ⭐3 — Deterministic diagnostics and recovery for DeepSeek Harness (✅ active)
+- [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) ⭐3 — File ownership/claim system for parallel agent sessions on the same project: claim/release, heartbeat stale takeover and async 3-way merge. (✅ active)
+- [dsh-file-mount](https://github.com/acefun29/dsh-file-mount) ⭐3 — Incremental file mounting with line-range deduplication: identical file contents are never re-sent to the model. (✅ active)
+- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud) ⭐3 — HUD status panel: git status, MCP servers, skills, model and token usage in a floating side panel. (✅ active)
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) ⭐3 — Bounded, layered, approval-gated and auditable cross-session memory with frozen snapshot injection. (✅ active)
+- [dsh-memory-evidence](https://github.com/LeslieWylie/dsh-memory-evidence) ⭐3 — Git-first memory navigation and bounded evidence tools for DeepSeek Harness. (💤 inactive)
+- [dsh-notebooks](https://github.com/havingautism/dsh-notebooks) ⭐3 — Notebooks plugin (cordis). (✅ active)
+- [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) ⭐3 — Windows notifications for DSH, zero dependencies. (✅ active)
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) ⭐3 — dsh-passwords: DeepSeek Harness login gateway - first-run setup, at-rest encryption, brute-force lockout, audit log, HTTPS (✅ active)
+- [dsh-plugin-diff-review](https://github.com/Civitasv/dsh-plugin-diff-review) ⭐3 — Diff Review Plugin for DeepSeek Harness (✅ active)
 - [dsh-plugins-raincode](https://github.com/rainforest888/dsh-plugins-raincode) ⭐3 — dsh plugin: DeepSeek Harness 的模型层 = raincode(模型池/缓存/重试) + /skills 浏览 (✅ active)
-- [dsh-token-panel](https://github.com/juhe291/dsh-token-panel) ⭐3 — A corner HUD for DeepSeek Harness that shows your session's token pressure, per-model cost, and daily/monthly usage at a glance — with an editable budget & balance that tracks spending for you. 右下角常驻的 Token 仪表盘：实时查看会话压力、按模型估算花费，预算和余额点一下就能改，每天每月用了多少都有记录。 (✅ active)
+- [dsh-restart](https://github.com/anweat/dsh-restart) ⭐3 — Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch. (✅ active)
+- [dsh-suggested-replies](https://github.com/Anionex/dsh-suggested-replies) ⭐3 — Predicted next-message candidates above the DSH Web composer, one click to fill the draft. (✅ active)
+- [dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) ⭐3 — Agent memory for DeepSeek Harness | DeepSeek Harness 记忆插件 (✅ active)
+- [dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) ⭐3 — Fail-closed export-copy redaction for DeepSeek Harness session telemetry (✅ active)
+- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) ⭐3 — Structured safe Git tools: status/diff/log/branch/stage/commit/stash/show with a destructive-command guard. (✅ active)
+- [dsh-ui-appearance](https://github.com/TQSY114514/dsh-ui-appearance) ⭐3 — Appearance customization plugin for DeepSeek Harness: theme color palette, background image, opacity/blur, glass effect (✅ active)
+- [dsh-ultra-ui](https://github.com/havingautism/dsh-ultra-ui) ⭐3 — Ultra UI plugin (cordis). (✅ active)
 - [dsh-usage-plugin](https://github.com/Yihong89/dsh-usage-plugin) ⭐3 — DeepSeek Harness (DSH) plugins. First: dsh-usage-report — per-session token usage & estimated cost (/usage + usage_report), priced from the DeepSeek pricing table. (✅ active)
-- [dsh-weather](https://github.com/sunshine-lang/dsh-weather) ⭐3 — Weather tool: current conditions and multi-day forecasts via Open-Meteo, free with no API key. (✅ active)
-- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) ⭐3 — Multi-engine persistent search: DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/XHS/Twitter/Reddit/RSS, with SQLite+LRU cache and Playwright rendering. (✅ active)
 - [dsh-webbridge](https://github.com/bill9109/dsh-webbridge) ⭐3 — DSH combined with Kimi WebBridge for real browser control. (✅ active)
-- [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐3 — Persistent common-word panel beside the composer with global/project buckets and one-click insert. (✅ active)
-- [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) ⭐2 — Cross-platform drag & drop for DSH Web UI with original-path insertion, no file copying. (✅ active)
-- [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) ⭐2 — File ownership/claim system for parallel agent sessions on the same project: claim/release, heartbeat stale takeover and async 3-way merge. (✅ active)
-- [dsh-file-mount](https://github.com/acefun29/dsh-file-mount) ⭐2 — Incremental file mounting with line-range deduplication: identical file contents are never re-sent to the model. (✅ active)
+- [tokenledger](https://github.com/zh667/TokenLedger) ⭐3 — Token usage accounting for DeepSeek Harness, reconciled against New API and Sub2API relay-site billing (✅ active)
+- [zotero-wave-rag](https://github.com/Fisfzy/zotero-wave-rag) ⭐3 — 面向 Zotero 论文库的浪潮式 RAG 细节检索系统 —— DSH 外部插件。移植 VCPToolBox 浪潮语义动力学思想（标签河道图传播/虫洞跳转/钟型阻尼/Ω重排），配 BM25+RRF 混合检索、claim-evidence 忠实度校验、两级增量索引 (✅ active)
+- [dsh-adb](https://github.com/SamXiaBing/dsh-adb) ⭐2 — ADB device & bench operations: device discovery, structured logcat (background streaming), apk install, file pull/push, dumpsys performance snapshots. (✅ active)
+- [dsh-deepseek-quota](https://github.com/yingjunnan/dsh-deepseek-quota) ⭐2 — DeepSeek API quota (balance) widget for the DSH web GUI: a floating bottom-right card showing remaining DeepSeek API balance. (✅ active)
+- [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) ⭐2 — Clickable file paths in DSH replies: inline open, reveal in file manager and a mentioned-files chip list. (✅ active)
 - [dsh-memory (Jesse-njx)](https://github.com/Jesse-njx/dsh-memory) ⭐2 — Cited memory over DSH's lossless session log: distilled, human-auditable facts with citations. (✅ active)
-- [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) ⭐2 — Windows notifications for DSH, zero dependencies. (✅ active)
-- [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) ⭐2 — PDF toolbox: extract text, metadata and page ranges via pdfjs-dist, local with no API key. (✅ active)
+- [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) ⭐2 — Pin assistant replies from the action strip and recall them into the next model turn (/pin /recall). (✅ active)
+- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) ⭐2 — mount one row in the composition and every plugin card on the Web Settings plugin list page gets a bilingual (zh/en) description; it also publishes the pluginDescriptions service so other plugins can register their own descriptions. (✅ active)
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) ⭐2 — Edit user and built-in system-prompt sections with live preview. (✅ active)
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) ⭐2 — Incremental diff reviewer: checkpoint-based review queue with a Web UI panel and /review command. (✅ active)
+- [dsh-scout](https://github.com/omdsh-dev/dsh-scout) ⭐2 — 面向 DeepSeek Harness 的只读环境探测插件，为智能体提供运行环境、软件版本、系统资源、端口、服务、硬件及工作区信息。 (✅ active)
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) ⭐2 — Index-free cross-agent session search for DeepSeek Harness. (✅ active)
-- [dsh-suggested-replies](https://github.com/Anionex/dsh-suggested-replies) ⭐2 — Predicted next-message candidates above the DSH Web composer, one click to fill the draft. (✅ active)
-- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) ⭐2 — RMB/USD token billing for the DSH web: official-policy auto pricing with peak/off-peak hours and per-message cost ledger. (✅ active)
+- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) ⭐2 — Structured test runner tool: auto-detect vitest/jest/pytest/node:test, run tests and parse failure summaries for the model. (✅ active)
+- [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) ⭐2 — Per-agent on-demand tool discovery and progressive schema disclosure. (✅ active)
 - [URL Manager](https://github.com/Piccolo123/url-manager) ⭐2 — Agent-first URL and knowledge collection system: auto-categorize, tag, full-text search and shared collections. (✅ active)
 - [dsh-computer-use](https://github.com/xiaoheizi1212/dsh-computer-use) ⭐1 — Model-agnostic Computer Use for DSH: isolated browser, Windows native helper and third-party bridges. (✅ active)
-- [dsh-memento](https://github.com/PerryLink/dsh-memento) ⭐1 — Bounded, layered, approval-gated and auditable cross-session memory with frozen snapshot injection. (✅ active)
+- [dsh-doctor](https://github.com/asdf17128/dsh-doctor) ⭐1 — Find what your DeepSeek Harness (dsh) patches silently broke — dead patches, config fields dropped by whole-config replacement, unmaintained plugins. Read-only, zero deps. (✅ active)
+- [dsh-news-plugin](https://github.com/canghai666x/dsh-news-plugin) ⭐1 — RSS/news ingestion returning structured title/link/source/date/summary for downstream model ranking and briefing. (✅ active)
 - [dsh-payload-capture](https://github.com/Moeblack/dsh-payload-capture) ⭐1 — Captures every upstream model API payload to JSON for debugging and observability. (✅ active)
-- [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) ⭐1 — Pin assistant replies from the action strip and recall them into the next model turn (/pin /recall). (✅ active)
-- [dsh-plugin-anydoc](https://github.com/beancookie/dsh-plugin-anydoc) ⭐1 — Convert Word, PPT, Excel, PDF, EPUB and CSV documents to GitHub-Flavored Markdown via @firecrawl/anydoc. (✅ active)
-- [dsh-spend](https://github.com/nonewind/dsh-spend) ⭐1 — Token usage and estimated spend: floating panel with per-model/day/session stats and auto-detected billing plans. (✅ active)
-- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) ⭐1 — Structured test runner tool: auto-detect vitest/jest/pytest/node:test, run tests and parse failure summaries for the model. (✅ active)
+- [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) ⭐1 — @dsh-pm/registry — discover dsh plugins by merging the awesome-dsh-plugin list, GitHub dsh-plugin-topic search, and npm keyword search into one deduped, offline-tolerant registry (the discovery engine of dsh pm) (✅ active)
+- [dsh-plugin-quote-reply](https://github.com/yangYzc/dsh-plugin-quote-reply) ⭐1 — DSH plugin: select text in a conversation, then quote it into the composer or reply in a new window. / DeepSeek Harness 划词引用插件：选中文字一键引用回复或新窗口回复。 (✅ active)
+- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) ⭐1 — Turn-index sidebar: one entry per user turn, click to jump with scroll-spy highlighting. (✅ active)
+- [dsh-turn-navigator](https://github.com/vibeinging/dsh-turn-navigator) ⭐1 — Private DSH Web turn navigation plugin (✅ active)
 - [dsh-view-modes](https://github.com/NigelYao/dsh-view-modes) ⭐1 — Output modes with Verbose, Normal and Summary views plus semantic grouping for tool calls and thinking. (✅ active)
-- [dsh-web-search-exa](https://github.com/TonyDua/dsh-web-search-exa) ⭐1 — Zero-config Exa web search provider: keyless anonymous MCP fallback plus keyed REST search. (✅ active)
-- [dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) ⭐1 — VS Code-style workspace keyword search: a Search tab for the Better Sidebar ecosystem. (✅ active)
-- [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions)  — Clickable file paths in DSH replies: inline open, reveal in file manager and a mentioned-files chip list. (✅ active)
+- [dshp](https://github.com/asdf17128/dshp) ⭐1 — Manage DeepSeek Harness profiles — list, create, clone, diff, and share a whole dsh setup as one portable file. (✅ active)
+- [dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter)  — dsh plugin: per-turn USD cost badge in the Web UI (session total + per-message footer, hover breakdown) from token usage x a configurable pricing table. (✅ active)
 - [dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads)  — Upload arbitrary local files from the Web composer with pending cards, managed in Settings. (✅ active)
 - [dsh-git-branch-switcher](https://github.com/mixin-ai/dsh-git-branch-switcher)  — Session-header git branch pill: shows the workspace branch and switches it from the Web UI. (✅ active)
-- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud)  — HUD status panel: git status, MCP servers, skills, model and token usage in a floating side panel. (✅ active)
 - [dsh-memoria](https://github.com/jiayan-xu/dsh-memoria)  — Vector + graph memory backend with namespace isolation, automatic observation, recall, importance handling and hot reload. (🧪 experimental)
 - [dsh-memory](https://github.com/flymysql/dsh-memory)  — Cross-session memory vault: memory_remember / memory_recall / memory_forget tools with a Settings page. (🧪 experimental)
-- [dsh-news-plugin](https://github.com/canghai666x/dsh-news-plugin)  — RSS/news ingestion returning structured title/link/source/date/summary for downstream model ranking and briefing. (✅ active)
-- [dsh-recommend](https://github.com/zp-home/dsh-recommend)  — Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data with an open scoring model. (✅ active)
-- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git)  — Structured safe Git tools: status/diff/log/branch/stage/commit/stash/show with a destructive-command guard. (✅ active)
-- [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search)  — Per-agent on-demand tool discovery and progressive schema disclosure. (✅ active)
-- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index)  — Turn-index sidebar: one entry per user turn, click to jump with scroll-spy highlighting. (✅ active)
+- [dsh-plugin-cost](https://github.com/yweilai77-dev/dsh-plugin-cost)  — Session cost estimate in the DSH Web composer dock (tokenUsage × configurable price table, one-click official-price refresh). (✅ active)
+- [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces. (✅ active)
+- [dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream)  — Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and respects prefers-reduced-motion. (✅ active)
+- [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech)  — Browser Web Speech API voice input for DSH: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech). (✅ active)
 
 ### Skills
 
@@ -925,33 +1081,40 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) | ⭐12 | DSH Web UI plugin: Skills settings section with hot enable/disable, delete and add. | ✅ active |
-| 2 | [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) | ⭐9 | Field-tested plugin development playbook (skill + docs): cordis dual copies, tsconfig triplets, Windows junctions and multi-frame zstd. | ✅ active |
-| 3 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | ⭐7 | Agent skills for building and testing DeepSeek Harness plugins, from scaffolding a package to publishing. | ✅ active |
-| 4 | [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | ⭐3 | Book-to-skill plugin: a 5-stage long task that fetches, parses, understands, generates and installs a skill. | ✅ active |
-| 5 | [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) | ⭐2 | Godot Engine 4.x full-stack game development skill plugin for DSH. | ✅ active |
-| 6 | [dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) | ⭐2 | Code review skill pack for DeepSeek Harness. | ✅ active |
-| 7 | [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) | ⭐1 | Bridges the vercel-labs/skills ecosystem: LLM-driven skill search, install and management. | ✅ active |
-| 8 | [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | ⭐1 | Security-audit skill pack: 5 agent skills covering secret scan, dependency audit and more. | ✅ active |
-| 9 | [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) | ⭐1 | Every skill you already have — Claude Code, Codex, Cursor, Gemini CLI — works in DSH. | ✅ active |
-| 10 | [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) | ⭐1 | Scans session-visible skills and ranks them by relevance to the recent conversation. | ✅ active |
+| 1 | [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) | ⭐224 | EasyEDA Pro automation: Go daemon + in-app connector + agent skill + stdio MCP server for typed schematic/PCB actions, workflow gates, and DRC. | ✅ active |
+| 2 | [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) | ⭐34 | DSH Web UI plugin: Skills settings section with hot enable/disable, delete and add. | ✅ active |
+| 3 | [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | ⭐12 | Complete reverse-skill (85 SKILL.md) as a DeepSeek Harness (dsh) Cordis plugin — reverse engineering, authorized pentesting and security research skill pack. | ✅ active |
+| 4 | [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) | ⭐10 | Field-tested plugin development playbook (skill + docs): cordis dual copies, tsconfig triplets, Windows junctions and multi-frame zstd. | ✅ active |
+| 5 | [dsh-science](https://github.com/biociao/dsh-science) | ⭐10 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ active |
+| 6 | [dsh-plugin-development](https://github.com/w2112515/dsh-plugin-development) | ⭐8 | Portable Agent Skill for developing and auditing DeepSeek Harness plugins, with an optional profile-installable DSH bundle adapter. | ✅ active |
+| 7 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | ⭐7 | Agent skills for building and testing DeepSeek Harness plugins, from scaffolding a package to publishing. | ✅ active |
+| 8 | [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | ⭐4 | Book-to-skill plugin: a 5-stage long task that fetches, parses, understands, generates and installs a skill. | ✅ active |
+| 9 | [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) | ⭐4 | Godot Engine 4.x full-stack game development skill plugin for DSH. | ✅ active |
+| 10 | [dsh-humanize](https://github.com/zevorn/dsh-humanize) | ⭐3 | De-AI writing skill: rewrite agent output to sound more human. | ✅ active |
 
-#### Complete list (14)
+#### Complete list (21)
 
-- [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) ⭐12 — DSH Web UI plugin: Skills settings section with hot enable/disable, delete and add. (✅ active)
-- [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) ⭐9 — Field-tested plugin development playbook (skill + docs): cordis dual copies, tsconfig triplets, Windows junctions and multi-frame zstd. (✅ active)
+- [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) ⭐224 — EasyEDA Pro automation: Go daemon + in-app connector + agent skill + stdio MCP server for typed schematic/PCB actions, workflow gates, and DRC. (✅ active)
+- [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) ⭐34 — DSH Web UI plugin: Skills settings section with hot enable/disable, delete and add. (✅ active)
+- [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) ⭐12 — Complete reverse-skill (85 SKILL.md) as a DeepSeek Harness (dsh) Cordis plugin — reverse engineering, authorized pentesting and security research skill pack. (✅ active)
+- [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) ⭐10 — Field-tested plugin development playbook (skill + docs): cordis dual copies, tsconfig triplets, Windows junctions and multi-frame zstd. (✅ active)
+- [dsh-science](https://github.com/biociao/dsh-science) ⭐10 — Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. (✅ active)
+- [dsh-plugin-development](https://github.com/w2112515/dsh-plugin-development) ⭐8 — Portable Agent Skill for developing and auditing DeepSeek Harness plugins, with an optional profile-installable DSH bundle adapter. (✅ active)
 - [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) ⭐7 — Agent skills for building and testing DeepSeek Harness plugins, from scaffolding a package to publishing. (✅ active)
-- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) ⭐3 — Book-to-skill plugin: a 5-stage long task that fetches, parses, understands, generates and installs a skill. (✅ active)
-- [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) ⭐2 — Godot Engine 4.x full-stack game development skill plugin for DSH. (✅ active)
+- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) ⭐4 — Book-to-skill plugin: a 5-stage long task that fetches, parses, understands, generates and installs a skill. (✅ active)
+- [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) ⭐4 — Godot Engine 4.x full-stack game development skill plugin for DSH. (✅ active)
+- [dsh-humanize](https://github.com/zevorn/dsh-humanize) ⭐3 — De-AI writing skill: rewrite agent output to sound more human. (✅ active)
+- [dsh-memoryhub](https://github.com/solknight48/dsh-memoryhub) ⭐3 — MemoryHub (mh) plugin for DeepSeek Harness (dsh): auto-loads checkpoint memory on session start, adds mh_* tools and the mh skill, and a Memory tab in the web UI (✅ active)
+- [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) ⭐3 — Scans session-visible skills and ranks them by relevance to the recent conversation. (✅ active)
+- [deepseek-harness-skillx](https://github.com/drowned-fish1/deepseek-harness-skillx) ⭐2 — Skill collection for DeepSeek Harness workflows. (✅ active)
+- [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) ⭐2 — Bridges the vercel-labs/skills ecosystem: LLM-driven skill search, install and management. (✅ active)
+- [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) ⭐2 — DSH knowledge-base plugin: build audit-able KB packs (references + SQLite FTS5) from md/txt/docx/pdf, deterministic retrieval (kb_query) and original-text reading (kb_read), zero-script generated skills. Apache-2.0. (✅ active)
 - [dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) ⭐2 — Code review skill pack for DeepSeek Harness. (✅ active)
-- [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) ⭐1 — Bridges the vercel-labs/skills ecosystem: LLM-driven skill search, install and management. (✅ active)
-- [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) ⭐1 — Security-audit skill pack: 5 agent skills covering secret scan, dependency audit and more. (✅ active)
-- [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) ⭐1 — Every skill you already have — Claude Code, Codex, Cursor, Gemini CLI — works in DSH. (✅ active)
-- [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) ⭐1 — Scans session-visible skills and ranks them by relevance to the recent conversation. (✅ active)
-- [deepseek-harness-skillx](https://github.com/drowned-fish1/deepseek-harness-skillx)  — Skill collection for DeepSeek Harness workflows. (✅ active)
-- [dsh-humanize](https://github.com/zevorn/dsh-humanize)  — De-AI writing skill: rewrite agent output to sound more human. (✅ active)
+- [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) ⭐2 — Security-audit skill pack: 5 agent skills covering secret scan, dependency audit and more. (✅ active)
+- [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) ⭐2 — Every skill you already have — Claude Code, Codex, Cursor, Gemini CLI — works in DSH. (✅ active)
+- [dsh-web-novel-research](https://github.com/canghai666x/dsh-web-novel-research) ⭐1 — Chinese web-novel plot lookup skill: free mirror-site workflow with GBK decoding and duplicate-chapter disambiguation. (✅ active)
 - [dsh-news-briefing](https://github.com/canghai666x/dsh-news-briefing)  — News briefing skill: multi-dimensional story scoring, anti-clickbait rules, content prioritization and Chinese editorial style. (✅ active)
-- [dsh-web-novel-research](https://github.com/canghai666x/dsh-web-novel-research)  — Chinese web-novel plot lookup skill: free mirror-site workflow with GBK decoding and duplicate-chapter disambiguation. (✅ active)
+- [mstar-workflow](https://github.com/btspoony/mstar-workflow)  — A Skill-driven Harness/Loop Engineering Workflow Agent Plugin (💤 inactive)
 
 ### Workflows & Automation
 
@@ -960,38 +1123,39 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | ⭐54 | Brings Claude Code's UltraCode mode to DSH: upgrade one-shot multi-agent dispatch into a generatable, saveable, governable, observable, recoverable workflow layer. | ✅ active |
-| 2 | [mstar-harness](https://github.com/btspoony/mstar-harness) | ⭐42 | Skill-driven harness/loop engineering workflow agent: tune agent loops as a first-class workflow. | ✅ active |
-| 3 | [dsh-automation](https://github.com/titanwings/dsh-automation) | ⭐27 | Run coding tasks on a schedule in fresh Agent sessions, managed by the user or the agent itself. | ✅ active |
-| 4 | [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | ⭐9 | Auto-resumes interrupted DSH Web requests: failure classification, adaptive retry, configurable continue message and browser notifications. | ✅ active |
-| 5 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | ⭐9 | Adaptive deep-research orchestrator built on the official workflow engine. | ✅ active |
-| 6 | [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) | ⭐7 | Ops toolbox: A/B dual-slot daily snapshot rotation with atomic switch and one-click rollback, plus a 10s watchdog. | ✅ active |
-| 7 | [dsh-track](https://github.com/fakechris/dsh-track) | ⭐5 | Embedded task-management engine: decision-point protocol, thought-capture wall and Linear-style issue storage. | ✅ active |
-| 8 | [engineer-software](https://github.com/KirschBluteX/engineer-software) | ⭐5 | Runtime-neutral, evidence-driven software engineering workflow for Codex and DeepSeek Harness. | ✅ active |
-| 9 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | ⭐4 | Resident desktop assistant: global hotkey, scheduled automation, quick replies and a plugin market. | ✅ active |
-| 10 | [dsh-plans](https://github.com/Optim-Agent/dsh-plans) | ⭐4 | Human-in-the-loop planning preset adapted from prime-plans: researched, reviewed, executed. | ✅ active |
+| 1 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | ⭐56 | Brings Claude Code's UltraCode mode to DSH: upgrade one-shot multi-agent dispatch into a generatable, saveable, governable, observable, recoverable workflow layer. | ✅ active |
+| 2 | [mstar-harness](https://github.com/btspoony/mstar-harness) | ⭐46 | Skill-driven harness/loop engineering workflow agent: tune agent loops as a first-class workflow. | ✅ active |
+| 3 | [dsh-automation](https://github.com/titanwings/dsh-automation) | ⭐39 | Run coding tasks on a schedule in fresh Agent sessions, managed by the user or the agent itself. | ✅ active |
+| 4 | [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | ⭐15 | Auto-resumes interrupted DSH Web requests: failure classification, adaptive retry, configurable continue message and browser notifications. | ✅ active |
+| 5 | [dsh-plans](https://github.com/Optim-Agent/dsh-plans) | ⭐13 | Human-in-the-loop planning preset adapted from prime-plans: researched, reviewed, executed. | ✅ active |
+| 6 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | ⭐12 | Adaptive deep-research orchestrator built on the official workflow engine. | ✅ active |
+| 7 | [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) | ⭐9 | Ops toolbox: A/B dual-slot daily snapshot rotation with atomic switch and one-click rollback, plus a 10s watchdog. | ✅ active |
+| 8 | [dsh-track](https://github.com/fakechris/dsh-track) | ⭐6 | Embedded task-management engine: decision-point protocol, thought-capture wall and Linear-style issue storage. | ✅ active |
+| 9 | [engineer-software](https://github.com/KirschBluteX/engineer-software) | ⭐6 | Runtime-neutral, evidence-driven software engineering workflow for Codex and DeepSeek Harness. | ✅ active |
+| 10 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | ⭐5 | Resident desktop assistant: global hotkey, scheduled automation, quick replies and a plugin market. | ✅ active |
 
-#### Complete list (20)
+#### Complete list (21)
 
-- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐54 — Brings Claude Code's UltraCode mode to DSH: upgrade one-shot multi-agent dispatch into a generatable, saveable, governable, observable, recoverable workflow layer. (✅ active)
-- [mstar-harness](https://github.com/btspoony/mstar-harness) ⭐42 — Skill-driven harness/loop engineering workflow agent: tune agent loops as a first-class workflow. (✅ active)
-- [dsh-automation](https://github.com/titanwings/dsh-automation) ⭐27 — Run coding tasks on a schedule in fresh Agent sessions, managed by the user or the agent itself. (✅ active)
-- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) ⭐9 — Auto-resumes interrupted DSH Web requests: failure classification, adaptive retry, configurable continue message and browser notifications. (✅ active)
-- [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) ⭐9 — Adaptive deep-research orchestrator built on the official workflow engine. (✅ active)
-- [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) ⭐7 — Ops toolbox: A/B dual-slot daily snapshot rotation with atomic switch and one-click rollback, plus a 10s watchdog. (✅ active)
-- [dsh-track](https://github.com/fakechris/dsh-track) ⭐5 — Embedded task-management engine: decision-point protocol, thought-capture wall and Linear-style issue storage. (✅ active)
-- [engineer-software](https://github.com/KirschBluteX/engineer-software) ⭐5 — Runtime-neutral, evidence-driven software engineering workflow for Codex and DeepSeek Harness. (✅ active)
-- [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) ⭐4 — Resident desktop assistant: global hotkey, scheduled automation, quick replies and a plugin market. (✅ active)
-- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) ⭐4 — Human-in-the-loop planning preset adapted from prime-plans: researched, reviewed, executed. (✅ active)
-- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) ⭐3 — DeepResearch plugin (cordis) for the Harness. (🧪 experimental)
-- [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) ⭐3 — Adversarial checkup → fix → review loop built on the official workflow engine. (✅ active)
+- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐56 — Brings Claude Code's UltraCode mode to DSH: upgrade one-shot multi-agent dispatch into a generatable, saveable, governable, observable, recoverable workflow layer. (✅ active)
+- [mstar-harness](https://github.com/btspoony/mstar-harness) ⭐46 — Skill-driven harness/loop engineering workflow agent: tune agent loops as a first-class workflow. (✅ active)
+- [dsh-automation](https://github.com/titanwings/dsh-automation) ⭐39 — Run coding tasks on a schedule in fresh Agent sessions, managed by the user or the agent itself. (✅ active)
+- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) ⭐15 — Auto-resumes interrupted DSH Web requests: failure classification, adaptive retry, configurable continue message and browser notifications. (✅ active)
+- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) ⭐13 — Human-in-the-loop planning preset adapted from prime-plans: researched, reviewed, executed. (✅ active)
+- [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) ⭐12 — Adaptive deep-research orchestrator built on the official workflow engine. (✅ active)
+- [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) ⭐9 — Ops toolbox: A/B dual-slot daily snapshot rotation with atomic switch and one-click rollback, plus a 10s watchdog. (✅ active)
+- [dsh-track](https://github.com/fakechris/dsh-track) ⭐6 — Embedded task-management engine: decision-point protocol, thought-capture wall and Linear-style issue storage. (✅ active)
+- [engineer-software](https://github.com/KirschBluteX/engineer-software) ⭐6 — Runtime-neutral, evidence-driven software engineering workflow for Codex and DeepSeek Harness. (✅ active)
+- [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) ⭐5 — Resident desktop assistant: global hotkey, scheduled automation, quick replies and a plugin market. (✅ active)
+- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) ⭐5 — DeepResearch plugin (cordis) for the Harness. (🧪 experimental)
+- [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) ⭐5 — Adversarial checkup → fix → review loop built on the official workflow engine. (✅ active)
+- [dsh-agent-orchestration](https://github.com/LeslieWylie/dsh-agent-orchestration) ⭐3 — Evidence-first multi-agent workflow planning, handoff validation, and Loop Guard skills for DeepSeek Harness. (💤 inactive)
 - [dsh-plugin-spur](https://github.com/HuanLinOTO/dsh-plugin-spur) ⭐3 — Hang a whip in the chat stream: flick it (>2.0 px/ms) to send the agent a 'go work' message. (✅ active)
 - [dsh-prime-agent](https://github.com/yoke233/dsh-prime-agent) ⭐3 — Prime Agent-inspired persistent RLM control plane for DSH Code Mode. (✅ active)
-- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) ⭐1 — Engineering-discipline loop: requirement grilling before edits, red/green test-evidence gates and adversarial delivery review. (✅ active)
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) ⭐2 — Engineering-discipline loop: requirement grilling before edits, red/green test-evidence gates and adversarial delivery review. (✅ active)
+- [dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) ⭐2 — Persistent live DAG visualization of workflow runs, subagents, status and dependencies. (✅ active)
 - [dsh-governance](https://github.com/tappass/dsh-governance) ⭐1 — Authority layer for agentic AI as a DSH plugin: governs every tool call against your policies. (✅ active)
+- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) ⭐1 — Turn a DSH session into deliverable work reports (daily/weekly/handoff/article) with verifiable receipts. (✅ active)
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval)  — Agent evaluation platform: benchmark YAML, headless dsh runs, trace-based metrics, scripted grading and run comparison. (✅ active)
-- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio)  — Turn a DSH session into deliverable work reports (daily/weekly/handoff/article) with verifiable receipts. (✅ active)
-- [dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag)  — Persistent live DAG visualization of workflow runs, subagents, status and dependencies. (✅ active)
 - [dsh-trajectory-debug](https://github.com/devmom/dsh-trajectory-debug)  — Trajectory waterfall, deterministic replay, breakpoints, edit-and-rerun, fork compare and performance analytics. (✅ active)
 
 ### Agents & Multi-Agent
@@ -1001,41 +1165,41 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) | ⭐2,324 | 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） | ✅ active |
-| 2 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | ⭐222 | Multi-agent team-oriented extensions for DSH. | ✅ active |
-| 3 | [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) | ⭐101 | SillyTavern migration and next-generation Agent roleplay for DSH. | ✅ active |
-| 4 | [allinluna](https://github.com/zenx0x/allinluna) | ⭐25 | Resource-aware multi-agent orchestration for Codex and DeepSeek Harness (All in Flash DSH plugin). | ✅ active |
-| 5 | [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | ⭐24 | Cross-instance message/event handoff plugins (interconnect service + tools). | ✅ active |
-| 6 | [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) | ⭐19 | OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 | ✅ active |
-| 7 | [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) | ⭐19 | DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 | ✅ active |
-| 8 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | ⭐17 | Session-scoped database connections with a dedicated data agent: let the model connect to databases and write SQL. | ✅ active |
-| 9 | [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | ⭐12 | Bridge DeepSeek Harness into Claude Code for review, critique, delegation and session import. | ✅ active |
-| 10 | [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) | ⭐8 | Role-based Codex/Claude Code/ACP subagent providers: continuable children with durable state. | ✅ active |
+| 1 | [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) | ⭐2,493 | 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） | ✅ active |
+| 2 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | ⭐312 | Multi-agent team-oriented extensions for DSH. | ✅ active |
+| 3 | [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) | ⭐121 | SillyTavern migration and next-generation Agent roleplay for DSH. | ✅ active |
+| 4 | [allinluna](https://github.com/zenx0x/allinluna) | ⭐28 | Resource-aware multi-agent orchestration for Codex and DeepSeek Harness (All in Flash DSH plugin). | ✅ active |
+| 5 | [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | ⭐27 | Cross-instance message/event handoff plugins (interconnect service + tools). | ✅ active |
+| 6 | [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) | ⭐26 | OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 | ✅ active |
+| 7 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | ⭐25 | Session-scoped database connections with a dedicated data agent: let the model connect to databases and write SQL. | ✅ active |
+| 8 | [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) | ⭐23 | DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 | ✅ active |
+| 9 | [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | ⭐15 | Bridge DeepSeek Harness into Claude Code for review, critique, delegation and session import. | ✅ active |
+| 10 | [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) | ⭐9 | Pair a second model that passively reviews each turn and injects notes. | ✅ active |
 
 #### Complete list (23)
 
-- [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) ⭐2,324 — 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） (✅ active)
-- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) ⭐222 — Multi-agent team-oriented extensions for DSH. (✅ active)
-- [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) ⭐101 — SillyTavern migration and next-generation Agent roleplay for DSH. (✅ active)
-- [allinluna](https://github.com/zenx0x/allinluna) ⭐25 — Resource-aware multi-agent orchestration for Codex and DeepSeek Harness (All in Flash DSH plugin). (✅ active)
-- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) ⭐24 — Cross-instance message/event handoff plugins (interconnect service + tools). (✅ active)
-- [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) ⭐19 — OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 (✅ active)
-- [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) ⭐19 — DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 (✅ active)
-- [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) ⭐17 — Session-scoped database connections with a dedicated data agent: let the model connect to databases and write SQL. (✅ active)
-- [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) ⭐12 — Bridge DeepSeek Harness into Claude Code for review, critique, delegation and session import. (✅ active)
-- [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) ⭐8 — Role-based Codex/Claude Code/ACP subagent providers: continuable children with durable state. (✅ active)
-- [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) ⭐5 — Pair a second model that passively reviews each turn and injects notes. (✅ active)
+- [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) ⭐2,493 — 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） (✅ active)
+- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) ⭐312 — Multi-agent team-oriented extensions for DSH. (✅ active)
+- [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) ⭐121 — SillyTavern migration and next-generation Agent roleplay for DSH. (✅ active)
+- [allinluna](https://github.com/zenx0x/allinluna) ⭐28 — Resource-aware multi-agent orchestration for Codex and DeepSeek Harness (All in Flash DSH plugin). (✅ active)
+- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) ⭐27 — Cross-instance message/event handoff plugins (interconnect service + tools). (✅ active)
+- [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) ⭐26 — OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 (✅ active)
+- [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) ⭐25 — Session-scoped database connections with a dedicated data agent: let the model connect to databases and write SQL. (✅ active)
+- [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) ⭐23 — DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 (✅ active)
+- [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) ⭐15 — Bridge DeepSeek Harness into Claude Code for review, critique, delegation and session import. (✅ active)
+- [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) ⭐9 — Pair a second model that passively reviews each turn and injects notes. (✅ active)
+- [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) ⭐9 — Role-based Codex/Claude Code/ACP subagent providers: continuable children with durable state. (✅ active)
+- [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) ⭐7 — Configurable subagent profile system: a single subagent tool with profile parameters, Web UI settings and live progress. (✅ active)
+- [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) ⭐7 — Side sessions: persistent /side sessions (Codex style) and one-off /btw questions (Claude style) in temporary forks. (✅ active)
 - [dsh-plugin-claude-bridge](https://github.com/YYTbit/dsh-plugin-claude-bridge) ⭐5 — Bridge Claude Code memory, skills and config into DeepSeek Harness. (✅ active)
-- [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) ⭐5 — Configurable subagent profile system: a single subagent tool with profile parameters, Web UI settings and live progress. (✅ active)
 - [Task Passport](https://github.com/dongsheng123132/task-passport) ⭐5 — Open task handoff protocol for DeepSeek Harness, WorkBuddy, Claude Code and Codex: verified state, not chat logs. (✅ active)
+- [dsh-a2a](https://github.com/dpskh/dsh-a2a) ⭐4 — Agent2Agent mesh for the Harness. (✅ active)
 - [dsh-agent-messaging](https://github.com/happyren/dsh-agent-messaging) ⭐4 — Cross-session agent-to-agent messaging: address another session by name. (✅ active)
-- [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) ⭐4 — Side sessions: persistent /side sessions (Codex style) and one-off /btw questions (Claude style) in temporary forks. (✅ active)
-- [dsh-a2a](https://github.com/dpskh/dsh-a2a) ⭐2 — Agent2Agent mesh for the Harness. (✅ active)
-- [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) ⭐2 — Role-based LLM retry and fallback strategy plugin. (✅ active)
+- [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) ⭐4 — Role-based LLM retry and fallback strategy plugin. (✅ active)
+- [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) ⭐2 — Cross-session messaging: DSH sessions on the same machine can discover, message and coordinate with each other. (✅ active)
+- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) ⭐2 — Per-call model/provider/persona/toolFilter overrides for subagent delegation with @preset references. (✅ active)
 - [dsh-cross-session](https://github.com/Wha1eChai/dsh-cross-session) ⭐1 — Same-runtime cross-session discovery and communication for DeepSeek Harness. (✅ active)
-- [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) ⭐1 — Cross-session messaging: DSH sessions on the same machine can discover, message and coordinate with each other. (✅ active)
 - [dsh-slice-agent-loop](https://github.com/TT-Wang/dsh-slice-agent-loop) ⭐1 — Drop-in agent loop whose context engine is a bounded slice instead of a growing transcript. (✅ active)
-- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) ⭐1 — Per-call model/provider/persona/toolFilter overrides for subagent delegation with @preset references. (✅ active)
 - [dsh-supervisor](https://github.com/Wha1eChai/dsh-supervisor) ⭐1 — Same-runtime cross-session discovery and communication for DeepSeek Harness. (✅ active)
 
 ### Clients (Desktop & TUI)
@@ -1045,54 +1209,70 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) | ⭐962 | Modern desktop experience built for the DeepSeek Harness ecosystem (plugin). | ✅ active |
-| 2 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | ⭐793 | Claude Code-style full-screen terminal plugin: pixel-whale top bar, live status line, streaming thoughts, double-Esc rollback, context progress bar and TPS meter. | ✅ active |
-| 3 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | ⭐160 | One-stop community distribution: TUI, desktop and Web UI in a unified experience with layered installation. | ✅ active |
-| 4 | [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) | ⭐140 | Desktop app for DeepSeek Harness. | ✅ active |
-| 5 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | ⭐125 | Interactive terminal UI plugin for DSH with added TDD, evidence gates and vision modules. | ✅ active |
-| 6 | [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) | ⭐104 | Minimal cross-platform desktop wrapper: no config, out of the box. | ✅ active |
-| 7 | [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) | ⭐74 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch | ✅ active |
-| 8 | [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) | ⭐67 | Desktop wrapper for DeepSeek Harness. | ✅ active |
-| 9 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | ⭐65 | Lightweight Windows launcher: silent autostart at logon plus a minimal WebView2 window. | ✅ active |
-| 10 | [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) | ⭐63 | One-click desktop app: fully local with self-healing core updates, zero environment setup. Windows/macOS/Linux. | ✅ active |
+| 1 | [open-design](https://github.com/nexu-io/open-design) | ⭐86,741 | 🎨 The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode / Hermes & 20+ CLIs via BYOK. | ✅ active |
+| 2 | [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) | ⭐4,667 | Modern desktop experience built for the DeepSeek Harness ecosystem (plugin). | ✅ active |
+| 3 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | ⭐1,156 | Claude Code-style full-screen terminal plugin: pixel-whale top bar, live status line, streaming thoughts, double-Esc rollback, context progress bar and TPS meter. | ✅ active |
+| 4 | [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) | ⭐227 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch | ✅ active |
+| 5 | [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) | ⭐221 | Desktop app for DeepSeek Harness. | ✅ active |
+| 6 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | ⭐184 | One-stop community distribution: TUI, desktop and Web UI in a unified experience with layered installation. | ✅ active |
+| 7 | [deepseek-harness-eac](https://github.com/zouyuxuan122/Deepseek-Harness-EAC) | ⭐158 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch, 10 built-in UI skins. EAC: Embracing All Creation 揽尽万象 | ✅ active |
+| 8 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | ⭐153 | Interactive terminal UI plugin for DSH with added TDD, evidence gates and vision modules. | ✅ active |
+| 9 | [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) | ⭐143 | One-click desktop app: fully local with self-healing core updates, zero environment setup. Windows/macOS/Linux. | ✅ active |
+| 10 | [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) | ⭐139 | Minimal cross-platform desktop wrapper: no config, out of the box. | ✅ active |
 
-#### Complete list (35)
+#### Complete list (51)
 
-- [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) ⭐962 — Modern desktop experience built for the DeepSeek Harness ecosystem (plugin). (✅ active)
-- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) ⭐793 — Claude Code-style full-screen terminal plugin: pixel-whale top bar, live status line, streaming thoughts, double-Esc rollback, context progress bar and TPS meter. (✅ active)
-- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) ⭐160 — One-stop community distribution: TUI, desktop and Web UI in a unified experience with layered installation. (✅ active)
-- [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) ⭐140 — Desktop app for DeepSeek Harness. (✅ active)
-- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) ⭐125 — Interactive terminal UI plugin for DSH with added TDD, evidence gates and vision modules. (✅ active)
-- [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) ⭐104 — Minimal cross-platform desktop wrapper: no config, out of the box. (✅ active)
-- [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) ⭐74 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch (✅ active)
-- [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) ⭐67 — Desktop wrapper for DeepSeek Harness. (✅ active)
-- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) ⭐65 — Lightweight Windows launcher: silent autostart at logon plus a minimal WebView2 window. (✅ active)
-- [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) ⭐63 — One-click desktop app: fully local with self-healing core updates, zero environment setup. Windows/macOS/Linux. (✅ active)
-- [deepseek-harness-desktop (xiincs)](https://github.com/xiincs/deepseek-harness-desktop) ⭐53 — Native desktop built on Tauri 2 with bundled Node.js runtime, tray residency and auto-update. (✅ active)
-- [Deepseek-Harness-Desktop (ChisaAlter)](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) ⭐50 — Electron desktop shell with theme and background-image customization. (✅ active)
-- [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) ⭐27 — Support the dsh runtime on Multica. (✅ active)
-- [dsh-work](https://github.com/vibeinging/dsh-work) ⭐25 — Local-first AI workbench for DSH Plugins, combining Agent sessions, project files, data analysis, web research, MCP, and Office artifacts in an Electron desktop app. (✅ active)
-- [deepseek-harness-app (ipfred)](https://github.com/ipfred/deepseek-harness-app) ⭐23 — Desktop app for DeepSeek Harness. (✅ active)
-- [deepseek-harness-desktop (hongfeiyucode)](https://github.com/hongfeiyucode/deepseek-harness-desktop) ⭐23 — Desktop wrapper for DeepSeek Harness. (✅ active)
-- [deepseek-harness-desktop (ningbainb)](https://github.com/ningbainb/deepseek-harness-desktop) ⭐21 — Lossless Windows desktop app with the complete DSH Web UI, plugins, skins and skill dock. (✅ active)
-- [DeepSeekHarnessDesktop (wess09)](https://github.com/wess09/DeepSeekHarnessDesktop) ⭐20 — Desktop packaging for DeepSeek Harness. (✅ active)
-- [dsh-desktop (bruc3van)](https://github.com/bruc3van/dsh-desktop) ⭐20 — Third-party desktop client loading the official Web UI: reuses a running official instance or a bundled dsh runtime. (✅ active)
-- [DeepSeek Harness TUI (openma-ai)](https://github.com/openma-ai/deepseek-harness-tui) ⭐15 — Rust/Ratatui terminal client speaking the DSH SDK JSON-RPC protocol directly; runs standalone or as a profile bundle. (✅ active)
-- [deepseek-harness-desktop (cc1252)](https://github.com/cc1252/deepseek-harness-desktop) ⭐14 — Unofficial open-source Windows Electron wrapper for DeepSeek Harness. (✅ active)
-- [DeepSeek-Harness-Desktop (sleep2agi)](https://github.com/sleep2agi/DeepSeek-Harness-Desktop) ⭐11 — Unofficial community desktop shell for the public dsh runtime. (✅ active)
-- [awesome-deepseek-harness-desktop (ADHD)](https://github.com/omdsh-dev/awesome-deepseek-harness-desktop) ⭐10 — ADHD — out-of-the-box Electron desktop wrapper for DeepSeek Harness. (✅ active)
+- [open-design](https://github.com/nexu-io/open-design) ⭐86,741 — 🎨 The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode / Hermes & 20+ CLIs via BYOK. (✅ active)
+- [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) ⭐4,667 — Modern desktop experience built for the DeepSeek Harness ecosystem (plugin). (✅ active)
+- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) ⭐1,156 — Claude Code-style full-screen terminal plugin: pixel-whale top bar, live status line, streaming thoughts, double-Esc rollback, context progress bar and TPS meter. (✅ active)
+- [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) ⭐227 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch (✅ active)
+- [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) ⭐221 — Desktop app for DeepSeek Harness. (✅ active)
+- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) ⭐184 — One-stop community distribution: TUI, desktop and Web UI in a unified experience with layered installation. (✅ active)
+- [deepseek-harness-eac](https://github.com/zouyuxuan122/Deepseek-Harness-EAC) ⭐158 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch, 10 built-in UI skins. EAC: Embracing All Creation 揽尽万象 (✅ active)
+- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) ⭐153 — Interactive terminal UI plugin for DSH with added TDD, evidence gates and vision modules. (✅ active)
+- [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) ⭐143 — One-click desktop app: fully local with self-healing core updates, zero environment setup. Windows/macOS/Linux. (✅ active)
+- [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) ⭐139 — Minimal cross-platform desktop wrapper: no config, out of the box. (✅ active)
+- [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) ⭐115 — DeepSeek Harness Desktop App: a local AI desktop workspace for DSH Sessions, projects, files, web research, plugins, and Office artifacts. (✅ active)
+- [dsh-work](https://github.com/vibeinging/dsh-work) ⭐115 — Local-first AI workbench for DSH Plugins, combining Agent sessions, project files, data analysis, web research, MCP, and Office artifacts in an Electron desktop app. (✅ active)
+- [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) ⭐94 — Desktop wrapper for DeepSeek Harness. (✅ active)
+- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) ⭐92 — Lightweight Windows launcher: silent autostart at logon plus a minimal WebView2 window. (✅ active)
+- [Deepseek-Harness-Desktop (ChisaAlter)](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) ⭐81 — Electron desktop shell with theme and background-image customization. (✅ active)
+- [deepseek-harness-desktop (ningbainb)](https://github.com/ningbainb/deepseek-harness-desktop) ⭐44 — Lossless Windows desktop app with the complete DSH Web UI, plugins, skins and skill dock. (✅ active)
+- [deepseek-harness-desktop (hongfeiyucode)](https://github.com/hongfeiyucode/deepseek-harness-desktop) ⭐37 — Desktop wrapper for DeepSeek Harness. (✅ active)
+- [DeepSeekHarnessDesktop (wess09)](https://github.com/wess09/DeepSeekHarnessDesktop) ⭐37 — Desktop packaging for DeepSeek Harness. (✅ active)
+- [deepseek-harness-desktop (xiincs)](https://github.com/xiincs/deepseek-harness-desktop) ⭐36 — Native desktop built on Tauri 2 with bundled Node.js runtime, tray residency and auto-update. (✅ active)
+- [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) ⭐34 — Support the dsh runtime on Multica. (✅ active)
+- [dsh-desktop (bruc3van)](https://github.com/bruc3van/dsh-desktop) ⭐29 — Third-party desktop client loading the official Web UI: reuses a running official instance or a bundled dsh runtime. (✅ active)
+- [deepseek-harness-app (ipfred)](https://github.com/ipfred/deepseek-harness-app) ⭐26 — Desktop app for DeepSeek Harness. (✅ active)
+- [DeepSeek Harness TUI (openma-ai)](https://github.com/openma-ai/deepseek-harness-tui) ⭐25 — Rust/Ratatui terminal client speaking the DSH SDK JSON-RPC protocol directly; runs standalone or as a profile bundle. (✅ active)
+- [deepseek-harness-desktop (cc1252)](https://github.com/cc1252/deepseek-harness-desktop) ⭐17 — Unofficial open-source Windows Electron wrapper for DeepSeek Harness. (✅ active)
+- [deepseek-harness-termux](https://github.com/Vengisk/deepseek-harness-termux) ⭐15 — Run @deepseek-ai/dsh on Android/Termux. (✅ active)
+- [dsh-plugin-session-delete](https://github.com/lsz-asd/dsh-plugin-session-delete) ⭐15 — Delete DeepSeek Harness sessions from the UI: header danger button + sidebar session-row menu item (no conversation jump), risk-consent dialog with session name/id, stops running agents first, in-place list refresh without page reload. Works in web and the desktop client. (✅ active)
+- [DeepSeek-Harness-Desktop (sleep2agi)](https://github.com/sleep2agi/DeepSeek-Harness-Desktop) ⭐14 — Unofficial community desktop shell for the public dsh runtime. (✅ active)
+- [dsh-usage-plugin](https://github.com/feiyang-dev/dsh-usage-plugin) ⭐14 — DeepSeek Harness 用量与消耗插件（dsh-usage）—— 每次调用的 token 用量/缓存命中统计、峰谷计费、余额查询、CSV/JSON/PNG 导出，可经桌面端一键安装或命令行 dsh plugin add 安装。 (✅ active)
+- [dsh-mobile](https://github.com/lehhair/dsh-mobile) ⭐12 — Mobile client plugin (cordis + dsh.plugin.json). (✅ active)
+- [awesome-deepseek-harness-desktop (ADHD)](https://github.com/omdsh-dev/awesome-deepseek-harness-desktop) ⭐11 — ADHD — out-of-the-box Electron desktop wrapper for DeepSeek Harness. (✅ active)
 - [deepseek-harness-desktop (chyra-moon)](https://github.com/chyra-moon/deepseek-harness-desktop) ⭐10 — Native Windows desktop shell: 1:1 official web UI with embedded server, tray and auto-recovery. (✅ active)
-- [deepseek-harness-termux](https://github.com/Vengisk/deepseek-harness-termux) ⭐9 — Run @deepseek-ai/dsh on Android/Termux. (✅ active)
-- [deepseek-harness-desktop](https://github.com/omdsh-dev/deepseek-harness-desktop) ⭐7 — DSH 桌面应用打包器 (✅ active)
-- [deepseek-harness-desktop](https://github.com/qyqy-1109/deepseek-harness-desktop) ⭐6 — DeepSeek Harness Desktop: self-contained Windows desktop shell (Electron) that auto-starts dsh web, plus a subtle Codex-flavored theme plugin. (✅ active)
-- [deepseek-harness-tui (gxinxing)](https://github.com/gxinxing/deepseek-harness-tui) ⭐6 — Terminal-native interactive TUI built with Ink (React for terminals). (✅ active)
+- [deepseek-harness-desktop](https://github.com/qyqy-1109/deepseek-harness-desktop) ⭐9 — DeepSeek Harness Desktop: self-contained Windows desktop shell (Electron) that auto-starts dsh web, plus a subtle Codex-flavored theme plugin. (✅ active)
+- [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) ⭐9 — TUI built with grok-build. (✅ active)
+- [deepseek-harness-desktop](https://github.com/omdsh-dev/deepseek-harness-desktop) ⭐8 — DSH 桌面应用打包器 (✅ active)
+- [deepseek-harness-fnos](https://github.com/techysy/deepseek-harness-fnos) ⭐8 — DeepSeek Harness (DeepSeek 官方 agent 浏览器 UI) fnOS 应用 — 本地常驻服务, 官方统一网关接入 (✅ active)
+- [dsh-melody-launcher](https://github.com/rirko/dsh-melody-launcher) ⭐8 — dsh-旋律启动器：DeepSeek Harness 桌面启动器与插件管理器 (✅ active)
+- [dsh-mobile-for-android](https://github.com/Hongtwenfive1226/DSH-Mobile-for-Android) ⭐8 — The Android mobile version of DeepSeek Harness that relies on Tailscale. (✅ active)
+- [deepseek-harness-tui (gxinxing)](https://github.com/gxinxing/deepseek-harness-tui) ⭐7 — Terminal-native interactive TUI built with Ink (React for terminals). (✅ active)
+- [dsh-desktop](https://github.com/foolgry/dsh-desktop) ⭐7 — Download-and-run desktop build of DeepSeek Harness — Electron shell with embedded Node, no npm required. (✅ active)
+- [deepseek-harness-desktop](https://github.com/RZX00/deepseek-harness-desktop) ⭐6 — DeepSeek Harness with a Windows desktop build: an Electron shell over the dsh web profile, packaged as an installer (✅ active)
+- [deepseek-harness-tui (boxeryao)](https://github.com/boxeryao/deepseek-harness-tui) ⭐6 — Lightweight fast terminal plugin connected directly to the DSH runtime. (✅ active)
 - [deepseek-harness-cli](https://github.com/Richard-Yang0130/deepseek-harness-cli) ⭐5 — Claude Code-style terminal interface for DeepSeek Harness (✅ active)
-- [deepseek-harness-desktop](https://github.com/RZX00/deepseek-harness-desktop) ⭐5 — DeepSeek Harness with a Windows desktop build: an Electron shell over the dsh web profile, packaged as an installer (✅ active)
-- [deepseek-harness-tui (boxeryao)](https://github.com/boxeryao/deepseek-harness-tui) ⭐5 — Lightweight fast terminal plugin connected directly to the DSH runtime. (✅ active)
-- [deepseek-harness-fnos](https://github.com/techysy/deepseek-harness-fnos) ⭐4 — DeepSeek Harness (DeepSeek 官方 agent 浏览器 UI) fnOS 应用 — 本地常驻服务, 官方统一网关接入 (✅ active)
+- [deepseek-harness-desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) ⭐4 — Windows desktop app for DeepSeek Harness: installer, themes, in-app plugin marketplace, model routing, and updates. (✅ active)
 - [dsh-desktop-electron](https://github.com/Void0312Aurora/dsh-desktop-electron) ⭐4 — Cross-platform Electron shell for the DSH Web GUI: tray-resident standalone window. (✅ active)
+- [dshcockpit](https://github.com/Lxiayu/DshCockpit) ⭐4 — DshCockpit — DeepSeek Harness 桌面驾驶舱 (desktop cockpit)：运行时自动更新、成本控制、全局快捷问询、定时任务、会话全文检索、数据安全。自动更新 / 成本中心 / Quick Ask / 定时任务 / 会话搜索 (✅ active)
+- [deepseek-harness-workbench](https://github.com/xuan-ao-1/deepseek-harness-workbench) ⭐3 — DeepSeek Harness 官方架构的 Windows 桌面发行版 (Desktop distribution of the official DeepSeek Harness) (✅ active)
+- [dsh-portable-launcher](https://github.com/15828148/dsh-portable-launcher) ⭐2 — One-click portable launcher for DeepSeek Harness (dsh) Web UI on Windows. Auto-installs Node.js and dsh with China mirror fallback, 3-stage progress with retries and resume, zero-download fast path when ready. No admin needed. (✅ active)
+- [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop-windows) ⭐1 — Unofficial in-process desktop app for DeepSeek Harness: the host composition boots inside the Electron main process with zero ports and an IPC bridge. Not affiliated with DeepSeek. (✅ active)
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) ⭐1 — Pi TUI front end: streaming markdown, thinking collapse, tool cards, slash commands and approval overlays. (✅ active)
-- [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui)  — TUI built with grok-build. (✅ active)
+- [dsh-desktop-launcher](https://github.com/becomeless/dsh-desktop-launcher)  — Windows/macOS desktop launcher for DeepSeek Harness: double-click to launch, zero console windows, auto-stop on close | 双击图标一键启动 DeepSeek Harness 的桌面启动器（Windows / macOS） (✅ active)
+- [dsh-quickstart](https://github.com/qzhqzh/dsh-quickstart)  — Desktop launcher for DeepSeek Harness - start dsh web with no console window and auto-open the browser. Tested on Windows; macOS/Linux in progress. (✅ active)
 
 ### MCP & Integrations
 
@@ -1101,42 +1281,52 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) | ⭐758 | Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. | ✅ active |
-| 2 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | ⭐64 | OpenPencil design preview and editing integration. | ✅ active |
-| 3 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | ⭐14 | Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 | ✅ active |
-| 4 | [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) | ⭐6 | ACP server implementation for DeepSeek Harness: exposes the full DSH agent to ACP clients while reusing credentials and sessions. | ✅ active |
-| 5 | [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) | ⭐6 | Community Docker and Kubernetes packaging for @deepseek-ai/dsh with a hardened image. | ✅ active |
-| 6 | [dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | ⭐6 | OAuth 2.1 Streamable HTTP MCP client plugin for DeepSeek Harness. | ✅ active |
-| 7 | [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) | ⭐5 | Community GitHub Action: AI code review, CI diagnosis, auto-fix and issue-to-PR implementation. | ✅ active |
-| 8 | [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) | ⭐5 | MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth. | ✅ active |
-| 9 | [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) | ⭐4 | DeepSeek Harness for VS Code as extension | ✅ active |
-| 10 | [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) | ⭐4 | Relay that turns Telegram into a remote conversation channel for DSH with notifications. | ✅ active |
+| 1 | [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) | ⭐787 | Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. | ✅ active |
+| 2 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | ⭐74 | OpenPencil design preview and editing integration. | ✅ active |
+| 3 | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | ⭐48 | Super-injector plugin (cordis) for context injection. | ✅ active |
+| 4 | [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot) | ⭐32 | 让 QQ 机器人接入 DeepSeek Harness（dsh）的官方插件 | ✅ active |
+| 5 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | ⭐16 | Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 | ✅ active |
+| 6 | [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) | ⭐11 | Community GitHub Action: AI code review, CI diagnosis, auto-fix and issue-to-PR implementation. | ✅ active |
+| 7 | [ikanban](https://github.com/isomoes/ikanban) | ⭐10 | Monorepo for the iKanban browser-surface fork for DeepSeek Harness. | ✅ active |
+| 8 | [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) | ⭐8 | Community Docker and Kubernetes packaging for @deepseek-ai/dsh with a hardened image. | ✅ active |
+| 9 | [dsh-git-graph](https://github.com/1841220388zzzcccxxx-star/dsh-git-graph) | ⭐8 | Embedded git repository graph visualizer for the DeepSeek Harness Web GUI | 嵌入式 Git 仓库图谱可视化插件（提交历史图 / 分支过滤 / 文件 diff / VSCode 式未提交改动） | ✅ active |
+| 10 | [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) | ⭐8 | Replace DSH's built-in web search with search MCP servers (Tavily/Brave/Exa/Perplexity/DuckDuckGo). | ✅ active |
 
-#### Complete list (25)
+#### Complete list (35)
 
-- [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐758 — Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. (✅ active)
-- [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) ⭐64 — OpenPencil design preview and editing integration. (✅ active)
-- [dsh-lark](https://github.com/omdsh-dev/dsh-lark) ⭐14 — Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 (✅ active)
-- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) ⭐6 — ACP server implementation for DeepSeek Harness: exposes the full DSH agent to ACP clients while reusing credentials and sessions. (✅ active)
-- [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) ⭐6 — Community Docker and Kubernetes packaging for @deepseek-ai/dsh with a hardened image. (✅ active)
+- [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐787 — Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. (✅ active)
+- [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) ⭐74 — OpenPencil design preview and editing integration. (✅ active)
+- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) ⭐48 — Super-injector plugin (cordis) for context injection. (✅ active)
+- [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot) ⭐32 — 让 QQ 机器人接入 DeepSeek Harness（dsh）的官方插件 (✅ active)
+- [dsh-lark](https://github.com/omdsh-dev/dsh-lark) ⭐16 — Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 (✅ active)
+- [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) ⭐11 — Community GitHub Action: AI code review, CI diagnosis, auto-fix and issue-to-PR implementation. (✅ active)
+- [ikanban](https://github.com/isomoes/ikanban) ⭐10 — Monorepo for the iKanban browser-surface fork for DeepSeek Harness. (✅ active)
+- [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) ⭐8 — Community Docker and Kubernetes packaging for @deepseek-ai/dsh with a hardened image. (✅ active)
+- [dsh-git-graph](https://github.com/1841220388zzzcccxxx-star/dsh-git-graph) ⭐8 — Embedded git repository graph visualizer for the DeepSeek Harness Web GUI | 嵌入式 Git 仓库图谱可视化插件（提交历史图 / 分支过滤 / 文件 diff / VSCode 式未提交改动） (✅ active)
+- [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) ⭐8 — Replace DSH's built-in web search with search MCP servers (Tavily/Brave/Exa/Perplexity/DuckDuckGo). (✅ active)
+- [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) ⭐8 — DeepSeek Harness 插件：DeepSeek 大脑 + 自动识图。GUI 附加图片自动经 OpenAI 兼容 VLM 转译成文字后交给 DeepSeek 作答；支持百炼/智谱/OpenRouter 等任意 OpenAI 兼容端点（默认 qwen3.7-flash），无 key 自动探测本地 Ollama（图片不出本机）；安装时有一问式确认 (✅ active)
+- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) ⭐7 — ACP server implementation for DeepSeek Harness: exposes the full DSH agent to ACP clients while reusing credentials and sessions. (✅ active)
+- [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) ⭐7 — DeepSeek Harness for VS Code as extension (✅ active)
+- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) ⭐6 — MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth. (✅ active)
 - [dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) ⭐6 — OAuth 2.1 Streamable HTTP MCP client plugin for DeepSeek Harness. (✅ active)
-- [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) ⭐5 — Community GitHub Action: AI code review, CI diagnosis, auto-fix and issue-to-PR implementation. (✅ active)
-- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) ⭐5 — MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth. (✅ active)
-- [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) ⭐4 — DeepSeek Harness for VS Code as extension (✅ active)
-- [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) ⭐4 — Relay that turns Telegram into a remote conversation channel for DSH with notifications. (✅ active)
-- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) ⭐4 — Telegram mobile remote for live DSH Web sessions: session picker, bind/unbind, same trajectory as desktop. (✅ active)
+- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) ⭐6 — Telegram mobile remote for live DSH Web sessions: session picker, bind/unbind, same trajectory as desktop. (✅ active)
+- [telegram](https://github.com/LoserFox/telegram) ⭐6 — Telegram Bot API 桥接插件：长轮询、per-chat 会话、HTML 格式化 (✅ active)
+- [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) ⭐5 — Relay that turns Telegram into a remote conversation channel for DSH with notifications. (✅ active)
+- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) ⭐5 — Expose DeepSeek Harness agent capabilities as an MCP server (brain=Hermes, arms=Harness). (✅ active)
+- [dsh-browser](https://github.com/xylt369/dsh-browser) ⭐4 — Browser capability for DeepSeek Harness: headed Edge/Playwright provider, SSRF-safe navigation, a11y-ref clicking, permission gate with auto-remember, gated evaluate (✅ active)
+- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) ⭐4 — LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure contexts. (✅ active)
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) ⭐4 — Read-only runtime management panel for the official DSH MCP client: /mcp command and a Settings tab. (✅ active)
+- [dsh-subscription-auth](https://github.com/Khellendros97/dsh-subscription-auth) ⭐4 — dsh对接openai、grok、anthropic、kimi订阅渠道 (✅ active)
 - [PicGo DSH Plugin](https://github.com/PicGo/dsh-plugin) ⭐4 — Official PicGo plugin: upload images/files to your image host from DSH and get public URLs. (✅ active)
-- [dsh-browser](https://github.com/xylt369/dsh-browser) ⭐3 — Browser capability for DeepSeek Harness: headed Edge/Playwright provider, SSRF-safe navigation, a11y-ref clicking, permission gate with auto-remember, gated evaluate (✅ active)
-- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) ⭐3 — Read-only runtime management panel for the official DSH MCP client: /mcp command and a Settings tab. (✅ active)
-- [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) ⭐3 — Replace DSH's built-in web search with search MCP servers (Tavily/Brave/Exa/Perplexity/DuckDuckGo). (✅ active)
-- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) ⭐2 — Expose DeepSeek Harness agent capabilities as an MCP server (brain=Hermes, arms=Harness). (✅ active)
+- [dsh-agentlink](https://github.com/hootandy321/dsh-Agentlink) ⭐3 — Caller-side bridge from Codex and other agent frameworks to DeepSeek Harness, with observable sessions, follow-up, cancellation, and human-gated approvals. (✅ active)
+- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) ⭐3 — DeepSeek Harness subagent delegation enhancement (✅ active)
+- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode) ⭐3 — VS Code chat windows backed by the DSH agent: OpenCode-style independent sessions with model auto-routing. (✅ active)
+- [dsh-github-integration](https://github.com/omdsh-dev/dsh-github-integration) ⭐2 — GitHub integration plugin for DSH. (✅ active)
+- [dsh-plugin-acn](https://github.com/acnlabs/dsh-plugin-acn) ⭐2 — DeepSeek Harness plugin: join ACN so this agent can discover, message, and collaborate with other agents. Defaults to the China region. (✅ active)
+- [vscode-deepseek-harness](https://github.com/kalynnka/vscode-deepseek-harness) ⭐2 — Unofficial: drive your own dsh as a native VS Code chat agent. (✅ active)
+- [deepseek-harness-rs](https://github.com/Tokimorphling/deepseek-harness-rs) ⭐1 — A Rust port of DeepSeek Harness. (🧪 experimental)
 - [dsh-chrome](https://github.com/YJSoooooo/dsh-chrome) ⭐1 — Chrome profile bridge: control an existing signed-in Chrome profile through Chrome DevTools Protocol. (✅ active)
-- [vscode-deepseek-harness](https://github.com/kalynnka/vscode-deepseek-harness) ⭐1 — Unofficial: drive your own dsh as a native VS Code chat agent. (✅ active)
-- [deepseek-harness-rs](https://github.com/Tokimorphling/deepseek-harness-rs)  — A Rust port of DeepSeek Harness. (🧪 experimental)
-- [dsh-github-integration](https://github.com/omdsh-dev/dsh-github-integration)  — GitHub integration plugin for DSH. (✅ active)
-- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access)  — LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure contexts. (✅ active)
-- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector)  — Super-injector plugin (cordis) for context injection. (✅ active)
-- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode)  — VS Code chat windows backed by the DSH agent: OpenCode-style independent sessions with model auto-routing. (✅ active)
+- [dsh-plugin-vision](https://github.com/tdf1995/dsh-plugin-vision)  — Vision for text-only LLMs in DeepSeek Harness (DSH): describe images / OCR / VQA via free Gemini & GLM vision APIs (✅ active)
 - [opendsh](https://github.com/TheChengXi/opendsh)  — Open the DeepSeek Harness Web UI inside VS Code with one-command start/stop. (✅ active)
 - [URL Manager MCP](https://github.com/Piccolo123/url-manager-mcp)  — MCP companion for URL Manager: 21 tools for save/search/categorize/share with magic-link delivery. (✅ active)
 
@@ -1147,23 +1337,23 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [hello-dsh](https://github.com/pingfanfan/hello-dsh) | ⭐37 | Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. | ✅ active |
+| 1 | [hello-dsh](https://github.com/pingfanfan/hello-dsh) | ⭐48 | Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. | ✅ active |
 | 2 | [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) | ⭐16 | Template for DeepSeek Harness plugin development. | ✅ active |
 | 3 | [turtle-ui](https://github.com/turtle1999/turtle-ui) | ⭐6 | Official UI plugin reference implementation. | ✅ active |
-| 4 | [dsh-101](https://github.com/bill9109/dsh-101) | ⭐2 | DSH documentation reading mode. | ✅ active |
-| 5 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐2 | Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. | ✅ active |
-| 6 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world style starter plugin for DSH. | ✅ active |
-| 7 | [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) |  | Plugin template repository derived from the original turtle-ui official repo. | ✅ active |
+| 4 | [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) | ⭐5 | Plugin template repository derived from the original turtle-ui official repo. | ✅ active |
+| 5 | [dsh-101](https://github.com/bill9109/dsh-101) | ⭐3 | DSH documentation reading mode. | ✅ active |
+| 6 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐3 | Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. | ✅ active |
+| 7 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world style starter plugin for DSH. | ✅ active |
 
 #### Complete list (7)
 
-- [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐37 — Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. (✅ active)
+- [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐48 — Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. (✅ active)
 - [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) ⭐16 — Template for DeepSeek Harness plugin development. (✅ active)
 - [turtle-ui](https://github.com/turtle1999/turtle-ui) ⭐6 — Official UI plugin reference implementation. (✅ active)
-- [dsh-101](https://github.com/bill9109/dsh-101) ⭐2 — DSH documentation reading mode. (✅ active)
-- [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐2 — Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. (✅ active)
+- [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) ⭐5 — Plugin template repository derived from the original turtle-ui official repo. (✅ active)
+- [dsh-101](https://github.com/bill9109/dsh-101) ⭐3 — DSH documentation reading mode. (✅ active)
+- [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐3 — Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. (✅ active)
 - [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello)  — Hello-world style starter plugin for DSH. (✅ active)
-- [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template)  — Plugin template repository derived from the original turtle-ui official repo. (✅ active)
 
 ### Tutorials & Learning
 
@@ -1172,30 +1362,31 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) | ⭐465 | Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. | ✅ active |
-| 2 | [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) | ⭐167 | From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). | ✅ active |
-| 3 | [dshfind](https://github.com/hikariming/dshfind) | ⭐56 | Learn DSH principles, plugin marketplace and best practices — from chapter-by-chapter Cordis paper reading to an auto-aggregated plugin market. | ✅ active |
-| 4 | [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) | ⭐32 | DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） | ✅ active |
-| 5 | [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) | ⭐17 | Detailed Chinese learning tutorial for DeepSeek Harness. | ✅ active |
-| 6 | [dsh-explain](https://github.com/yuezengwu/dsh-explain) | ⭐9 | Local-first learning mode: cross-session global learning threads, explain-by-source, ExplainContext and compression. | ✅ active |
-| 7 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | DeepSeek Harness prompts for different modes. | ✅ active |
-| 8 | [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) | ⭐5 | Learning website built from a systematic breakdown of the deepseek-harness repository, for developers curious how AI agent frameworks work. | ✅ active |
-| 9 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐5 | 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. | ✅ active |
-| 10 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | ⭐3 | Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. | ✅ active |
+| 1 | [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) | ⭐706 | Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. | ✅ active |
+| 2 | [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) | ⭐273 | From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). | ✅ active |
+| 3 | [dshfind](https://github.com/hikariming/dshfind) | ⭐80 | Learn DSH principles, plugin marketplace and best practices — from chapter-by-chapter Cordis paper reading to an auto-aggregated plugin market. | ✅ active |
+| 4 | [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) | ⭐43 | Detailed Chinese learning tutorial for DeepSeek Harness. | ✅ active |
+| 5 | [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) | ⭐40 | DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） | ✅ active |
+| 6 | [dsh-explain](https://github.com/yuezengwu/dsh-explain) | ⭐11 | Local-first learning mode: cross-session global learning threads, explain-by-source, ExplainContext and compression. | ✅ active |
+| 7 | [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) | ⭐7 | Learning website built from a systematic breakdown of the deepseek-harness repository, for developers curious how AI agent frameworks work. | ✅ active |
+| 8 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | DeepSeek Harness prompts for different modes. | ✅ active |
+| 9 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐6 | 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. | ✅ active |
+| 10 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | ⭐4 | Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. | ✅ active |
 
-#### Complete list (11)
+#### Complete list (12)
 
-- [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐465 — Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. (✅ active)
-- [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐167 — From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). (✅ active)
-- [dshfind](https://github.com/hikariming/dshfind) ⭐56 — Learn DSH principles, plugin marketplace and best practices — from chapter-by-chapter Cordis paper reading to an auto-aggregated plugin market. (✅ active)
-- [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) ⭐32 — DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） (✅ active)
-- [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) ⭐17 — Detailed Chinese learning tutorial for DeepSeek Harness. (✅ active)
-- [dsh-explain](https://github.com/yuezengwu/dsh-explain) ⭐9 — Local-first learning mode: cross-session global learning threads, explain-by-source, ExplainContext and compression. (✅ active)
+- [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐706 — Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. (✅ active)
+- [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐273 — From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). (✅ active)
+- [dshfind](https://github.com/hikariming/dshfind) ⭐80 — Learn DSH principles, plugin marketplace and best practices — from chapter-by-chapter Cordis paper reading to an auto-aggregated plugin market. (✅ active)
+- [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) ⭐43 — Detailed Chinese learning tutorial for DeepSeek Harness. (✅ active)
+- [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) ⭐40 — DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） (✅ active)
+- [dsh-explain](https://github.com/yuezengwu/dsh-explain) ⭐11 — Local-first learning mode: cross-session global learning threads, explain-by-source, ExplainContext and compression. (✅ active)
+- [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) ⭐7 — Learning website built from a systematic breakdown of the deepseek-harness repository, for developers curious how AI agent frameworks work. (✅ active)
 - [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) ⭐6 — DeepSeek Harness prompts for different modes. (✅ active)
-- [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) ⭐5 — Learning website built from a systematic breakdown of the deepseek-harness repository, for developers curious how AI agent frameworks work. (✅ active)
-- [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) ⭐5 — 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. (✅ active)
-- [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐3 — Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. (✅ active)
-- [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐1 — Checks DeepSeek tool loops, reasoning_content, strict schemas and captured SSE; also works as a DSH plugin. (✅ active)
+- [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) ⭐6 — 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. (✅ active)
+- [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐4 — Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. (✅ active)
+- [gitlearnos](https://github.com/Guojiz/gitlearnos) ⭐3 — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory. (✅ active)
+- [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐2 — Checks DeepSeek tool loops, reasoning_content, strict schemas and captured SSE; also works as a DSH plugin. (✅ active)
 
 ### Awesome Lists & Registries
 
@@ -1204,44 +1395,53 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | ⭐751 | Large curated list of installable DSH plugins (bilingual). | ✅ active |
-| 2 | [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) | ⭐751 | Radar index repo: auto-scanning all discovered dsh plugin candidates with an evidence-based compatibility matrix. | ✅ active |
-| 3 | [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) | ⭐360 | Curated DSH ecosystem directory: plugins, tools and infrastructure from dsh-external/hub and the public dsh-plugin topic. | ✅ active |
-| 4 | [notes (zhaoolee)](https://github.com/zhaoolee/notes) | ⭐138 | Open-source Smartisan Notes clone: Docker private deployment, skill invocation, dsh plugin support and one-click WeChat-format export. | ✅ active |
-| 5 | [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) | ⭐86 | Find the right DSH plugin in 30 seconds: what problem each plugin solves, who it is for and where to start. | ✅ active |
-| 6 | [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) | ⭐47 | Curated list of DeepSeek Harness plugins. | ✅ active |
-| 7 | [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | ⭐47 | Meticulously curated list of plugins, extensions, tools and development resources for DSH. | ✅ active |
-| 8 | [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | ⭐43 | Plugin ecosystem for DSH: 700+ plugins registered only through extension seams, without modifying the agent-loop skeleton. | ✅ active |
-| 9 | [plugin-registry](https://github.com/vlln/plugin-registry) | ⭐31 | DSH plugin ecosystem infrastructure: thin console to manage official repository plugins (0 patch) plus the make-dsh-plugin skill. | ✅ active |
-| 10 | [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) | ⭐30 | Curated list of plugins, skills, MCP servers, patch/profile layers, orchestrators and UIs for DeepSeek Harness. | ✅ active |
+| 1 | [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent) | ⭐5,853 | Official curated guides for integrating DeepSeek models into agent/coding-assistant tools (AstrBot, Cherry Studio, Claude Code, Codex, DeepSeek-TUI, Reasonix and more). | ✅ active |
+| 2 | [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | ⭐2,516 | Large curated list of installable DSH plugins (bilingual). | ✅ active |
+| 3 | [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) | ⭐942 | Radar index repo: auto-scanning all discovered dsh plugin candidates with an evidence-based compatibility matrix. | ✅ active |
+| 4 | [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) | ⭐465 | Curated DSH ecosystem directory: plugins, tools and infrastructure from dsh-external/hub and the public dsh-plugin topic. | ✅ active |
+| 5 | [notes (zhaoolee)](https://github.com/zhaoolee/notes) | ⭐142 | Open-source Smartisan Notes clone: Docker private deployment, skill invocation, dsh plugin support and one-click WeChat-format export. | ✅ active |
+| 6 | [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) | ⭐139 | Find the right DSH plugin in 30 seconds: what problem each plugin solves, who it is for and where to start. | ✅ active |
+| 7 | [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) | ⭐62 | Ultimate guide: quick start, resources, curated plugins and practical tools. | ✅ active |
+| 8 | [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | ⭐62 | Meticulously curated list of plugins, extensions, tools and development resources for DSH. | ✅ active |
+| 9 | [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) | ⭐61 | Curated list of DeepSeek Harness plugins. | ✅ active |
+| 10 | [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) | ⭐47 | Curated list of plugins, skills, MCP servers, patch/profile layers, orchestrators and UIs for DeepSeek Harness. | ✅ active |
 
-#### Complete list (25)
+#### Complete list (34)
 
-- [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐751 — Large curated list of installable DSH plugins (bilingual). (✅ active)
-- [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐751 — Radar index repo: auto-scanning all discovered dsh plugin candidates with an evidence-based compatibility matrix. (✅ active)
-- [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) ⭐360 — Curated DSH ecosystem directory: plugins, tools and infrastructure from dsh-external/hub and the public dsh-plugin topic. (✅ active)
-- [notes (zhaoolee)](https://github.com/zhaoolee/notes) ⭐138 — Open-source Smartisan Notes clone: Docker private deployment, skill invocation, dsh plugin support and one-click WeChat-format export. (✅ active)
-- [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) ⭐86 — Find the right DSH plugin in 30 seconds: what problem each plugin solves, who it is for and where to start. (✅ active)
-- [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) ⭐47 — Curated list of DeepSeek Harness plugins. (✅ active)
-- [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) ⭐47 — Meticulously curated list of plugins, extensions, tools and development resources for DSH. (✅ active)
-- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) ⭐43 — Plugin ecosystem for DSH: 700+ plugins registered only through extension seams, without modifying the agent-loop skeleton. (✅ active)
-- [plugin-registry](https://github.com/vlln/plugin-registry) ⭐31 — DSH plugin ecosystem infrastructure: thin console to manage official repository plugins (0 patch) plus the make-dsh-plugin skill. (✅ active)
-- [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) ⭐30 — Curated list of plugins, skills, MCP servers, patch/profile layers, orchestrators and UIs for DeepSeek Harness. (✅ active)
-- [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) ⭐29 — Ultimate guide: quick start, resources, curated plugins and practical tools. (✅ active)
-- [oh-my-dsh](https://github.com/like-study1/Oh-My-DSH) ⭐21 — 🐳 DeepSeek Harness 插件聚合社区 — 自动同步 dsh-plugin 生态 · 精选目录 · 每 8 小时自动维护 | Oh-My-DSH: a community-maintained catalog of DeepSeek Harness plugins, auto-synced from the dsh-plugin topic (✅ active)
-- [deepseek-plugin-store](https://github.com/Ericwong5021/deepseek-plugin-store) ⭐12 — DeepSeek Harness 独立社区插件商店：发现、安装并提交经过验证的插件、工具与扩展。 | Independent community plugin directory. (✅ active)
-- [dsh-suite](https://github.com/whyihaveyou/dsh-suite) ⭐11 — Living DSH plugin directory (785+ plugins, refreshed hourly) with daily compatibility CI, a bilingual catalog site and an in-app plugin store. (✅ active)
-- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) ⭐9 — Curated navigation of community meme plugins (skins, desktop pets, mini-games), bilingual. (✅ active)
-- [awesome-dsh-plugins (white0dew)](https://github.com/white0dew/awesome-dsh-plugins) ⭐7 — Public GitHub directory for DSH plugins with install commands. (✅ active)
-- [awesome-deepseek-harness (jiji262)](https://github.com/jiji262/awesome-deepseek-harness) ⭐6 — Curated DeepSeek Harness resources. (✅ active)
-- [awesome-dsh-plugin (billLiao)](https://github.com/billLiao/awesome-dsh-plugin) ⭐5 — Curated list of plugins for DeepSeek Harness. (✅ active)
-- [awesome-dsh-plugins (kejixiaoliang)](https://github.com/kejixiaoliang/awesome-dsh-plugins) ⭐5 — Curated DSH plugin catalog: 14 categories, 280+ community plugins covering MCP/Skill/TUI/multi-agent/context memory/UI skins. (✅ active)
-- [dsh-plugin-marketplace](https://github.com/YELEBAI/dsh-plugin-marketplace) ⭐4 — Verified plugin marketplace and autonomous registry for DeepSeek Harness (✅ active)
-- [dsh-plugins](https://github.com/HackSing/dsh-plugins) ⭐4 — A bilingual, continuously maintained directory of plugins for DeepSeek Harness (DSH). (✅ active)
-- [zat-dsh-engine](https://github.com/mishibeikejie/zat-dsh-engine) ⭐4 — Visual plugin marketplace for DeepSeek Harness — browse, search and install community plugins (✅ active)
-- [dsh-market](https://github.com/2BingLing/dsh-market) ⭐3 — DeepSeek Harness 插件市场 · 持续收录 500+ DSH 插件：中文搜索 + 实用五维评分 + 一键安装。Web 版与 DSH 侧边栏插件双形态。Plugin marketplace for DeepSeek Harness: 500+ plugins, Chinese search, 5-dim scoring, one-click install. (✅ active)
+- [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent) ⭐5,853 — Official curated guides for integrating DeepSeek models into agent/coding-assistant tools (AstrBot, Cherry Studio, Claude Code, Codex, DeepSeek-TUI, Reasonix and more). (✅ active)
+- [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐2,516 — Large curated list of installable DSH plugins (bilingual). (✅ active)
+- [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐942 — Radar index repo: auto-scanning all discovered dsh plugin candidates with an evidence-based compatibility matrix. (✅ active)
+- [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) ⭐465 — Curated DSH ecosystem directory: plugins, tools and infrastructure from dsh-external/hub and the public dsh-plugin topic. (✅ active)
+- [notes (zhaoolee)](https://github.com/zhaoolee/notes) ⭐142 — Open-source Smartisan Notes clone: Docker private deployment, skill invocation, dsh plugin support and one-click WeChat-format export. (✅ active)
+- [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) ⭐139 — Find the right DSH plugin in 30 seconds: what problem each plugin solves, who it is for and where to start. (✅ active)
+- [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) ⭐62 — Ultimate guide: quick start, resources, curated plugins and practical tools. (✅ active)
+- [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) ⭐62 — Meticulously curated list of plugins, extensions, tools and development resources for DSH. (✅ active)
+- [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) ⭐61 — Curated list of DeepSeek Harness plugins. (✅ active)
+- [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) ⭐47 — Curated list of plugins, skills, MCP servers, patch/profile layers, orchestrators and UIs for DeepSeek Harness. (✅ active)
+- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) ⭐47 — Plugin ecosystem for DSH: 700+ plugins registered only through extension seams, without modifying the agent-loop skeleton. (✅ active)
+- [plugin-registry](https://github.com/vlln/plugin-registry) ⭐40 — DSH plugin ecosystem infrastructure: thin console to manage official repository plugins (0 patch) plus the make-dsh-plugin skill. (✅ active)
+- [oh-my-dsh](https://github.com/like-study1/Oh-My-DSH) ⭐31 — 🐳 DeepSeek Harness 插件聚合社区 — 自动同步 dsh-plugin 生态 · 精选目录 · 每 8 小时自动维护 | Oh-My-DSH: a community-maintained catalog of DeepSeek Harness plugins, auto-synced from the dsh-plugin topic (✅ active)
+- [zat-dsh-engine](https://github.com/mishibeikejie/zat-dsh-engine) ⭐29 — Visual plugin marketplace for DeepSeek Harness — browse, search and install community plugins (✅ active)
+- [awesome-dsh-plugin](https://github.com/beancookie/awesome-dsh-plugin) ⭐25 — Awesome DeepSeek Harness (DSH) Plugin (✅ active)
+- [dsh-suite](https://github.com/whyihaveyou/dsh-suite) ⭐23 — Living DSH plugin directory (785+ plugins, refreshed hourly) with daily compatibility CI, a bilingual catalog site and an in-app plugin store. (✅ active)
+- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) ⭐20 — Curated navigation of community meme plugins (skins, desktop pets, mini-games), bilingual. (✅ active)
+- [dsh-plugin-marketplace](https://github.com/YELEBAI/dsh-plugin-marketplace) ⭐17 — Verified plugin marketplace and autonomous registry for DeepSeek Harness (✅ active)
+- [dsh-plugin-hub](https://github.com/cclank/dsh-plugin-hub) ⭐15 — DeepSeek Harness community plugin registry with evidence-based screening (✅ active)
+- [deepseek-plugin-store](https://github.com/Ericwong5021/deepseek-plugin-store) ⭐13 — DeepSeek Harness 独立社区插件商店：发现、安装并提交经过验证的插件、工具与扩展。 | Independent community plugin directory. (✅ active)
+- [dsh-plugin-marketplace](https://github.com/AwesomeHou/dsh-plugin-marketplace) ⭐13 — Plugin marketplace for DeepSeek Harness — live-syncs the GitHub dsh-plugin topic (1800+ repos) into a searchable, paginated settings tab with one-click install and agent tools (market_search / market_install). (✅ active)
+- [awesome-dsh-plugins (kejixiaoliang)](https://github.com/kejixiaoliang/awesome-dsh-plugins) ⭐12 — Curated DSH plugin catalog: 14 categories, 280+ community plugins covering MCP/Skill/TUI/multi-agent/context memory/UI skins. (✅ active)
+- [dsh-market](https://github.com/2BingLing/dsh-market) ⭐11 — DeepSeek Harness 插件市场 · 持续收录 500+ DSH 插件：中文搜索 + 实用五维评分 + 一键安装。Web 版与 DSH 侧边栏插件双形态。Plugin marketplace for DeepSeek Harness: 500+ plugins, Chinese search, 5-dim scoring, one-click install. (✅ active)
+- [awesome-deepseek-harness (jiji262)](https://github.com/jiji262/awesome-deepseek-harness) ⭐10 — Curated DeepSeek Harness resources. (✅ active)
+- [awesome-deepseek-harness-plugins](https://github.com/imsai-sh/awesome-deepseek-harness-plugins) ⭐9 — Curated community plugin directory and live marketplace for DeepSeek Harness. (✅ active)
+- [awesome-dsh-plugins (white0dew)](https://github.com/white0dew/awesome-dsh-plugins) ⭐9 — Public GitHub directory for DSH plugins with install commands. (✅ active)
+- [awesome-dsh-plugin (billLiao)](https://github.com/billLiao/awesome-dsh-plugin) ⭐7 — Curated list of plugins for DeepSeek Harness. (✅ active)
+- [dsh-plugins](https://github.com/HackSing/dsh-plugins) ⭐5 — A bilingual, continuously maintained directory of plugins for DeepSeek Harness (DSH). (✅ active)
+- [awesome-deepseek-harness-plugins](https://github.com/walkinglabs/awesome-deepseek-harness-plugins) ⭐4 — A curated, bilingual list of verified plugins, tools, design workflows, and learning resources for DeepSeek Harness (DSH). (✅ active)
+- [dsh-marketplace](https://github.com/ouyangyipeng/dsh-marketplace) ⭐3 — A safe, live plugin marketplace for DeepSeek Harness (✅ active)
+- [dsh-plugin-market](https://github.com/chnjames/dsh-plugin-market) ⭐3 — DSH 插件市场 — DeepSeek Harness 设置内一键安装社区插件，并提供公开目录站（浏览 / 复制安装命令） (✅ active)
+- [dsh-plugin-market](https://github.com/TheYoungChen/dsh-plugin-market) ⭐3 — DeepSeek Harness plugin market - browse, search & install dsh-plugin topic plugins (dsh 插件市场：浏览/搜索/安装插件) (✅ active)
 - [dsh-plugins](https://github.com/lwmxiaobei/dsh-plugins) ⭐3 — DeepSeek Harness 社区插件目录，自动汇总并基础校验 GitHub 插件，支持搜索、筛选、双语详情与最新版本安装命令复制。Community directory for DeepSeek Harness plugins with automated discovery, basic validation, search, filters, bilingual details, and latest version install commands. (✅ active)
-- [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent)  — Official curated guides for integrating DeepSeek models into agent/coding-assistant tools (AstrBot, Cherry Studio, Claude Code, Codex, DeepSeek-TUI, Reasonix and more). (✅ active)
+- [sandbase-skills](https://github.com/sandbaseai/sandbase-skills) ⭐3 — 88 installable open-source Agent Skills for research, social intelligence, marketing, and business workflows—compatible with Codex, Claude Code, Cursor, Gemini CLI, and DeepSeek Harness. (✅ active)
 
 ### Related Agent Harnesses
 
@@ -1250,24 +1450,24 @@ awesome-deepseek-harness/
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
-| 1 | [DeerFlow](https://github.com/bytedance/deer-flow) | ⭐80,001 | Open-source long-horizon SuperAgent harness by ByteDance: skills, memory, sandboxes, subagents, tools and a message gateway. | ✅ active |
-| 2 | [Cordis](https://github.com/cordiverse/cordis) | ⭐3,182 | Meta-Framework of Spatiotemporal Composability — the plugin runtime DeepSeek Harness is built on. | ✅ active |
-| 3 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐573 | Open-source CMA-compatible agent runtime for any model: MCP tools, sandboxed sessions, audit, replay. | ✅ active |
-| 4 | [mnemon](https://github.com/mnemon-dev/mnemon) | ⭐430 | LLM-supervised persistent memory for AI agents: graph-based recall and cross-session knowledge in a single binary. | ✅ active |
-| 5 | [claude-paper](https://github.com/alaliqing/claude-paper) | ⭐294 | Cross-agent research paper toolkit for Claude Code, Codex, OpenCode and DeepSeek Harness: quick summaries and deep dives. | ✅ active |
-| 6 | [Axern](https://github.com/cofy-x/axern) | ⭐272 | Open-source sandboxes for AI agents: untrusted code execution and durable services. | ✅ active |
-| 7 | [open-managed-agents](https://github.com/openma-ai/open-managed-agents) | ⭐235 | Open-source Claude Managed Agents API implementation and self-hosted Claude Tag-style agent runtime. | ✅ active |
+| 1 | [DeerFlow](https://github.com/bytedance/deer-flow) | ⭐80,038 | Open-source long-horizon SuperAgent harness by ByteDance: skills, memory, sandboxes, subagents, tools and a message gateway. | ✅ active |
+| 2 | [Cordis](https://github.com/cordiverse/cordis) | ⭐3,780 | Meta-Framework of Spatiotemporal Composability — the plugin runtime DeepSeek Harness is built on. | ✅ active |
+| 3 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐586 | Open-source CMA-compatible agent runtime for any model: MCP tools, sandboxed sessions, audit, replay. | ✅ active |
+| 4 | [mnemon](https://github.com/mnemon-dev/mnemon) | ⭐449 | LLM-supervised persistent memory for AI agents: graph-based recall and cross-session knowledge in a single binary. | ✅ active |
+| 5 | [claude-paper](https://github.com/alaliqing/claude-paper) | ⭐301 | Cross-agent research paper toolkit for Claude Code, Codex, OpenCode and DeepSeek Harness: quick summaries and deep dives. | ✅ active |
+| 6 | [open-managed-agents](https://github.com/openma-ai/open-managed-agents) | ⭐236 | Open-source Claude Managed Agents API implementation and self-hosted Claude Tag-style agent runtime. | ✅ active |
+| 7 | [Axern](https://github.com/cofy-x/axern) | ⭐167 | Open-source sandboxes for AI agents: untrusted code execution and durable services. | ✅ active |
 | 8 | [deepseek-auto-evolving-harness](https://github.com/liuchen6667/deepseek-auto-evolving-harness) | ⭐28 | Auto-evolving LLM agent harness: benchmark-driven evolution via Claude Code and a self_evolution.md guide. | ✅ active |
 
 #### Complete list (8)
 
-- [DeerFlow](https://github.com/bytedance/deer-flow) ⭐80,001 — Open-source long-horizon SuperAgent harness by ByteDance: skills, memory, sandboxes, subagents, tools and a message gateway. (✅ active)
-- [Cordis](https://github.com/cordiverse/cordis) ⭐3,182 — Meta-Framework of Spatiotemporal Composability — the plugin runtime DeepSeek Harness is built on. (✅ active)
-- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) ⭐573 — Open-source CMA-compatible agent runtime for any model: MCP tools, sandboxed sessions, audit, replay. (✅ active)
-- [mnemon](https://github.com/mnemon-dev/mnemon) ⭐430 — LLM-supervised persistent memory for AI agents: graph-based recall and cross-session knowledge in a single binary. (✅ active)
-- [claude-paper](https://github.com/alaliqing/claude-paper) ⭐294 — Cross-agent research paper toolkit for Claude Code, Codex, OpenCode and DeepSeek Harness: quick summaries and deep dives. (✅ active)
-- [Axern](https://github.com/cofy-x/axern) ⭐272 — Open-source sandboxes for AI agents: untrusted code execution and durable services. (✅ active)
-- [open-managed-agents](https://github.com/openma-ai/open-managed-agents) ⭐235 — Open-source Claude Managed Agents API implementation and self-hosted Claude Tag-style agent runtime. (✅ active)
+- [DeerFlow](https://github.com/bytedance/deer-flow) ⭐80,038 — Open-source long-horizon SuperAgent harness by ByteDance: skills, memory, sandboxes, subagents, tools and a message gateway. (✅ active)
+- [Cordis](https://github.com/cordiverse/cordis) ⭐3,780 — Meta-Framework of Spatiotemporal Composability — the plugin runtime DeepSeek Harness is built on. (✅ active)
+- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) ⭐586 — Open-source CMA-compatible agent runtime for any model: MCP tools, sandboxed sessions, audit, replay. (✅ active)
+- [mnemon](https://github.com/mnemon-dev/mnemon) ⭐449 — LLM-supervised persistent memory for AI agents: graph-based recall and cross-session knowledge in a single binary. (✅ active)
+- [claude-paper](https://github.com/alaliqing/claude-paper) ⭐301 — Cross-agent research paper toolkit for Claude Code, Codex, OpenCode and DeepSeek Harness: quick summaries and deep dives. (✅ active)
+- [open-managed-agents](https://github.com/openma-ai/open-managed-agents) ⭐236 — Open-source Claude Managed Agents API implementation and self-hosted Claude Tag-style agent runtime. (✅ active)
+- [Axern](https://github.com/cofy-x/axern) ⭐167 — Open-source sandboxes for AI agents: untrusted code execution and durable services. (✅ active)
 - [deepseek-auto-evolving-harness](https://github.com/liuchen6667/deepseek-auto-evolving-harness) ⭐28 — Auto-evolving LLM agent harness: benchmark-driven evolution via Claude Code and a self_evolution.md guide. (✅ active)
 <!-- AUTO:resources:END -->` are produced by `scripts/generate-readme.py`. Edit the JSON, never the tables.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -160,157 +160,213 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [petdex](https://github.com/crafter-station/petdex) | ⭐3,777 | A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. | ✅ 活跃 |
-| 2 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | ⭐1,697 | DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。 | ✅ 活跃 |
-| 3 | [modlens](https://github.com/liustack/modlens) | ⭐1,158 | DSH 首个视觉插件，也是所有纯文本编码 Agent 的视觉桥梁：粘贴图片即可用。 | ✅ 活跃 |
-| 4 | [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | ⭐684 | 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。 | ✅ 活跃 |
-| 5 | [museai](https://github.com/yejiming/MuseAI) | ⭐538 | 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） | ✅ 活跃 |
-| 6 | [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | ⭐506 | DSH Web 鲸鱼娘皮肤系列（CC BY-NC-SA 4.0）。 | ✅ 活跃 |
-| 7 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐309 | 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。 | ✅ 活跃 |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐302 | 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。 | ✅ 活跃 |
-| 9 | [whale-girl](https://github.com/vlln/whale-girl) | ⭐118 | QQ 宠物形态桌面宠物：DSH Web 右下角悬浮，可拖拽/投喂/玩耍。 | ✅ 活跃 |
-| 10 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | ⭐116 | Codex 风格 @file 提及：在 DSH 输入框中搜索工作区文件并附加内容到提示词。 | ✅ 活跃 |
+| 1 | [petdex](https://github.com/crafter-station/petdex) | ⭐3,825 | A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. | ✅ 活跃 |
+| 2 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | ⭐2,484 | DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。 | ✅ 活跃 |
+| 3 | [dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) | ⭐1,831 | Two-phase DeepSeek Harness preset: Minimal-aligned bootstrap, then full Standard tools (Project2 98/99) | ✅ 活跃 |
+| 4 | [modlens](https://github.com/liustack/modlens) | ⭐1,736 | DSH 首个视觉插件，也是所有纯文本编码 Agent 的视觉桥梁：粘贴图片即可用。 | ✅ 活跃 |
+| 5 | [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | ⭐1,065 | 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。 | ✅ 活跃 |
+| 6 | [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | ⭐834 | DSH Web 鲸鱼娘皮肤系列（CC BY-NC-SA 4.0）。 | ✅ 活跃 |
+| 7 | [museai](https://github.com/yejiming/MuseAI) | ⭐556 | 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） | ✅ 活跃 |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐409 | 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。 | ✅ 活跃 |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐396 | 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。 | ✅ 活跃 |
+| 10 | [dsh-market](https://github.com/dsh-market/dsh-market) | ⭐218 | DSH 内置可视化插件市场：浏览、搜索、一键安装。 | ✅ 活跃 |
 
-#### 完整列表（138）
+#### 完整列表（194）
 
-- [petdex](https://github.com/crafter-station/petdex) ⭐3,777 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more.（✅ 活跃）
-- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐1,697 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
-- [modlens](https://github.com/liustack/modlens) ⭐1,158 — DSH 首个视觉插件，也是所有纯文本编码 Agent 的视觉桥梁：粘贴图片即可用。（✅ 活跃）
-- [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) ⭐684 — 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。（✅ 活跃）
-- [museai](https://github.com/yejiming/MuseAI) ⭐538 — 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用）（✅ 活跃）
-- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) ⭐506 — DSH Web 鲸鱼娘皮肤系列（CC BY-NC-SA 4.0）。（✅ 活跃）
-- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) ⭐309 — 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。（✅ 活跃）
-- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) ⭐302 — 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。（✅ 活跃）
-- [whale-girl](https://github.com/vlln/whale-girl) ⭐118 — QQ 宠物形态桌面宠物：DSH Web 右下角悬浮，可拖拽/投喂/玩耍。（✅ 活跃）
-- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) ⭐116 — Codex 风格 @file 提及：在 DSH 输入框中搜索工作区文件并附加内容到提示词。（✅ 活跃）
-- [modsearch](https://github.com/liustack/modsearch) ⭐85 — DSH 网页插件：为没有原生联网能力的模型提供搜索桥梁。（✅ 活跃）
-- [dsh-browser](https://github.com/Lum1104/dsh-browser) ⭐78 — Chrome 侧栏扩展：让 DSH 直接操控你的浏览器，无需视觉能力。（✅ 活跃）
-- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐74 — 对话内交互式 HTML UI：流式预览与沙箱渲染。（✅ 活跃）
-- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐71 — 对话内生成式 UI：布局、图表、表单、测验、Mermaid 与交互事件内联渲染。（✅ 活跃）
-- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐67 — DSH 生态插件发现工具。（✅ 活跃）
-- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐47 — 跨会话长期记忆 + 后台自我进化：五轨记忆、git 分支感知、回合内自我审查、技能自我进化。（✅ 活跃）
-- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) ⭐39 — DSH Web 选中批注：选文字→批注→随消息发送，回复按批注逐条对照。（✅ 活跃）
-- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) ⭐39 — 从 Web GUI 直接在工作区中打开 VS Code 目录/文件。（✅ 活跃）
-- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) ⭐37 — 回合完成桌面通知，按结果分控 + 关键词包含/排除过滤。（✅ 活跃）
-- [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐35 — 对话与代码状态回退插件，基于持久化变更账本。（✅ 活跃）
-- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) ⭐29 — 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。（✅ 活跃）
-- [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) ⭐28 — 在 DSH Web GUI 中一键浏览、安装与更新全部 GitHub dsh-plugin 插件。（✅ 活跃）
-- [ui-status-label](https://github.com/alingalingling/ui-status-label) ⭐28 — 把鲸鱼娘思考时的 deep diving 状态自定义成任意文字。（✅ 活跃）
-- [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) ⭐27 — 会话标题栏全手绘像素鲸鱼伙伴：眨眼、摆尾、回合完成喷水，零核心改动。（✅ 活跃）
-- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) ⭐22 — 用 Monaco 编辑器创建和管理 DSH 沙箱化 JavaScript 工具，模型驱动工具列表。（✅ 活跃）
-- [dskin](https://github.com/dancingmemory/dskin) ⭐22 — 卡通像素皮肤插件：原始界面不动，像素宠物散步、眨眼、跳跃。（✅ 活跃）
-- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐20 — 从 Claude Code、Codex、ChatGPT、Cursor、Gemini、Reasonix、OpenCode 导入历史消息并在 DSH 中继续对话。（✅ 活跃）
-- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) ⭐18 — 换肤系统：21 套内置皮肤 + 一张图生成整套配色，构建期校验可读性。（✅ 活跃）
-- [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) ⭐18 — 为 DeepSeek Harness 提供电脑控制插件：新鲜 Accessibility 观测、过期状态拒绝、作用域权限与安全输入（目前支持macos）｜Accessibility-first macOS Computer Use bundle for DSH with fresh observations, stale-state rejection, scoped permissions, and safe input.（✅ 活跃）
-- [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) ⭐18 — 紧凑侧边栏：文件浏览器、终端与 Git 审查。（✅ 活跃）
-- [anysearch-dsh](https://github.com/anysearch-team/anysearch-dsh) ⭐17 — AnySearch 网页搜索 provider 与高级搜索工具。（✅ 活跃）
-- [deepseek-harness-snowsalt](https://github.com/KYZHXL/deepseek-harness-snowsalt) ⭐17 — 雪盐主题皮肤。（✅ 活跃）
+- [petdex](https://github.com/crafter-station/petdex) ⭐3,825 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more.（✅ 活跃）
+- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐2,484 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
+- [dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) ⭐1,831 — Two-phase DeepSeek Harness preset: Minimal-aligned bootstrap, then full Standard tools (Project2 98/99)（✅ 活跃）
+- [modlens](https://github.com/liustack/modlens) ⭐1,736 — DSH 首个视觉插件，也是所有纯文本编码 Agent 的视觉桥梁：粘贴图片即可用。（✅ 活跃）
+- [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) ⭐1,065 — 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。（✅ 活跃）
+- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) ⭐834 — DSH Web 鲸鱼娘皮肤系列（CC BY-NC-SA 4.0）。（✅ 活跃）
+- [museai](https://github.com/yejiming/MuseAI) ⭐556 — 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用）（✅ 活跃）
+- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) ⭐409 — 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。（✅ 活跃）
+- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) ⭐396 — 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。（✅ 活跃）
+- [dsh-market](https://github.com/dsh-market/dsh-market) ⭐218 — DSH 内置可视化插件市场：浏览、搜索、一键安装。（✅ 活跃）
+- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) ⭐198 — Codex 风格 @file 提及：在 DSH 输入框中搜索工作区文件并附加内容到提示词。（✅ 活跃）
+- [whale-girl](https://github.com/vlln/whale-girl) ⭐160 — QQ 宠物形态桌面宠物：DSH Web 右下角悬浮，可拖拽/投喂/玩耍。（✅ 活跃）
+- [dsh-browser](https://github.com/Lum1104/dsh-browser) ⭐140 — Chrome 侧栏扩展：让 DSH 直接操控你的浏览器，无需视觉能力。（✅ 活跃）
+- [v4-flash-godmode-opencode-go](https://github.com/SheberDavid/v4-flash-godmode-opencode-go) ⭐127 — V4 Flash 神模式 (opencode-go)：让 opencode-go 的 DeepSeek V4 Flash 从鬼模式切换到神模式的 dsh agent preset（✅ 活跃）
+- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) ⭐111 — 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。（✅ 活跃）
+- [modsearch](https://github.com/liustack/modsearch) ⭐104 — DSH 网页插件：为没有原生联网能力的模型提供搜索桥梁。（✅ 活跃）
+- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐100 — 对话内交互式 HTML UI：流式预览与沙箱渲染。（✅ 活跃）
+- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐99 — 对话内生成式 UI：布局、图表、表单、测验、Mermaid 与交互事件内联渲染。（✅ 活跃）
+- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐89 — DSH 生态插件发现工具。（✅ 活跃）
+- [dsh-gitbash-preset](https://github.com/liceses/dsh-gitbash-preset) ⭐86 — DeepSeek Harness 插件：一键安装「极简模式 (Git Bash)」agent preset —— 把 DSH 自带极简模式中的 bash 调用映射到 Git for Windows 的 bash（MSYS），让 Windows 上的极简模式真正可用。（✅ 活跃）
+- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐82 — 跨会话长期记忆 + 后台自我进化：五轨记忆、git 分支感知、回合内自我审查、技能自我进化。（✅ 活跃）
+- [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) ⭐64 — 在 DSH Web GUI 中一键浏览、安装与更新全部 GitHub dsh-plugin 插件。（✅ 活跃）
+- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) ⭐50 — DSH Web 选中批注：选文字→批注→随消息发送，回复按批注逐条对照。（✅ 活跃）
+- [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐50 — 对话与代码状态回退插件，基于持久化变更账本。（✅ 活跃）
+- [dsh-auto-mode](https://github.com/NanmiCoder/dsh-auto-mode) ⭐48 — Safe automatic permissions for DeepSeek Harness.（✅ 活跃）
+- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) ⭐47 — 回合完成桌面通知，按结果分控 + 关键词包含/排除过滤。（✅ 活跃）
+- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) ⭐42 — 从 Web GUI 直接在工作区中打开 VS Code 目录/文件。（✅ 活跃）
+- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) ⭐42 — dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin.com 目录，一键安装/卸载到 profile。（✅ 活跃）
+- [dsh-context](https://github.com/bowenliang123/dsh-context) ⭐40 — A DeepSeek Harness plugin for  Context insight dashboard — showing what the model's context window is made of and how it evolves.（✅ 活跃）
+- [dsh-pet](https://github.com/PC2005-cloud/dsh-pet) ⭐38 — DeepSeek Harness 桌面宠物插件 + 完整素材生成链：AI 提示词 → 绿幕视频 → 透明动画 → 可安装插件，从零到宠物全流程可复现（✅ 活跃）
+- [dsh-plugins-store](https://github.com/ZASENJC/dsh-plugins-store) ⭐38 — 自动收录与分类 GitHub dsh-plugin Topic 项目的静态目录网站。（✅ 活跃）
+- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) ⭐34 — 换肤系统：21 套内置皮肤 + 一张图生成整套配色，构建期校验可读性。（✅ 活跃）
+- [dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) ⭐33 — Web UI 中一键管理 DSH 插件：查看、实时启停、安装/卸载、环境管理、插件市场。（✅ 活跃）
+- [ui-status-label](https://github.com/alingalingling/ui-status-label) ⭐32 — 把鲸鱼娘思考时的 deep diving 状态自定义成任意文字。（✅ 活跃）
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) ⭐31 — DeepSeek Harness 会话费用统计插件:本会话费用、当日费用、历史记录与官方价格同步（✅ 活跃）
+- [anysearch-dsh](https://github.com/anysearch-team/anysearch-dsh) ⭐30 — AnySearch 网页搜索 provider 与高级搜索工具。（✅ 活跃）
+- [dsh-kun-like-pet](https://github.com/liyupi/dsh-kun-like-pet) ⭐30 — Kun Like 桌宠 —— DeepSeek Harness 桌面宠物插件：右下角小坤宠随 Agent 工作状态切换 9 种动作，任务完成播放「你干嘛~哎哟」（✅ 活跃）
+- [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) ⭐30 — 会话标题栏全手绘像素鲸鱼伙伴：眨眼、摆尾、回合完成喷水，零核心改动。（✅ 活跃）
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐29 — 从 Claude Code、Codex、ChatGPT、Cursor、Gemini、Reasonix、OpenCode 导入历史消息并在 DSH 中继续对话。（✅ 活跃）
+- [dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) ⭐29 — Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the DeepSeek Harness Web GUI (dsh web).（✅ 活跃）
+- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) ⭐26 — 三层本地记忆系统：运行时热记忆、项目文档、长期记忆空间，监督式写回。（✅ 活跃）
+- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) ⭐24 — 用 Monaco 编辑器创建和管理 DSH 沙箱化 JavaScript 工具，模型驱动工具列表。（✅ 活跃）
+- [dsh-transparent-ui-plugin](https://github.com/WYH66666666/DSH-Transparent-UI-Plugin) ⭐24 — 是一层高自由度的玻璃质感主题，套在 DeepSeek Harness 网页端。顶栏、侧边栏、输入框、统计行、轨迹视图都成了磨砂玻璃片。玻璃模糊度、磨砂度、背景（流体或自定义壁纸，壁纸还能单独调模糊和磨砂）全都能在设置卡片里自由调节。关掉开关就回到原生界面，不改 DSH 任何一行源码。（✅ 活跃）
+- [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) ⭐23 — 会话内插件发现：直接在 DSH 中搜索 GitHub dsh-plugin 主题的实时插件。（✅ 活跃）
+- [dsh-navbar](https://github.com/vlln/dsh-navbar) ⭐23 — DSH 插件：对话节点导航条（右缘节点串快速跳转 user 消息）。官方 bundle 插件，dsh plugin --profile web add 安装（✅ 活跃）
+- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) ⭐23 — 插件管理面板：一键启停已装插件 + GitHub dsh-plugin 市场，带详情与一键安装。（✅ 活跃）
+- [dsh-vision (william-jin-cmu)](https://github.com/william-jin-cmu/dsh-vision) ⭐23 — 视觉桥接：view_image 工具桥接任意 OpenAI 兼容 VLM，默认智谱免费档。（✅ 活跃）
+- [deepseek-harness-snowsalt](https://github.com/KYZHXL/deepseek-harness-snowsalt) ⭐21 — 雪盐主题皮肤。（✅ 活跃）
+- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) ⭐21 — 分支式消息编辑、重掷、重试与版本时间线。（✅ 活跃）
+- [dskin](https://github.com/dancingmemory/dskin) ⭐21 — 卡通像素皮肤插件：原始界面不动，像素宠物散步、眨眼、跳跃。（✅ 活跃）
+- [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) ⭐20 — 为 DeepSeek Harness 提供电脑控制插件：新鲜 Accessibility 观测、过期状态拒绝、作用域权限与安全输入（目前支持macos）｜Accessibility-first macOS Computer Use bundle for DSH with fresh observations, stale-state rejection, scoped permissions, and safe input.（✅ 活跃）
+- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) ⭐20 — 向模型暴露 MinerU 文档解析：PDF/图片/DOCX/PPTX/XLSX 转结构化 Markdown/JSON。（✅ 活跃）
+- [dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) ⭐20 — Steam 创意工坊风格插件浏览器：零服务器、GitHub 驱动搜索、一键安装。（✅ 活跃）
+- [dsh-share](https://github.com/hellodigua/dsh-share) ⭐19 — DSH 对话一键分享。（✅ 活跃）
+- [dsh-minigames](https://github.com/lhh010/dsh-minigames) ⭐18 — DSH Web UI 右侧小游戏面板：18 款离线小游戏（恐龙跳一跳 / 俄罗斯方块 / 坦克大战 / 扫雷 / 2048 / 数独 / 吃豆人 / 跟枪练习等），可扩展游戏注册表，等待模型回复或修 bug 时的摸鱼神器（✅ 活跃）
+- [dsh-plugin](https://github.com/Tabbit-Browser/dsh-plugin) ⭐18 — Tabbit Broser plugins for Deepseek Harness（✅ 活跃）
+- [dsh-emoji](https://github.com/hellodigua/dsh-emoji) ⭐17 — 让 AI 回复加入自定义表情。（✅ 活跃）
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) ⭐17 — 插件健康检查：清单协议、patch 格式、构建陷阱与 hub 收录状态，零依赖只读。（✅ 活跃）
-- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) ⭐16 — 分支式消息编辑、重掷、重试与版本时间线。（✅ 活跃）
-- [dsh-share](https://github.com/hellodigua/dsh-share) ⭐16 — DSH 对话一键分享。（✅ 活跃）
-- [dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) ⭐16 — Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the DeepSeek Harness Web GUI (dsh web).（✅ 活跃）
-- [dsh-vision (william-jin-cmu)](https://github.com/william-jin-cmu/dsh-vision) ⭐16 — 视觉桥接：view_image 工具桥接任意 OpenAI 兼容 VLM，默认智谱免费档。（✅ 活跃）
-- [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) ⭐15 — 零依赖工具包：计算器、CSV、diff、编码、JSON、Markdown、正则、时间。（✅ 活跃）
-- [dsh-group-photo](https://github.com/SenmuuuuW/dsh-group-photo) ⭐14 — DSH 内测收官合影墙：GitHub OAuth 零权限登录 + 冻结白名单校验的拍立得合影站（含 DSH Skill 包装）（✅ 活跃）
-- [dsh-navbar](https://github.com/vlln/dsh-navbar) ⭐14 — DSH 插件：对话节点导航条（右缘节点串快速跳转 user 消息）。官方 bundle 插件，dsh plugin --profile web add 安装（✅ 活跃）
-- [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) ⭐13 — DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。（✅ 活跃）
-- [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) ⭐12 — 为 dsh 提供新的「聚焦会话」精简会话视图，更轻松易于阅读，只关注最终产出结果。（✅ 活跃）
-- [dsh-kun-like-pet](https://github.com/liyupi/dsh-kun-like-pet) ⭐12 — Kun Like 桌宠 —— DeepSeek Harness 桌面宠物插件：右下角小坤宠随 Agent 工作状态切换 9 种动作，任务完成播放「你干嘛~哎哟」（✅ 活跃）
-- [dsh-market](https://github.com/dsh-market/dsh-market) ⭐12 — DSH 内置可视化插件市场：浏览、搜索、一键安装。（✅ 活跃）
-- [dsh-minigames](https://github.com/lhh010/dsh-minigames) ⭐12 — DSH Web UI 右侧小游戏面板：18 款离线小游戏（恐龙跳一跳 / 俄罗斯方块 / 坦克大战 / 扫雷 / 2048 / 数独 / 吃豆人 / 跟枪练习等），可扩展游戏注册表，等待模型回复或修 bug 时的摸鱼神器（✅ 活跃）
-- [dsh-plugins-store](https://github.com/ZASENJC/dsh-plugins-store) ⭐12 — 自动收录与分类 GitHub dsh-plugin Topic 项目的静态目录网站。（✅ 活跃）
-- [ego-browser](https://github.com/Fisfzy/ego-browser) ⭐12 — 把 ego-lite 智能体浏览器（为 AI Agent 打造的 Chromium）接入 DSH，13 个结构化工具。（✅ 活跃）
-- [DeepSeek-Harness-Web-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Web-Tools) ⭐11 — 免费免密钥的 web_search/web_fetch，DuckDuckGo 驱动，无需注册。（✅ 活跃）
-- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) ⭐11 — DeepSeek account balance and session cost readout for the DeepSeek Harness Web GUI（✅ 活跃）
-- [dsh-emoji](https://github.com/hellodigua/dsh-emoji) ⭐11 — 让 AI 回复加入自定义表情。（✅ 活跃）
-- [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) ⭐11 — 会话内插件发现：直接在 DSH 中搜索 GitHub dsh-plugin 主题的实时插件。（✅ 活跃）
-- [dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) ⭐11 — 在 DSH 中与 AI 下五子棋，也可以让 AI 对局比试模型强弱。（✅ 活跃）
-- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) ⭐11 — 三层本地记忆系统：运行时热记忆、项目文档、长期记忆空间，监督式写回。（✅ 活跃）
+- [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) ⭐17 — 零依赖工具包：计算器、CSV、diff、编码、JSON、Markdown、正则、时间。（✅ 活跃）
+- [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) ⭐16 — 为 dsh 提供新的「聚焦会话」精简会话视图，更轻松易于阅读，只关注最终产出结果。（✅ 活跃）
+- [dsh-group-photo](https://github.com/SenmuuuuW/dsh-group-photo) ⭐16 — DSH 内测收官合影墙：GitHub OAuth 零权限登录 + 冻结白名单校验的拍立得合影站（含 DSH Skill 包装）（✅ 活跃）
+- [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) ⭐16 — 紧凑侧边栏：文件浏览器、终端与 Git 审查。（💤 停更）
+- [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) ⭐16 — DSH WebUI sticker plugin for bidirectional user and agent reactions（✅ 活跃）
+- [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) ⭐15 — DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。（✅ 活跃）
+- [dsh-balance](https://github.com/crazywoola/dsh-balance) ⭐14 — 设置页余额插件。（✅ 活跃）
+- [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) ⭐14 — Git 风格里程碑时间线：悬停查看元数据，点击跳转任意消息。（✅ 活跃）
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) ⭐13 — DeepSeek account balance and session cost readout for the DeepSeek Harness Web GUI（✅ 活跃）
+- [dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) ⭐13 — 在 DSH 中与 AI 下五子棋，也可以让 AI 对局比试模型强弱。（✅ 活跃）
+- [ego-browser](https://github.com/Fisfzy/ego-browser) ⭐13 — 把 ego-lite 智能体浏览器（为 AI Agent 打造的 Chromium）接入 DSH，13 个结构化工具。（✅ 活跃）
+- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) ⭐12 — 模型驱动的上下文管理（Active Context Pruning）：由模型决定何时压缩、压缩什么。（✅ 活跃）
+- [DeepSeek-Harness-Web-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Web-Tools) ⭐12 — 免费免密钥的 web_search/web_fetch，DuckDuckGo 驱动，无需注册。（✅ 活跃）
+- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) ⭐12 — PiUI 风格 Web diff 查看器，替代默认 diff 视图。（✅ 活跃）
+- [dsh-plugin-pet-rs](https://github.com/HuanLinOTO/dsh-plugin-pet-rs) ⭐12 — Rust 桌宠：5 态鲸鱼 + 双 SSE 实时推送 + 透明置顶窗 + 系统托盘，三端支持。（✅ 活跃）
+- [dsh-remote](https://github.com/flymysql/dsh-remote) ⭐12 — 远程工作区：SSH 连接远程主机，用 rw_pick_workspace/rw_read_file/rw_exec 等工具远程操作。（✅ 活跃）
+- [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) ⭐12 — 为 DSH 增加桌面通知提醒。（✅ 活跃）
+- [dsh-recommend](https://github.com/zp-home/dsh-recommend) ⭐11 — 透明插件排行榜与推荐：每日自动抓取 dsh-plugin 主题数据，开放评分模型。（✅ 活跃）
 - [dsh-sdk-platform-rs](https://github.com/kpn-dsh/dsh-sdk-platform-rs) ⭐11 — A Rust SDK to interact with the DSH Platform. This library provides convenient building blocks for services that need to connect to DSH Kafka, fetch tokens for various protocols, manage Prometheus metrics, and more.（✅ 活跃）
-- [dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) ⭐11 — Web UI 中一键管理 DSH 插件：查看、实时启停、安装/卸载、环境管理、插件市场。（✅ 活跃）
-- [dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) ⭐10 — Steam 创意工坊风格插件浏览器：零服务器、GitHub 驱动搜索、一键安装。（✅ 活跃）
-- [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) ⭐10 — DSH 本机安全审计插件：配置/插件来源/会话/网络暴露面，只读脱敏风险报告（✅ 活跃）
-- [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) ⭐10 — 股票行情插件（整活：有效解决了写代码时账户不能同时亏钱的 BUG）。（✅ 活跃）
-- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) ⭐10 — dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin.com 目录，一键安装/卸载到 profile。（✅ 活跃）
-- [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) ⭐9 — Git 风格里程碑时间线：悬停查看元数据，点击跳转任意消息。（✅ 活跃）
-- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) ⭐9 — 向模型暴露 MinerU 文档解析：PDF/图片/DOCX/PPTX/XLSX 转结构化 Markdown/JSON。（✅ 活跃）
+- [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) ⭐11 — DSH 本机安全审计插件：配置/插件来源/会话/网络暴露面，只读脱敏风险报告（✅ 活跃）
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) ⭐11 — Codex 风格皮肤切换器 + 自定义半透明壁纸，支持透明度/模糊控制。（✅ 活跃）
+- [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) ⭐11 — 股票行情插件（整活：有效解决了写代码时账户不能同时亏钱的 BUG）。（✅ 活跃）
+- [DeepSeek-Harness-Vision-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Vision-Tools) ⭐10 — 视觉代理：任意文本模型 + 任意视觉模型即可让 DSH 看图。（✅ 活跃）
+- [dsh-mneme](https://github.com/modusensus/dsh-mneme) ⭐10 — 记忆主权归用户的本地跨会话记忆：SQLite + 可人工编辑的 Markdown 镜像，autoDream 后台巩固。（✅ 活跃）
+- [touhou-hakurei](https://github.com/xiake595/touhou-hakurei) ⭐10 — 灵梦（Reimu）·博丽神社（东方Project）美化版皮肤：神社昼夜实景背景、灵梦立绘、画框侧边栏与输入框、纸白透明界面 — DeepSeek Harness Web GUI skin（✅ 活跃）
+- [DeepSeek-Harness-billing-plugin](https://github.com/WilliamLIiii/DeepSeek-Harness-billing-plugin) ⭐9 — 账户余额 + 按模型剩余任务估算，带会话费用台账。（✅ 活跃）
+- [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) ⭐9 — 🐋 DSH 有声桌宠：悬浮桌面的 DeepSeek 小鲸鱼，不打开 DSH 也能实时感知会话状态（需要确认/工作中/完成/空闲/离线），支持音效提醒与零代码定制素材（✅ 活跃）
+- [dsh-plugin-better-sidebar-plugin-office](https://github.com/HuanLinOTO/dsh-plugin-better-sidebar-plugin-office) ⭐9 — 为 better-sidebar 提供 Office 三件套预览（.docx/.xlsx/.pptx），独立瘦身 bundle。（✅ 活跃）
 - [dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) ⭐9 — 多帧 zstd 会话文件的帧级扫描诊断：撕裂/损坏/空会话检测，零依赖只读。（✅ 活跃）
-- [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) ⭐9 — 为 DSH 增加桌面通知提醒。（✅ 活跃）
 - [deepseek-harness-SupportVisionModel](https://github.com/TryDing-T/deepseek-harness-SupportVisionModel) ⭐8 — 基于 deepseek-harness 二次开发：支持单独配置视觉模型读图。（✅ 活跃）
-- [DeepSeek-Harness-Vision-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Vision-Tools) ⭐8 — 视觉代理：任意文本模型 + 任意视觉模型即可让 DSH 看图。（✅ 活跃）
-- [dsh-mneme](https://github.com/modusensus/dsh-mneme) ⭐8 — 记忆主权归用户的本地跨会话记忆：SQLite + 可人工编辑的 Markdown 镜像，autoDream 后台巩固。（✅ 活跃）
+- [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) ⭐8 — Excel 风格电子表格皮肤。（✅ 活跃）
 - [dsh-paste-input](https://github.com/lhh010/dsh-paste-input) ⭐8 — DSH WebUI 文件输入增强：Ctrl+V 粘贴、拖拽、选择文件，发送时复制进会话工作区。（✅ 活跃）
-- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) ⭐7 — 模型驱动的上下文管理（Active Context Pruning）：由模型决定何时压缩、压缩什么。（✅ 活跃）
-- [DeepSeek-Harness-billing-plugin](https://github.com/WilliamLIiii/DeepSeek-Harness-billing-plugin) ⭐7 — 账户余额 + 按模型剩余任务估算，带会话费用台账。（✅ 活跃）
+- [dsh-plugin-ya-workspace-sidebar](https://github.com/HuanLinOTO/dsh-plugin-ya-workspace-sidebar) ⭐8 — DSH Web 工作区侧栏替代，顶部全局最近会话 + Workspace→Session 二级菜单 + 面包屑 | DSH Web workspace sidebar replacement: top global recent sessions + Workspace→Session two-level menu + breadcrumbs（✅ 活跃）
+- [dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) ⭐8 — 将 'Deep diving…' 状态替换为阶段感知的打字机消息。（✅ 活跃）
+- [dsh-undo-plugin](https://github.com/lire1131/dsh-undo-plugin) ⭐8 — DSH plugin: snapshot & rollback your plugin/skin/settings configs. Auto-save on change, undo/redo stack, snapshot manager panel, keyboard shortcuts, plus an offline PowerShell CLI & GUI that work even when DSH won't boot.（✅ 活跃）
+- [dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) ⭐7 — DSH 自动记忆插件:三层记忆(用户级/项目笔记/每日日志)自动注入与检索、每日反思、可视化面板与设置页,支持继承其他 AI 工具的历史记忆。An auto-memory plugin for the DeepSeek Harness Web GUI: three-layer memory (user-level / project notes / daily logs) with automatic injection and retrieval, daily reflections, a visual panel and settings page, and inheritance of memories from other AI tools.（✅ 活跃）
+- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) ⭐7 — 上下文注入审计插件：统计 AGENTS.md 指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。（✅ 活跃）
 - [dsh-director-toolkit](https://github.com/lhmd/dsh-director-toolkit) ⭐7 — DSH Director Toolkit is a DeepSeek Harness plugin for 3D artists, technical designers, and creative coders. Paste a half-formed idea, a reference note, or a portfolio caption and get a compact direction pack for Blender, Three.js, Houdini, or C4D.（✅ 活跃）
-- [dsh-plugin-better-sidebar-plugin-office](https://github.com/HuanLinOTO/dsh-plugin-better-sidebar-plugin-office) ⭐7 — 为 better-sidebar 提供 Office 三件套预览（.docx/.xlsx/.pptx），独立瘦身 bundle。（✅ 活跃）
-- [dsh-plugin-pet-rs](https://github.com/HuanLinOTO/dsh-plugin-pet-rs) ⭐7 — Rust 桌宠：5 态鲸鱼 + 双 SSE 实时推送 + 透明置顶窗 + 系统托盘，三端支持。（✅ 活跃）
-- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) ⭐6 — 上下文注入审计插件：统计 AGENTS.md 指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。（✅ 活跃）
-- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) ⭐6 — PiUI 风格 Web diff 查看器，替代默认 diff 视图。（✅ 活跃）
-- [dsh-skin](https://github.com/KinGao294/dsh-skin) ⭐6 — Codex 风格皮肤切换器 + 自定义半透明壁纸，支持透明度/模糊控制。（✅ 活跃）
-- [dsh-balance](https://github.com/crazywoola/dsh-balance) ⭐5 — 设置页余额插件。（✅ 活跃）
-- [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) ⭐5 — Excel 风格电子表格皮肤。（✅ 活跃）
+- [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) ⭐7 — DSH Web UI 跨平台文件拖拽与原始路径插入，无需复制文件。（✅ 活跃）
+- [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) ⭐7 — DSH 插件：git 提交固定使用环境自身作者身份（优先 gh CLI 登录账号，GitHub noreply 邮箱），GIT_AUTHOR_*/GIT_COMMITTER_* 环境变量注入压过一切 git config（✅ 活跃）
+- [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) ⭐7 — 左下角便签：随手记点子/感想/TODO，实时保存到归档目录，清单+悬浮归档（✅ 活跃）
+- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) ⭐7 — 多引擎持久搜索：DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/推特/Reddit/RSS，SQLite+LRU 缓存 + Playwright 渲染。（✅ 活跃）
+- [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) ⭐6 — provider-agnostic AIGC HTTP 桥 + 无限画布 + ffmpeg 后处理，13 个工具含画布连边/reroll/媒体编辑 | Provider-agnostic AIGC HTTP bridge + infinite canvas + ffmpeg post-processing; 13 tools incl. canvas linking/reroll/media-edit（✅ 活跃）
+- [dsh-plugin-anti-ads](https://github.com/HuanLinOTO/dsh-plugin-anti-ads) ⭐6 — DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin（✅ 活跃）
+- [dsh-plugin-auto-blame](https://github.com/HuanLinOTO/dsh-plugin-auto-blame) ⭐6 — 模型回合结束后用 LLM 生成 3 条批判性跟进建议，点击即发送 | After a model turn, an LLM generates 3 critical follow-up suggestions shown as click-to-send chips（✅ 活跃）
+- [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) ⭐6 — 将 DSH 接入 GitHub 插件生态的市场插件。（✅ 活跃）
+- [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) ⭐6 — 暴露 run_python/run_node 工具，通过 stdin 执行代码返回 stdout/stderr/exit。（✅ 活跃）
+- [dsh-token-panel](https://github.com/juhe291/dsh-token-panel) ⭐6 — A corner HUD for DeepSeek Harness that shows your session's token pressure, per-model cost, and daily/monthly usage at a glance — with an editable budget & balance that tracks spending for you. 右下角常驻的 Token 仪表盘：实时查看会话压力、按模型估算花费，预算和余额点一下就能改，每天每月用了多少都有记录。（✅ 活跃）
+- [dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) ⭐6 — A DeepSeek Harness Web plugin for real-time Token usage, cost estimates, per-round charts, and DeepSeek API balance.（✅ 活跃）
+- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) ⭐6 — DSH Web 中英文金额 Token 计费：官方策略自动定价（含高峰/低谷），逐条消息费用台账。（✅ 活跃）
+- [weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) ⭐6 — Native WeShop Cordis plugin for DeepSeek Harness. Allow you to use infinite canvas with infinite creative skills.（✅ 活跃）
+- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) ⭐5 — 官方 DSH Web 内置功能可读目录 + 安全 UI 开关。（✅ 活跃）
+- [dsh-cost-plugin](https://github.com/RoxsLee/dsh-cost-plugin) ⭐5 — DSH 费用/余额读数插件：在输入框统计行旁实时显示「本次 ≈¥x · 会话 ≈¥x · 余额 ¥x」，内置 DeepSeek 官方价目表，支持 2026-08-17 起生效的峰谷定价（按节点时间戳自动选档），余额经官方 /user/balance 实时查询，失败静默降级。（✅ 活跃）
+- [dsh-cue-plugin](https://github.com/unnnnoooo/dsh-cue-plugin) ⭐5 — DeepSeek Harness 的跨会话引用(cue)插件（✅ 活跃）
 - [dsh-ohos-patch](https://github.com/shenjackyuanjie/dsh-ohos-patch) ⭐5 — 让deepseek harness能在 ohos上跑！（✅ 活跃）
+- [dsh-opencode-go-usage](https://github.com/Xenia0922/dsh-opencode-go-usage) ⭐5 — DeepSeek Harness 插件:OpenCode Go 用量与花费悬浮仪表盘(配额、逐请求成本、模型/来源分布)（✅ 活跃）
+- [dsh-plugin-anydoc](https://github.com/beancookie/dsh-plugin-anydoc) ⭐5 — 基于 @firecrawl/anydoc 将 Word/PPT/Excel/PDF/EPUB/CSV 等文档转换为 GFM Markdown。（✅ 活跃）
 - [dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) ⭐5 — 模型生成时右下角弹出小游戏菜单：Wordle/消消乐/192 款参数化小游戏。（✅ 活跃）
-- [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) ⭐5 — 将 DSH 接入 GitHub 插件生态的市场插件。（✅ 活跃）
-- [dsh-plugin-ya-workspace-sidebar](https://github.com/HuanLinOTO/dsh-plugin-ya-workspace-sidebar) ⭐5 — DSH Web 工作区侧栏替代，顶部全局最近会话 + Workspace→Session 二级菜单 + 面包屑 | DSH Web workspace sidebar replacement: top global recent sessions + Workspace→Session two-level menu + breadcrumbs（✅ 活跃）
-- [dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) ⭐5 — 将 'Deep diving…' 状态替换为阶段感知的打字机消息。（✅ 活跃）
+- [dsh-spend](https://github.com/nonewind/dsh-spend) ⭐5 — Token 用量与费用估算：悬浮面板，按模型/天/会话统计，自动识别计费套餐。（✅ 活跃）
+- [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) ⭐5 — DSH Web 键盘优先命令面板。（✅ 活跃）
 - [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) ⭐5 — 将 Nowledge Mem 记忆服务接入 DeepSeek Harness 的社区插件包。（✅ 活跃）
-- [dsh-cost-plugin](https://github.com/RoxsLee/dsh-cost-plugin) ⭐4 — DSH 费用/余额读数插件：在输入框统计行旁实时显示「本次 ≈¥x · 会话 ≈¥x · 余额 ¥x」，内置 DeepSeek 官方价目表，支持 2026-08-17 起生效的峰谷定价（按节点时间戳自动选档），余额经官方 /user/balance 实时查询，失败静默降级。（✅ 活跃）
-- [dsh-cue-plugin](https://github.com/unnnnoooo/dsh-cue-plugin) ⭐4 — DeepSeek Harness 的跨会话引用(cue)插件（✅ 活跃）
+- [zotero-harvest](https://github.com/Fisfzy/zotero-harvest) ⭐5 — Zotero 文献采集入库插件（DSH external plugin）：多源检索（OpenAlex/arXiv/Crossref/Europe PMC/Semantic Scholar）+ OA 下载链接解析（Unpaywall）+ 充分性审计 + 入库本地 Zotero + 触发 zotero-wave-rag 重建（✅ 活跃）
+- [codex-eyes-hands](https://github.com/651002/codex-eyes-hands) ⭐4 — 专为 DeepSeek Harness 打造：把本机 Codex CLI 变成纯文本 AI agent 的眼睛和手——看图/读文件/画图/监督执行/双通道容灾（✅ 活跃）
+- [context-vista](https://github.com/GooodWei/context-vista) ⭐4 — 上下文/Token 实时监控：悬浮面板 + /context 命令，环形图展示用量、分配与估算费用。（✅ 活跃）
+- [deepseek-harness-zh_pro](https://github.com/magian1127/deepseek-harness-zh_pro) ⭐4 — Chinese enhancement plugin for DeepSeek Harness (DSH) - DSH 中文增强插件（✅ 活跃）
+- [dsh-calculator](https://github.com/bobcat848/dsh-calculator) ⭐4 — Calculate the real-time cost of DeepSeek API calls made by DeepSeek Harness.（✅ 活跃）
 - [dsh-input-history](https://github.com/lhh010/dsh-input-history) ⭐4 — 终端风格输入历史：Ctrl+Up/Down 召回与切换已发送消息。（✅ 活跃）
-- [dsh-pet](https://github.com/PC2005-cloud/dsh-pet) ⭐4 — DeepSeek Harness 桌面宠物插件 + 完整素材生成链：AI 提示词 → 绿幕视频 → 透明动画 → 可安装插件，从零到宠物全流程可复现（✅ 活跃）
-- [dsh-plugin-anti-ads](https://github.com/HuanLinOTO/dsh-plugin-anti-ads) ⭐4 — DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin（✅ 活跃）
+- [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) ⭐4 — PDF 工具箱：pdfjs-dist 本地提取文本、元数据与页区间，无需 API Key。（✅ 活跃）
 - [dsh-plugin-deepeye](https://github.com/Favio8/dsh-plugin-deepeye) ⭐4 — DeepEye vision plugin for DeepSeek Harness (DSH): image description, OCR, VQA, UI layout, and clipboard analysis.（✅ 活跃）
-- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) ⭐4 — 插件管理面板：一键启停已装插件 + GitHub dsh-plugin 市场，带详情与一键安装。（✅ 活跃）
-- [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) ⭐4 — 暴露 run_python/run_node 工具，通过 stdin 执行代码返回 stdout/stderr/exit。（✅ 活跃）
-- [dsh-remote](https://github.com/flymysql/dsh-remote) ⭐4 — 远程工作区：SSH 连接远程主机，用 rw_pick_workspace/rw_read_file/rw_exec 等工具远程操作。（✅ 活跃）
-- [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) ⭐4 — DSH Web 键盘优先命令面板。（✅ 活跃）
-- [weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) ⭐4 — Native WeShop Cordis plugin for DeepSeek Harness. Allow you to use infinite canvas with infinite creative skills.（✅ 活跃）
-- [context-vista](https://github.com/GooodWei/context-vista) ⭐3 — 上下文/Token 实时监控：悬浮面板 + /context 命令，环形图展示用量、分配与估算费用。（✅ 活跃）
-- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) ⭐3 — 官方 DSH Web 内置功能可读目录 + 安全 UI 开关。（✅ 活跃）
-- [dsh-calculator](https://github.com/bobcat848/dsh-calculator) ⭐3 — Calculate the real-time cost of DeepSeek API calls made by DeepSeek Harness.（✅ 活跃）
-- [dsh-opencode-go-usage](https://github.com/Xenia0922/dsh-opencode-go-usage) ⭐3 — DeepSeek Harness 插件:OpenCode Go 用量与花费悬浮仪表盘(配额、逐请求成本、模型/来源分布)（✅ 活跃）
+- [dsh-prompt-enhancer](https://github.com/Fishsb/dsh-prompt-enhancer) ⭐4 — DeepSeek Harness DSH 提示词增强插件：✨ 一键优化草稿，增强提示词。（✅ 活跃）
+- [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) ⭐4 — 为 DeepSeek Harness 提供会话删除能力，支持侧边栏 ⋮ 菜单入口（✅ 活跃）
+- [dsh-split-panes](https://github.com/lehhair/dsh-split-panes) ⭐4 — Split panes.（✅ 活跃）
+- [dsh-usage-dashboard](https://github.com/Cassius0924/dsh-usage-dashboard) ⭐4 — DeepSeek 额度与用量仪表盘 — DSH (DeepSeek Harness) 动态 Cordis 插件（✅ 活跃）
+- [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) ⭐4 — Privacy-minimal heuristic per-turn verification summaries for DeepSeek Harness（✅ 活跃）
+- [dsh-weather](https://github.com/sunshine-lang/dsh-weather) ⭐4 — 天气工具：Open-Meteo 当前天气与多日预报，免费免密钥。（✅ 活跃）
+- [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) ⭐4 — Attention reminders for the DeepSeek Harness Web UI: frame badge, (N) tab title and whale-favicon recolor for sessions waiting for input or finished unopened.（✅ 活跃）
+- [dsh-web-search-exa](https://github.com/TonyDua/dsh-web-search-exa) ⭐4 — 零配置 Exa 网页搜索：免密钥匿名 MCP 回退 + API Key REST 搜索。（✅ 活跃）
+- [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐4 — 输入框旁常用词箱：全局/项目词桶，一键插入。（✅ 活跃）
+- [dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) ⭐4 — VS Code 风格工作区关键词搜索：Better Sidebar 生态的搜索 Tab。（✅ 活跃）
+- [deepseek-harness-plugin-manager](https://github.com/hrhgit/deepseek-harness-plugin-manager) ⭐3 — Web plugin manager for DeepSeek Harness (DSH): inspect, search, group, enable, and disable Cordis plugins.（✅ 活跃）
+- [dsh-agentmemory](https://github.com/elementor-i/dsh-agentmemory) ⭐3 — agentmemory for DeepSeek Harness (dsh): full memory_* tools, capture hooks, and context injection over the local REST server（✅ 活跃）
+- [dsh-browser](https://github.com/anweat/dsh-browser) ⭐3 — Self-contained browser runtime plugin for DeepSeek Harness — bundles Playwright (chromium) and OpenCLI as plugin-local dependencies, exposes a browser service and interactive browser tools.（✅ 活跃）
+- [dsh-doctor](https://github.com/astra3294/dsh-doctor) ⭐3 — Deterministic diagnostics and recovery for DeepSeek Harness（✅ 活跃）
+- [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) ⭐3 — 并行 Agent 会话的文件归属/认领系统：认领/释放、心跳过期接管、异步三路合并。（✅ 活跃）
+- [dsh-file-mount](https://github.com/acefun29/dsh-file-mount) ⭐3 — 增量文件挂载 + 行区间去重：相同文件内容不再重复发送给模型。（✅ 活跃）
+- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud) ⭐3 — HUD 状态面板：浮动侧栏展示 git 状态、MCP 服务器、技能、模型与 token 用量。（✅ 活跃）
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) ⭐3 — 有界分层、审批门控、可审计的跨会话记忆，支持冻结快照注入。（✅ 活跃）
+- [dsh-memory-evidence](https://github.com/LeslieWylie/dsh-memory-evidence) ⭐3 — Git-first memory navigation and bounded evidence tools for DeepSeek Harness.（💤 停更）
+- [dsh-notebooks](https://github.com/havingautism/dsh-notebooks) ⭐3 — Notebooks plugin (cordis).（✅ 活跃）
+- [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) ⭐3 — DSH Windows 原生通知，零依赖。（✅ 活跃）
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) ⭐3 — dsh-passwords: DeepSeek Harness login gateway - first-run setup, at-rest encryption, brute-force lockout, audit log, HTTPS（✅ 活跃）
+- [dsh-plugin-diff-review](https://github.com/Civitasv/dsh-plugin-diff-review) ⭐3 — Diff Review Plugin for DeepSeek Harness（✅ 活跃）
 - [dsh-plugins-raincode](https://github.com/rainforest888/dsh-plugins-raincode) ⭐3 — dsh plugin: DeepSeek Harness 的模型层 = raincode(模型池/缓存/重试) + /skills 浏览（✅ 活跃）
-- [dsh-token-panel](https://github.com/juhe291/dsh-token-panel) ⭐3 — A corner HUD for DeepSeek Harness that shows your session's token pressure, per-model cost, and daily/monthly usage at a glance — with an editable budget & balance that tracks spending for you. 右下角常驻的 Token 仪表盘：实时查看会话压力、按模型估算花费，预算和余额点一下就能改，每天每月用了多少都有记录。（✅ 活跃）
+- [dsh-restart](https://github.com/anweat/dsh-restart) ⭐3 — Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.（✅ 活跃）
+- [dsh-suggested-replies](https://github.com/Anionex/dsh-suggested-replies) ⭐3 — DSH Web 预测回复插件：AI 回复后在输入框上方生成可点击填入草稿的候选。（✅ 活跃）
+- [dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) ⭐3 — Agent memory for DeepSeek Harness | DeepSeek Harness 记忆插件（✅ 活跃）
+- [dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) ⭐3 — Fail-closed export-copy redaction for DeepSeek Harness session telemetry（✅ 活跃）
+- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) ⭐3 — 结构化安全 Git 工具：status/diff/log/branch/stage/commit/stash/show，带破坏性命令防护。（✅ 活跃）
+- [dsh-ui-appearance](https://github.com/TQSY114514/dsh-ui-appearance) ⭐3 — Appearance customization plugin for DeepSeek Harness: theme color palette, background image, opacity/blur, glass effect（✅ 活跃）
+- [dsh-ultra-ui](https://github.com/havingautism/dsh-ultra-ui) ⭐3 — Ultra UI plugin (cordis).（✅ 活跃）
 - [dsh-usage-plugin](https://github.com/Yihong89/dsh-usage-plugin) ⭐3 — DeepSeek Harness (DSH) plugins. First: dsh-usage-report — per-session token usage & estimated cost (/usage + usage_report), priced from the DeepSeek pricing table.（✅ 活跃）
-- [dsh-weather](https://github.com/sunshine-lang/dsh-weather) ⭐3 — 天气工具：Open-Meteo 当前天气与多日预报，免费免密钥。（✅ 活跃）
-- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) ⭐3 — 多引擎持久搜索：DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/推特/Reddit/RSS，SQLite+LRU 缓存 + Playwright 渲染。（✅ 活跃）
 - [dsh-webbridge](https://github.com/bill9109/dsh-webbridge) ⭐3 — DSH 结合 Kimi WebBridge 操控真实浏览器。（✅ 活跃）
-- [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐3 — 输入框旁常用词箱：全局/项目词桶，一键插入。（✅ 活跃）
-- [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) ⭐2 — DSH Web UI 跨平台文件拖拽与原始路径插入，无需复制文件。（✅ 活跃）
-- [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) ⭐2 — 并行 Agent 会话的文件归属/认领系统：认领/释放、心跳过期接管、异步三路合并。（✅ 活跃）
-- [dsh-file-mount](https://github.com/acefun29/dsh-file-mount) ⭐2 — 增量文件挂载 + 行区间去重：相同文件内容不再重复发送给模型。（✅ 活跃）
+- [tokenledger](https://github.com/zh667/TokenLedger) ⭐3 — Token usage accounting for DeepSeek Harness, reconciled against New API and Sub2API relay-site billing（✅ 活跃）
+- [zotero-wave-rag](https://github.com/Fisfzy/zotero-wave-rag) ⭐3 — 面向 Zotero 论文库的浪潮式 RAG 细节检索系统 —— DSH 外部插件。移植 VCPToolBox 浪潮语义动力学思想（标签河道图传播/虫洞跳转/钟型阻尼/Ω重排），配 BM25+RRF 混合检索、claim-evidence 忠实度校验、两级增量索引（✅ 活跃）
+- [dsh-adb](https://github.com/SamXiaBing/dsh-adb) ⭐2 — ADB device & bench operations: device discovery, structured logcat (background streaming), apk install, file pull/push, dumpsys performance snapshots.（✅ 活跃）
+- [dsh-deepseek-quota](https://github.com/yingjunnan/dsh-deepseek-quota) ⭐2 — DeepSeek API quota (balance) widget for the DSH web GUI: a floating bottom-right card showing remaining DeepSeek API balance.（✅ 活跃）
+- [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) ⭐2 — 回复中文件路径可点击：内联打开、文件管理器揭示、提及文件芯片列表。（✅ 活跃）
 - [dsh-memory (Jesse-njx)](https://github.com/Jesse-njx/dsh-memory) ⭐2 — 基于 DSH 无损会话日志的引用式记忆：可人工审计的蒸馏事实，带引用来源。（✅ 活跃）
-- [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) ⭐2 — DSH Windows 原生通知，零依赖。（✅ 活跃）
-- [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) ⭐2 — PDF 工具箱：pdfjs-dist 本地提取文本、元数据与页区间，无需 API Key。（✅ 活跃）
+- [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) ⭐2 — 从操作条固定助手回复，并在下一轮召回（/pin /recall）。（✅ 活跃）
+- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) ⭐2 — mount one row in the composition and every plugin card on the Web Settings plugin list page gets a bilingual (zh/en) description; it also publishes the pluginDescriptions service so other plugins can register their own descriptions.（✅ 活跃）
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) ⭐2 — 带实时预览编辑用户与内置系统提示词片段。（✅ 活跃）
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) ⭐2 — 增量代码审查：基于检查点的审查队列 + Web UI 面板 + /review 命令。（✅ 活跃）
+- [dsh-scout](https://github.com/omdsh-dev/dsh-scout) ⭐2 — 面向 DeepSeek Harness 的只读环境探测插件，为智能体提供运行环境、软件版本、系统资源、端口、服务、硬件及工作区信息。（✅ 活跃）
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) ⭐2 — 免索引跨 Agent 会话搜索。（✅ 活跃）
-- [dsh-suggested-replies](https://github.com/Anionex/dsh-suggested-replies) ⭐2 — DSH Web 预测回复插件：AI 回复后在输入框上方生成可点击填入草稿的候选。（✅ 活跃）
-- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) ⭐2 — DSH Web 中英文金额 Token 计费：官方策略自动定价（含高峰/低谷），逐条消息费用台账。（✅ 活跃）
+- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) ⭐2 — 结构化测试运行工具：自动识别 vitest/jest/pytest/node:test，运行并解析失败摘要。（✅ 活跃）
+- [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) ⭐2 — 按 Agent 按需工具发现与渐进式 schema 披露。（✅ 活跃）
 - [URL Manager](https://github.com/Piccolo123/url-manager) ⭐2 — Agent 优先的 URL 与知识收集系统：自动分类、标签、全文检索与共享收藏。（✅ 活跃）
 - [dsh-computer-use](https://github.com/xiaoheizi1212/dsh-computer-use) ⭐1 — 模型无关的 Computer Use：隔离浏览器、Windows 原生助手与第三方桥接。（✅ 活跃）
-- [dsh-memento](https://github.com/PerryLink/dsh-memento) ⭐1 — 有界分层、审批门控、可审计的跨会话记忆，支持冻结快照注入。（✅ 活跃）
+- [dsh-doctor](https://github.com/asdf17128/dsh-doctor) ⭐1 — Find what your DeepSeek Harness (dsh) patches silently broke — dead patches, config fields dropped by whole-config replacement, unmaintained plugins. Read-only, zero deps.（✅ 活跃）
+- [dsh-news-plugin](https://github.com/canghai666x/dsh-news-plugin) ⭐1 — RSS/新闻摄入插件：返回结构化的标题/链接/来源/日期/摘要，供模型排序与简报。（✅ 活跃）
 - [dsh-payload-capture](https://github.com/Moeblack/dsh-payload-capture) ⭐1 — 捕捉每次上行模型 API payload，JSON 落盘，用于调试与可观测性。（✅ 活跃）
-- [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) ⭐1 — 从操作条固定助手回复，并在下一轮召回（/pin /recall）。（✅ 活跃）
-- [dsh-plugin-anydoc](https://github.com/beancookie/dsh-plugin-anydoc) ⭐1 — 基于 @firecrawl/anydoc 将 Word/PPT/Excel/PDF/EPUB/CSV 等文档转换为 GFM Markdown。（✅ 活跃）
-- [dsh-spend](https://github.com/nonewind/dsh-spend) ⭐1 — Token 用量与费用估算：悬浮面板，按模型/天/会话统计，自动识别计费套餐。（✅ 活跃）
-- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) ⭐1 — 结构化测试运行工具：自动识别 vitest/jest/pytest/node:test，运行并解析失败摘要。（✅ 活跃）
+- [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) ⭐1 — @dsh-pm/registry — discover dsh plugins by merging the awesome-dsh-plugin list, GitHub dsh-plugin-topic search, and npm keyword search into one deduped, offline-tolerant registry (the discovery engine of dsh pm)（✅ 活跃）
+- [dsh-plugin-quote-reply](https://github.com/yangYzc/dsh-plugin-quote-reply) ⭐1 — DSH plugin: select text in a conversation, then quote it into the composer or reply in a new window. / DeepSeek Harness 划词引用插件：选中文字一键引用回复或新窗口回复。（✅ 活跃）
+- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) ⭐1 — 回合索引侧栏：每个用户回合一条，点击跳转，滚动监听高亮。（✅ 活跃）
+- [dsh-turn-navigator](https://github.com/vibeinging/dsh-turn-navigator) ⭐1 — Private DSH Web turn navigation plugin（✅ 活跃）
 - [dsh-view-modes](https://github.com/NigelYao/dsh-view-modes) ⭐1 — Verbose/Normal/Summary 三种输出模式，工具调用与思考语义分组。（✅ 活跃）
-- [dsh-web-search-exa](https://github.com/TonyDua/dsh-web-search-exa) ⭐1 — 零配置 Exa 网页搜索：免密钥匿名 MCP 回退 + API Key REST 搜索。（✅ 活跃）
-- [dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) ⭐1 — VS Code 风格工作区关键词搜索：Better Sidebar 生态的搜索 Tab。（✅ 活跃）
-- [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions)  — 回复中文件路径可点击：内联打开、文件管理器揭示、提及文件芯片列表。（✅ 活跃）
+- [dshp](https://github.com/asdf17128/dshp) ⭐1 — Manage DeepSeek Harness profiles — list, create, clone, diff, and share a whole dsh setup as one portable file.（✅ 活跃）
+- [dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter)  — dsh plugin: per-turn USD cost badge in the Web UI (session total + per-message footer, hover breakdown) from token usage x a configurable pricing table.（✅ 活跃）
 - [dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads)  — 从 Web 输入框上传任意本地文件，待传卡片显示，设置页统一管理。（✅ 活跃）
 - [dsh-git-branch-switcher](https://github.com/mixin-ai/dsh-git-branch-switcher)  — 会话头部 git 分支胶囊：显示并在 Web UI 中切换工作区分支。（✅ 活跃）
-- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud)  — HUD 状态面板：浮动侧栏展示 git 状态、MCP 服务器、技能、模型与 token 用量。（✅ 活跃）
 - [dsh-memoria](https://github.com/jiayan-xu/dsh-memoria)  — 向量 + 图记忆后端：命名空间隔离、自动观察、召回、重要性处理与热重载。（🧪 实验性）
 - [dsh-memory](https://github.com/flymysql/dsh-memory)  — 跨会话记忆库：memory_remember / memory_recall / memory_forget 工具 + 设置页。（🧪 实验性）
-- [dsh-news-plugin](https://github.com/canghai666x/dsh-news-plugin)  — RSS/新闻摄入插件：返回结构化的标题/链接/来源/日期/摘要，供模型排序与简报。（✅ 活跃）
-- [dsh-recommend](https://github.com/zp-home/dsh-recommend)  — 透明插件排行榜与推荐：每日自动抓取 dsh-plugin 主题数据，开放评分模型。（✅ 活跃）
-- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git)  — 结构化安全 Git 工具：status/diff/log/branch/stage/commit/stash/show，带破坏性命令防护。（✅ 活跃）
-- [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search)  — 按 Agent 按需工具发现与渐进式 schema 披露。（✅ 活跃）
-- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index)  — 回合索引侧栏：每个用户回合一条，点击跳转，滚动监听高亮。（✅ 活跃）
+- [dsh-plugin-cost](https://github.com/yweilai77-dev/dsh-plugin-cost)  — Session cost estimate in the DSH Web composer dock (tokenUsage × configurable price table, one-click official-price refresh).（✅ 活跃）
+- [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces.（✅ 活跃）
+- [dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream)  — 丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 prefers-reduced-motion。（✅ 活跃）
+- [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech)  — Browser Web Speech API voice input for DSH: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).（✅ 活跃）
 
 ### Skills
 
@@ -319,33 +375,40 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) | ⭐12 | DSH Web 技能设置区：热启停、删除与新增。 | ✅ 活跃 |
-| 2 | [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) | ⭐9 | 插件开发踩坑与做法档案（skill + 文档）：cordis 双副本、tsconfig 三件套、Windows junction、多帧 zstd 实测。 | ✅ 活跃 |
-| 3 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | ⭐7 | 构建与测试 DSH 插件的 Agent 技能：从脚手架到发布。 | ✅ 活跃 |
-| 4 | [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | ⭐3 | 书转技能插件：获取→解析→理解→生成→安装的五阶段长任务。 | ✅ 活跃 |
-| 5 | [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) | ⭐2 | Godot Engine 4.x 全栈游戏开发技能插件。 | ✅ 活跃 |
-| 6 | [dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) | ⭐2 | DSH 代码评审技能集。 | ✅ 活跃 |
-| 7 | [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) | ⭐1 | 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索、安装与管理。 | ✅ 活跃 |
-| 8 | [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | ⭐1 | 安全审计技能包：5 个 Agent 技能，覆盖密钥扫描、依赖审计等。 | ✅ 活跃 |
-| 9 | [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) | ⭐1 | 让 Claude Code、Codex、Cursor、Gemini CLI 已有的技能在 DSH 中直接可用。 | ✅ 活跃 |
-| 10 | [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) | ⭐1 | 扫描会话可见技能，按与近期对话的相关度排序。 | ✅ 活跃 |
+| 1 | [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) | ⭐224 | EasyEDA Pro automation: Go daemon + in-app connector + agent skill + stdio MCP server for typed schematic/PCB actions, workflow gates, and DRC. | ✅ 活跃 |
+| 2 | [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) | ⭐34 | DSH Web 技能设置区：热启停、删除与新增。 | ✅ 活跃 |
+| 3 | [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | ⭐12 | Complete reverse-skill (85 SKILL.md) as a DeepSeek Harness (dsh) Cordis plugin — reverse engineering, authorized pentesting and security research skill pack. | ✅ 活跃 |
+| 4 | [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) | ⭐10 | 插件开发踩坑与做法档案（skill + 文档）：cordis 双副本、tsconfig 三件套、Windows junction、多帧 zstd 实测。 | ✅ 活跃 |
+| 5 | [dsh-science](https://github.com/biociao/dsh-science) | ⭐10 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ 活跃 |
+| 6 | [dsh-plugin-development](https://github.com/w2112515/dsh-plugin-development) | ⭐8 | Portable Agent Skill for developing and auditing DeepSeek Harness plugins, with an optional profile-installable DSH bundle adapter. | ✅ 活跃 |
+| 7 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | ⭐7 | 构建与测试 DSH 插件的 Agent 技能：从脚手架到发布。 | ✅ 活跃 |
+| 8 | [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | ⭐4 | 书转技能插件：获取→解析→理解→生成→安装的五阶段长任务。 | ✅ 活跃 |
+| 9 | [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) | ⭐4 | Godot Engine 4.x 全栈游戏开发技能插件。 | ✅ 活跃 |
+| 10 | [dsh-humanize](https://github.com/zevorn/dsh-humanize) | ⭐3 | 去 AI 味写作技能：让 Agent 输出更自然。 | ✅ 活跃 |
 
-#### 完整列表（14）
+#### 完整列表（21）
 
-- [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) ⭐12 — DSH Web 技能设置区：热启停、删除与新增。（✅ 活跃）
-- [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) ⭐9 — 插件开发踩坑与做法档案（skill + 文档）：cordis 双副本、tsconfig 三件套、Windows junction、多帧 zstd 实测。（✅ 活跃）
+- [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) ⭐224 — EasyEDA Pro automation: Go daemon + in-app connector + agent skill + stdio MCP server for typed schematic/PCB actions, workflow gates, and DRC.（✅ 活跃）
+- [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) ⭐34 — DSH Web 技能设置区：热启停、删除与新增。（✅ 活跃）
+- [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) ⭐12 — Complete reverse-skill (85 SKILL.md) as a DeepSeek Harness (dsh) Cordis plugin — reverse engineering, authorized pentesting and security research skill pack.（✅ 活跃）
+- [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) ⭐10 — 插件开发踩坑与做法档案（skill + 文档）：cordis 双副本、tsconfig 三件套、Windows junction、多帧 zstd 实测。（✅ 活跃）
+- [dsh-science](https://github.com/biociao/dsh-science) ⭐10 — Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.（✅ 活跃）
+- [dsh-plugin-development](https://github.com/w2112515/dsh-plugin-development) ⭐8 — Portable Agent Skill for developing and auditing DeepSeek Harness plugins, with an optional profile-installable DSH bundle adapter.（✅ 活跃）
 - [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) ⭐7 — 构建与测试 DSH 插件的 Agent 技能：从脚手架到发布。（✅ 活跃）
-- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) ⭐3 — 书转技能插件：获取→解析→理解→生成→安装的五阶段长任务。（✅ 活跃）
-- [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) ⭐2 — Godot Engine 4.x 全栈游戏开发技能插件。（✅ 活跃）
+- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) ⭐4 — 书转技能插件：获取→解析→理解→生成→安装的五阶段长任务。（✅ 活跃）
+- [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) ⭐4 — Godot Engine 4.x 全栈游戏开发技能插件。（✅ 活跃）
+- [dsh-humanize](https://github.com/zevorn/dsh-humanize) ⭐3 — 去 AI 味写作技能：让 Agent 输出更自然。（✅ 活跃）
+- [dsh-memoryhub](https://github.com/solknight48/dsh-memoryhub) ⭐3 — MemoryHub (mh) plugin for DeepSeek Harness (dsh): auto-loads checkpoint memory on session start, adds mh_* tools and the mh skill, and a Memory tab in the web UI（✅ 活跃）
+- [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) ⭐3 — 扫描会话可见技能，按与近期对话的相关度排序。（✅ 活跃）
+- [deepseek-harness-skillx](https://github.com/drowned-fish1/deepseek-harness-skillx) ⭐2 — DSH 工作流技能合集。（✅ 活跃）
+- [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) ⭐2 — 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索、安装与管理。（✅ 活跃）
+- [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) ⭐2 — DSH knowledge-base plugin: build audit-able KB packs (references + SQLite FTS5) from md/txt/docx/pdf, deterministic retrieval (kb_query) and original-text reading (kb_read), zero-script generated skills. Apache-2.0.（✅ 活跃）
 - [dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) ⭐2 — DSH 代码评审技能集。（✅ 活跃）
-- [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) ⭐1 — 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索、安装与管理。（✅ 活跃）
-- [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) ⭐1 — 安全审计技能包：5 个 Agent 技能，覆盖密钥扫描、依赖审计等。（✅ 活跃）
-- [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) ⭐1 — 让 Claude Code、Codex、Cursor、Gemini CLI 已有的技能在 DSH 中直接可用。（✅ 活跃）
-- [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) ⭐1 — 扫描会话可见技能，按与近期对话的相关度排序。（✅ 活跃）
-- [deepseek-harness-skillx](https://github.com/drowned-fish1/deepseek-harness-skillx)  — DSH 工作流技能合集。（✅ 活跃）
-- [dsh-humanize](https://github.com/zevorn/dsh-humanize)  — 去 AI 味写作技能：让 Agent 输出更自然。（✅ 活跃）
+- [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) ⭐2 — 安全审计技能包：5 个 Agent 技能，覆盖密钥扫描、依赖审计等。（✅ 活跃）
+- [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) ⭐2 — 让 Claude Code、Codex、Cursor、Gemini CLI 已有的技能在 DSH 中直接可用。（✅ 活跃）
+- [dsh-web-novel-research](https://github.com/canghai666x/dsh-web-novel-research) ⭐1 — 中文网文情节查证技能：免费镜像站流程，GBK 解码与跨卷重复章节消歧。（✅ 活跃）
 - [dsh-news-briefing](https://github.com/canghai666x/dsh-news-briefing)  — 新闻简报技能：多维故事评分、反标题党规则、内容优先级与中文编辑风格。（✅ 活跃）
-- [dsh-web-novel-research](https://github.com/canghai666x/dsh-web-novel-research)  — 中文网文情节查证技能：免费镜像站流程，GBK 解码与跨卷重复章节消歧。（✅ 活跃）
+- [mstar-workflow](https://github.com/btspoony/mstar-workflow)  — A Skill-driven Harness/Loop Engineering Workflow Agent Plugin（💤 停更）
 
 ### Workflows & Automation
 
@@ -354,38 +417,39 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | ⭐54 | 把 Claude Code 的 UltraCode 模式带给 DSH：将一次性多 Agent 调度升级为可生成、可保存、可治理、可观察、可恢复的 Workflow 层。 | ✅ 活跃 |
-| 2 | [mstar-harness](https://github.com/btspoony/mstar-harness) | ⭐42 | 技能驱动的 Harness/Loop 工程工作流 Agent：把 Agent 循环调优作为一等工作流。 | ✅ 活跃 |
-| 3 | [dsh-automation](https://github.com/titanwings/dsh-automation) | ⭐27 | 让 Coding 任务按计划在全新 Agent Session 中运行，由用户或 Agent 创建和管理定时任务。 | ✅ 活跃 |
-| 4 | [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | ⭐9 | 自动恢复中断的请求：失败分类、自适应退避重试、可配置续写消息与浏览器通知。 | ✅ 活跃 |
-| 5 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | ⭐9 | 基于官方 workflow 引擎的自适应深度研究编排器。 | ✅ 活跃 |
-| 6 | [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) | ⭐7 | 运维工具箱：官方每日快照 A/B 双槽轮换、原子切换、一键回滚、守护进程自动拉起。 | ✅ 活跃 |
-| 7 | [dsh-track](https://github.com/fakechris/dsh-track) | ⭐5 | 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。 | ✅ 活跃 |
-| 8 | [engineer-software](https://github.com/KirschBluteX/engineer-software) | ⭐5 | 与运行时无关、证据驱动的软件工程工作流，适用于 Codex 与 DeepSeek Harness。 | ✅ 活跃 |
-| 9 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | ⭐4 | 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场。 | ✅ 活跃 |
-| 10 | [dsh-plans](https://github.com/Optim-Agent/dsh-plans) | ⭐4 | 从 prime-plans 移植的人机协同规划预设：调研、评审、执行。 | ✅ 活跃 |
+| 1 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | ⭐56 | 把 Claude Code 的 UltraCode 模式带给 DSH：将一次性多 Agent 调度升级为可生成、可保存、可治理、可观察、可恢复的 Workflow 层。 | ✅ 活跃 |
+| 2 | [mstar-harness](https://github.com/btspoony/mstar-harness) | ⭐46 | 技能驱动的 Harness/Loop 工程工作流 Agent：把 Agent 循环调优作为一等工作流。 | ✅ 活跃 |
+| 3 | [dsh-automation](https://github.com/titanwings/dsh-automation) | ⭐39 | 让 Coding 任务按计划在全新 Agent Session 中运行，由用户或 Agent 创建和管理定时任务。 | ✅ 活跃 |
+| 4 | [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | ⭐15 | 自动恢复中断的请求：失败分类、自适应退避重试、可配置续写消息与浏览器通知。 | ✅ 活跃 |
+| 5 | [dsh-plans](https://github.com/Optim-Agent/dsh-plans) | ⭐13 | 从 prime-plans 移植的人机协同规划预设：调研、评审、执行。 | ✅ 活跃 |
+| 6 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | ⭐12 | 基于官方 workflow 引擎的自适应深度研究编排器。 | ✅ 活跃 |
+| 7 | [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) | ⭐9 | 运维工具箱：官方每日快照 A/B 双槽轮换、原子切换、一键回滚、守护进程自动拉起。 | ✅ 活跃 |
+| 8 | [dsh-track](https://github.com/fakechris/dsh-track) | ⭐6 | 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。 | ✅ 活跃 |
+| 9 | [engineer-software](https://github.com/KirschBluteX/engineer-software) | ⭐6 | 与运行时无关、证据驱动的软件工程工作流，适用于 Codex 与 DeepSeek Harness。 | ✅ 活跃 |
+| 10 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | ⭐5 | 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场。 | ✅ 活跃 |
 
-#### 完整列表（20）
+#### 完整列表（21）
 
-- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐54 — 把 Claude Code 的 UltraCode 模式带给 DSH：将一次性多 Agent 调度升级为可生成、可保存、可治理、可观察、可恢复的 Workflow 层。（✅ 活跃）
-- [mstar-harness](https://github.com/btspoony/mstar-harness) ⭐42 — 技能驱动的 Harness/Loop 工程工作流 Agent：把 Agent 循环调优作为一等工作流。（✅ 活跃）
-- [dsh-automation](https://github.com/titanwings/dsh-automation) ⭐27 — 让 Coding 任务按计划在全新 Agent Session 中运行，由用户或 Agent 创建和管理定时任务。（✅ 活跃）
-- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) ⭐9 — 自动恢复中断的请求：失败分类、自适应退避重试、可配置续写消息与浏览器通知。（✅ 活跃）
-- [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) ⭐9 — 基于官方 workflow 引擎的自适应深度研究编排器。（✅ 活跃）
-- [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) ⭐7 — 运维工具箱：官方每日快照 A/B 双槽轮换、原子切换、一键回滚、守护进程自动拉起。（✅ 活跃）
-- [dsh-track](https://github.com/fakechris/dsh-track) ⭐5 — 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。（✅ 活跃）
-- [engineer-software](https://github.com/KirschBluteX/engineer-software) ⭐5 — 与运行时无关、证据驱动的软件工程工作流，适用于 Codex 与 DeepSeek Harness。（✅ 活跃）
-- [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) ⭐4 — 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场。（✅ 活跃）
-- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) ⭐4 — 从 prime-plans 移植的人机协同规划预设：调研、评审、执行。（✅ 活跃）
-- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) ⭐3 — 面向 Harness 的 DeepResearch 插件（cordis）。（🧪 实验性）
-- [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) ⭐3 — 发现问题(checkup) → 修复交付(fix) → 质量复查(review) 的对抗式闭环。（✅ 活跃）
+- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐56 — 把 Claude Code 的 UltraCode 模式带给 DSH：将一次性多 Agent 调度升级为可生成、可保存、可治理、可观察、可恢复的 Workflow 层。（✅ 活跃）
+- [mstar-harness](https://github.com/btspoony/mstar-harness) ⭐46 — 技能驱动的 Harness/Loop 工程工作流 Agent：把 Agent 循环调优作为一等工作流。（✅ 活跃）
+- [dsh-automation](https://github.com/titanwings/dsh-automation) ⭐39 — 让 Coding 任务按计划在全新 Agent Session 中运行，由用户或 Agent 创建和管理定时任务。（✅ 活跃）
+- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) ⭐15 — 自动恢复中断的请求：失败分类、自适应退避重试、可配置续写消息与浏览器通知。（✅ 活跃）
+- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) ⭐13 — 从 prime-plans 移植的人机协同规划预设：调研、评审、执行。（✅ 活跃）
+- [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) ⭐12 — 基于官方 workflow 引擎的自适应深度研究编排器。（✅ 活跃）
+- [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) ⭐9 — 运维工具箱：官方每日快照 A/B 双槽轮换、原子切换、一键回滚、守护进程自动拉起。（✅ 活跃）
+- [dsh-track](https://github.com/fakechris/dsh-track) ⭐6 — 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。（✅ 活跃）
+- [engineer-software](https://github.com/KirschBluteX/engineer-software) ⭐6 — 与运行时无关、证据驱动的软件工程工作流，适用于 Codex 与 DeepSeek Harness。（✅ 活跃）
+- [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) ⭐5 — 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场。（✅ 活跃）
+- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) ⭐5 — 面向 Harness 的 DeepResearch 插件（cordis）。（🧪 实验性）
+- [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) ⭐5 — 发现问题(checkup) → 修复交付(fix) → 质量复查(review) 的对抗式闭环。（✅ 活跃）
+- [dsh-agent-orchestration](https://github.com/LeslieWylie/dsh-agent-orchestration) ⭐3 — Evidence-first multi-agent workflow planning, handoff validation, and Loop Guard skills for DeepSeek Harness.（💤 停更）
 - [dsh-plugin-spur](https://github.com/HuanLinOTO/dsh-plugin-spur) ⭐3 — 聊天流中悬挂皮鞭：甩动鞭梢即向 agent 发送 go work 消息（整活）。（✅ 活跃）
 - [dsh-prime-agent](https://github.com/yoke233/dsh-prime-agent) ⭐3 — Prime Agent 启发的持久 RLM 控制平面，面向 DSH Code 模式。（✅ 活跃）
-- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) ⭐1 — 工程纪律循环：编辑前需求拷问、红/绿测试证据门、对抗式交付审查。（✅ 活跃）
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) ⭐2 — 工程纪律循环：编辑前需求拷问、红/绿测试证据门、对抗式交付审查。（✅ 活跃）
+- [dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) ⭐2 — 工作流运行、子代理、状态与依赖的持久化实时 DAG 可视化。（✅ 活跃）
 - [dsh-governance](https://github.com/tappass/dsh-governance) ⭐1 — Agentic AI 的权威层插件：按你的策略治理每次工具调用。（✅ 活跃）
+- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) ⭐1 — 把 DSH 会话变成可交付工作报告（日报/周报/交接/文章），带可验证凭证。（✅ 活跃）
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval)  — Agent 评测平台：benchmark YAML、无头 dsh 运行、基于 trace 的指标、脚本评分与运行对比。（✅ 活跃）
-- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio)  — 把 DSH 会话变成可交付工作报告（日报/周报/交接/文章），带可验证凭证。（✅ 活跃）
-- [dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag)  — 工作流运行、子代理、状态与依赖的持久化实时 DAG 可视化。（✅ 活跃）
 - [dsh-trajectory-debug](https://github.com/devmom/dsh-trajectory-debug)  — 轨迹瀑布流、确定性回放、断点、编辑重跑、fork 对比与性能分析。（✅ 活跃）
 
 ### Agents & Multi-Agent
@@ -395,41 +459,41 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) | ⭐2,324 | 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） | ✅ 活跃 |
-| 2 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | ⭐222 | 面向团队的 DSH 多 Agent 扩展。 | ✅ 活跃 |
-| 3 | [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) | ⭐101 | SillyTavern 迁移与下一代 Agent 角色扮演。 | ✅ 活跃 |
-| 4 | [allinluna](https://github.com/zenx0x/allinluna) | ⭐25 | 面向 Codex 与 DeepSeek Harness 的资源感知多 Agent 编排。 | ✅ 活跃 |
-| 5 | [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | ⭐24 | 跨实例消息/事件交接插件（interconnect 服务 + 工具）。 | ✅ 活跃 |
-| 6 | [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) | ⭐19 | OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 | ✅ 活跃 |
-| 7 | [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) | ⭐19 | DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 | ✅ 活跃 |
-| 8 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | ⭐17 | 会话级数据库连接 + 专用数据 Agent：让模型连数据库、写 SQL。 | ✅ 活跃 |
-| 9 | [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | ⭐12 | 将 DSH 桥接到 Claude Code：审查、批判、委托与会话导入。 | ✅ 活跃 |
-| 10 | [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) | ⭐8 | 基于角色的 Codex/Claude Code/ACP 子代理提供方：可延续的子任务，带持久状态。 | ✅ 活跃 |
+| 1 | [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) | ⭐2,493 | 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） | ✅ 活跃 |
+| 2 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | ⭐312 | 面向团队的 DSH 多 Agent 扩展。 | ✅ 活跃 |
+| 3 | [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) | ⭐121 | SillyTavern 迁移与下一代 Agent 角色扮演。 | ✅ 活跃 |
+| 4 | [allinluna](https://github.com/zenx0x/allinluna) | ⭐28 | 面向 Codex 与 DeepSeek Harness 的资源感知多 Agent 编排。 | ✅ 活跃 |
+| 5 | [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | ⭐27 | 跨实例消息/事件交接插件（interconnect 服务 + 工具）。 | ✅ 活跃 |
+| 6 | [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) | ⭐26 | OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 | ✅ 活跃 |
+| 7 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | ⭐25 | 会话级数据库连接 + 专用数据 Agent：让模型连数据库、写 SQL。 | ✅ 活跃 |
+| 8 | [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) | ⭐23 | DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 | ✅ 活跃 |
+| 9 | [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | ⭐15 | 将 DSH 桥接到 Claude Code：审查、批判、委托与会话导入。 | ✅ 活跃 |
+| 10 | [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) | ⭐9 | 配对第二模型被动审查每一回合并注入建议。 | ✅ 活跃 |
 
 #### 完整列表（23）
 
-- [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) ⭐2,324 — 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin）（✅ 活跃）
-- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) ⭐222 — 面向团队的 DSH 多 Agent 扩展。（✅ 活跃）
-- [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) ⭐101 — SillyTavern 迁移与下一代 Agent 角色扮演。（✅ 活跃）
-- [allinluna](https://github.com/zenx0x/allinluna) ⭐25 — 面向 Codex 与 DeepSeek Harness 的资源感知多 Agent 编排。（✅ 活跃）
-- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) ⭐24 — 跨实例消息/事件交接插件（interconnect 服务 + 工具）。（✅ 活跃）
-- [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) ⭐19 — OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。（✅ 活跃）
-- [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) ⭐19 — DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。（✅ 活跃）
-- [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) ⭐17 — 会话级数据库连接 + 专用数据 Agent：让模型连数据库、写 SQL。（✅ 活跃）
-- [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) ⭐12 — 将 DSH 桥接到 Claude Code：审查、批判、委托与会话导入。（✅ 活跃）
-- [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) ⭐8 — 基于角色的 Codex/Claude Code/ACP 子代理提供方：可延续的子任务，带持久状态。（✅ 活跃）
-- [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) ⭐5 — 配对第二模型被动审查每一回合并注入建议。（✅ 活跃）
+- [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) ⭐2,493 — 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin）（✅ 活跃）
+- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) ⭐312 — 面向团队的 DSH 多 Agent 扩展。（✅ 活跃）
+- [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) ⭐121 — SillyTavern 迁移与下一代 Agent 角色扮演。（✅ 活跃）
+- [allinluna](https://github.com/zenx0x/allinluna) ⭐28 — 面向 Codex 与 DeepSeek Harness 的资源感知多 Agent 编排。（✅ 活跃）
+- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) ⭐27 — 跨实例消息/事件交接插件（interconnect 服务 + 工具）。（✅ 活跃）
+- [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) ⭐26 — OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。（✅ 活跃）
+- [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) ⭐25 — 会话级数据库连接 + 专用数据 Agent：让模型连数据库、写 SQL。（✅ 活跃）
+- [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) ⭐23 — DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。（✅ 活跃）
+- [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) ⭐15 — 将 DSH 桥接到 Claude Code：审查、批判、委托与会话导入。（✅ 活跃）
+- [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) ⭐9 — 配对第二模型被动审查每一回合并注入建议。（✅ 活跃）
+- [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) ⭐9 — 基于角色的 Codex/Claude Code/ACP 子代理提供方：可延续的子任务，带持久状态。（✅ 活跃）
+- [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) ⭐7 — 可配置子代理 profile 系统：单一 subagent 工具 + profile 参数，含 Web UI 设置与实时进度。（✅ 活跃）
+- [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) ⭐7 — 侧会话：/side 持续性侧会话（Codex 风格）与 /btw 一次性侧问（Claude 风格），临时 fork 中运行。（✅ 活跃）
 - [dsh-plugin-claude-bridge](https://github.com/YYTbit/dsh-plugin-claude-bridge) ⭐5 — 把 Claude Code 的记忆、技能与配置桥接到 DSH。（✅ 活跃）
-- [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) ⭐5 — 可配置子代理 profile 系统：单一 subagent 工具 + profile 参数，含 Web UI 设置与实时进度。（✅ 活跃）
 - [Task Passport](https://github.com/dongsheng123132/task-passport) ⭐5 — 跨编码 Agent 环境的开放任务交接协议：交接可验证的状态而非聊天记录。（✅ 活跃）
+- [dsh-a2a](https://github.com/dpskh/dsh-a2a) ⭐4 — 面向 Harness 的 Agent2Agent 网状网络。（✅ 活跃）
 - [dsh-agent-messaging](https://github.com/happyren/dsh-agent-messaging) ⭐4 — 跨会话 Agent 互发消息：按名称寻址其他会话。（✅ 活跃）
-- [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) ⭐4 — 侧会话：/side 持续性侧会话（Codex 风格）与 /btw 一次性侧问（Claude 风格），临时 fork 中运行。（✅ 活跃）
-- [dsh-a2a](https://github.com/dpskh/dsh-a2a) ⭐2 — 面向 Harness 的 Agent2Agent 网状网络。（✅ 活跃）
-- [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) ⭐2 — 基于角色的模型重试与备用策略插件。（✅ 活跃）
+- [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) ⭐4 — 基于角色的模型重试与备用策略插件。（✅ 活跃）
+- [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) ⭐2 — 跨会话消息：同机 DSH 会话之间可发现、互发消息并协同。（✅ 活跃）
+- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) ⭐2 — 子代理委托的逐调用模型/provider/persona/toolFilter 覆盖，支持 @preset 引用。（✅ 活跃）
 - [dsh-cross-session](https://github.com/Wha1eChai/dsh-cross-session) ⭐1 — 同运行时跨会话发现与通信。（✅ 活跃）
-- [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) ⭐1 — 跨会话消息：同机 DSH 会话之间可发现、互发消息并协同。（✅ 活跃）
 - [dsh-slice-agent-loop](https://github.com/TT-Wang/dsh-slice-agent-loop) ⭐1 — 可替换的 Agent 循环：上下文引擎是有界切片而非不断增长的记录。（✅ 活跃）
-- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) ⭐1 — 子代理委托的逐调用模型/provider/persona/toolFilter 覆盖，支持 @preset 引用。（✅ 活跃）
 - [dsh-supervisor](https://github.com/Wha1eChai/dsh-supervisor) ⭐1 — 同运行时跨会话发现与通信。（✅ 活跃）
 
 ### Clients (Desktop & TUI)
@@ -439,54 +503,70 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) | ⭐962 | 为 DeepSeek Harness 生态打造的现代化桌面端体验（插件）。 | ✅ 活跃 |
-| 2 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | ⭐793 | Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表。 | ✅ 活跃 |
-| 3 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | ⭐160 | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，分层安装。 | ✅ 活跃 |
-| 4 | [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) | ⭐140 | DeepSeek Harness 桌面应用。 | ✅ 活跃 |
-| 5 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | ⭐125 | DSH 交互式终端 UI 插件：在官方基础上增加 TDD、证据门、视觉图像模块等工作流。 | ✅ 活跃 |
-| 6 | [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) | ⭐104 | 极简跨平台桌面端：免配置，开箱即用。 | ✅ 活跃 |
-| 7 | [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) | ⭐74 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch | ✅ 活跃 |
-| 8 | [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) | ⭐67 | DeepSeek Harness 桌面封装。 | ✅ 活跃 |
-| 9 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | ⭐65 | 轻量 Windows 启动器：登录静默自启 + 极简 WebView2 窗口。 | ✅ 活跃 |
-| 10 | [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) | ⭐63 | 一键桌面应用：全本地运行，核心自愈更新，零环境配置。Win/macOS/Linux。 | ✅ 活跃 |
+| 1 | [open-design](https://github.com/nexu-io/open-design) | ⭐86,741 | 🎨 The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode / Hermes & 20+ CLIs via BYOK. | ✅ 活跃 |
+| 2 | [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) | ⭐4,667 | 为 DeepSeek Harness 生态打造的现代化桌面端体验（插件）。 | ✅ 活跃 |
+| 3 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | ⭐1,156 | Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表。 | ✅ 活跃 |
+| 4 | [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) | ⭐227 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch | ✅ 活跃 |
+| 5 | [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) | ⭐221 | DeepSeek Harness 桌面应用。 | ✅ 活跃 |
+| 6 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | ⭐184 | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，分层安装。 | ✅ 活跃 |
+| 7 | [deepseek-harness-eac](https://github.com/zouyuxuan122/Deepseek-Harness-EAC) | ⭐158 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch, 10 built-in UI skins. EAC: Embracing All Creation 揽尽万象 | ✅ 活跃 |
+| 8 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | ⭐153 | DSH 交互式终端 UI 插件：在官方基础上增加 TDD、证据门、视觉图像模块等工作流。 | ✅ 活跃 |
+| 9 | [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) | ⭐143 | 一键桌面应用：全本地运行，核心自愈更新，零环境配置。Win/macOS/Linux。 | ✅ 活跃 |
+| 10 | [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) | ⭐139 | 极简跨平台桌面端：免配置，开箱即用。 | ✅ 活跃 |
 
-#### 完整列表（35）
+#### 完整列表（51）
 
-- [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) ⭐962 — 为 DeepSeek Harness 生态打造的现代化桌面端体验（插件）。（✅ 活跃）
-- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) ⭐793 — Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表。（✅ 活跃）
-- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) ⭐160 — 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，分层安装。（✅ 活跃）
-- [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) ⭐140 — DeepSeek Harness 桌面应用。（✅ 活跃）
-- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) ⭐125 — DSH 交互式终端 UI 插件：在官方基础上增加 TDD、证据门、视觉图像模块等工作流。（✅ 活跃）
-- [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) ⭐104 — 极简跨平台桌面端：免配置，开箱即用。（✅ 活跃）
-- [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) ⭐74 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch（✅ 活跃）
-- [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) ⭐67 — DeepSeek Harness 桌面封装。（✅ 活跃）
-- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) ⭐65 — 轻量 Windows 启动器：登录静默自启 + 极简 WebView2 窗口。（✅ 活跃）
-- [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) ⭐63 — 一键桌面应用：全本地运行，核心自愈更新，零环境配置。Win/macOS/Linux。（✅ 活跃）
-- [deepseek-harness-desktop (xiincs)](https://github.com/xiincs/deepseek-harness-desktop) ⭐53 — 基于 Tauri 2 的原生桌面版：内置 Node.js 运行时，托盘常驻，自动更新。（✅ 活跃）
-- [Deepseek-Harness-Desktop (ChisaAlter)](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) ⭐50 — Electron 桌面壳：支持主题与背景图等多种个性化配置。（✅ 活跃）
-- [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) ⭐27 — 在 Multica 上支持 dsh 运行时。（✅ 活跃）
-- [dsh-work](https://github.com/vibeinging/dsh-work) ⭐25 — Local-first AI workbench for DSH Plugins, combining Agent sessions, project files, data analysis, web research, MCP, and Office artifacts in an Electron desktop app.（✅ 活跃）
-- [deepseek-harness-app (ipfred)](https://github.com/ipfred/deepseek-harness-app) ⭐23 — DeepSeek Harness 桌面应用。（✅ 活跃）
-- [deepseek-harness-desktop (hongfeiyucode)](https://github.com/hongfeiyucode/deepseek-harness-desktop) ⭐23 — DeepSeek Harness 桌面封装。（✅ 活跃）
-- [deepseek-harness-desktop (ningbainb)](https://github.com/ningbainb/deepseek-harness-desktop) ⭐21 — 无损 Windows 桌面应用：完整 DSH Web UI、插件、皮肤与技能停靠栏。（✅ 活跃）
-- [DeepSeekHarnessDesktop (wess09)](https://github.com/wess09/DeepSeekHarnessDesktop) ⭐20 — DeepSeek Harness 桌面端打包。（✅ 活跃）
-- [dsh-desktop (bruc3van)](https://github.com/bruc3van/dsh-desktop) ⭐20 — 第三方桌面客户端：直接加载官方 Web UI，可复用本机实例或内置 dsh 运行时。（✅ 活跃）
-- [DeepSeek Harness TUI (openma-ai)](https://github.com/openma-ai/deepseek-harness-tui) ⭐15 — Rust/Ratatui 终端客户端，直接与 DSH 的 SDK JSON-RPC 协议通信。（✅ 活跃）
-- [deepseek-harness-desktop (cc1252)](https://github.com/cc1252/deepseek-harness-desktop) ⭐14 — 非官方 Windows Electron 封装。（✅ 活跃）
-- [DeepSeek-Harness-Desktop (sleep2agi)](https://github.com/sleep2agi/DeepSeek-Harness-Desktop) ⭐11 — 社区桌面壳。（✅ 活跃）
-- [awesome-deepseek-harness-desktop (ADHD)](https://github.com/omdsh-dev/awesome-deepseek-harness-desktop) ⭐10 — ADHD — 开箱即用的 Electron 桌面封装。（✅ 活跃）
+- [open-design](https://github.com/nexu-io/open-design) ⭐86,741 — 🎨 The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode / Hermes & 20+ CLIs via BYOK.（✅ 活跃）
+- [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) ⭐4,667 — 为 DeepSeek Harness 生态打造的现代化桌面端体验（插件）。（✅ 活跃）
+- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) ⭐1,156 — Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表。（✅ 活跃）
+- [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) ⭐227 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch（✅ 活跃）
+- [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) ⭐221 — DeepSeek Harness 桌面应用。（✅ 活跃）
+- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) ⭐184 — 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，分层安装。（✅ 活跃）
+- [deepseek-harness-eac](https://github.com/zouyuxuan122/Deepseek-Harness-EAC) ⭐158 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch, 10 built-in UI skins. EAC: Embracing All Creation 揽尽万象（✅ 活跃）
+- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) ⭐153 — DSH 交互式终端 UI 插件：在官方基础上增加 TDD、证据门、视觉图像模块等工作流。（✅ 活跃）
+- [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) ⭐143 — 一键桌面应用：全本地运行，核心自愈更新，零环境配置。Win/macOS/Linux。（✅ 活跃）
+- [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) ⭐139 — 极简跨平台桌面端：免配置，开箱即用。（✅ 活跃）
+- [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) ⭐115 — DeepSeek Harness Desktop App: a local AI desktop workspace for DSH Sessions, projects, files, web research, plugins, and Office artifacts.（✅ 活跃）
+- [dsh-work](https://github.com/vibeinging/dsh-work) ⭐115 — Local-first AI workbench for DSH Plugins, combining Agent sessions, project files, data analysis, web research, MCP, and Office artifacts in an Electron desktop app.（✅ 活跃）
+- [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) ⭐94 — DeepSeek Harness 桌面封装。（✅ 活跃）
+- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) ⭐92 — 轻量 Windows 启动器：登录静默自启 + 极简 WebView2 窗口。（✅ 活跃）
+- [Deepseek-Harness-Desktop (ChisaAlter)](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) ⭐81 — Electron 桌面壳：支持主题与背景图等多种个性化配置。（✅ 活跃）
+- [deepseek-harness-desktop (ningbainb)](https://github.com/ningbainb/deepseek-harness-desktop) ⭐44 — 无损 Windows 桌面应用：完整 DSH Web UI、插件、皮肤与技能停靠栏。（✅ 活跃）
+- [deepseek-harness-desktop (hongfeiyucode)](https://github.com/hongfeiyucode/deepseek-harness-desktop) ⭐37 — DeepSeek Harness 桌面封装。（✅ 活跃）
+- [DeepSeekHarnessDesktop (wess09)](https://github.com/wess09/DeepSeekHarnessDesktop) ⭐37 — DeepSeek Harness 桌面端打包。（✅ 活跃）
+- [deepseek-harness-desktop (xiincs)](https://github.com/xiincs/deepseek-harness-desktop) ⭐36 — 基于 Tauri 2 的原生桌面版：内置 Node.js 运行时，托盘常驻，自动更新。（✅ 活跃）
+- [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) ⭐34 — 在 Multica 上支持 dsh 运行时。（✅ 活跃）
+- [dsh-desktop (bruc3van)](https://github.com/bruc3van/dsh-desktop) ⭐29 — 第三方桌面客户端：直接加载官方 Web UI，可复用本机实例或内置 dsh 运行时。（✅ 活跃）
+- [deepseek-harness-app (ipfred)](https://github.com/ipfred/deepseek-harness-app) ⭐26 — DeepSeek Harness 桌面应用。（✅ 活跃）
+- [DeepSeek Harness TUI (openma-ai)](https://github.com/openma-ai/deepseek-harness-tui) ⭐25 — Rust/Ratatui 终端客户端，直接与 DSH 的 SDK JSON-RPC 协议通信。（✅ 活跃）
+- [deepseek-harness-desktop (cc1252)](https://github.com/cc1252/deepseek-harness-desktop) ⭐17 — 非官方 Windows Electron 封装。（✅ 活跃）
+- [deepseek-harness-termux](https://github.com/Vengisk/deepseek-harness-termux) ⭐15 — 在 Android/Termux 上运行 DeepSeek Harness。（✅ 活跃）
+- [dsh-plugin-session-delete](https://github.com/lsz-asd/dsh-plugin-session-delete) ⭐15 — Delete DeepSeek Harness sessions from the UI: header danger button + sidebar session-row menu item (no conversation jump), risk-consent dialog with session name/id, stops running agents first, in-place list refresh without page reload. Works in web and the desktop client.（✅ 活跃）
+- [DeepSeek-Harness-Desktop (sleep2agi)](https://github.com/sleep2agi/DeepSeek-Harness-Desktop) ⭐14 — 社区桌面壳。（✅ 活跃）
+- [dsh-usage-plugin](https://github.com/feiyang-dev/dsh-usage-plugin) ⭐14 — DeepSeek Harness 用量与消耗插件（dsh-usage）—— 每次调用的 token 用量/缓存命中统计、峰谷计费、余额查询、CSV/JSON/PNG 导出，可经桌面端一键安装或命令行 dsh plugin add 安装。（✅ 活跃）
+- [dsh-mobile](https://github.com/lehhair/dsh-mobile) ⭐12 — Mobile client plugin (cordis + dsh.plugin.json).（✅ 活跃）
+- [awesome-deepseek-harness-desktop (ADHD)](https://github.com/omdsh-dev/awesome-deepseek-harness-desktop) ⭐11 — ADHD — 开箱即用的 Electron 桌面封装。（✅ 活跃）
 - [deepseek-harness-desktop (chyra-moon)](https://github.com/chyra-moon/deepseek-harness-desktop) ⭐10 — Windows 原生桌面壳：官方 Web UI 1:1 复刻，内置服务、托盘与自动恢复。（✅ 活跃）
-- [deepseek-harness-termux](https://github.com/Vengisk/deepseek-harness-termux) ⭐9 — 在 Android/Termux 上运行 DeepSeek Harness。（✅ 活跃）
-- [deepseek-harness-desktop](https://github.com/omdsh-dev/deepseek-harness-desktop) ⭐7 — DSH 桌面应用打包器（✅ 活跃）
-- [deepseek-harness-desktop](https://github.com/qyqy-1109/deepseek-harness-desktop) ⭐6 — DeepSeek Harness Desktop: self-contained Windows desktop shell (Electron) that auto-starts dsh web, plus a subtle Codex-flavored theme plugin.（✅ 活跃）
-- [deepseek-harness-tui (gxinxing)](https://github.com/gxinxing/deepseek-harness-tui) ⭐6 — 基于 Ink（终端 React）构建的终端原生交互 TUI。（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/qyqy-1109/deepseek-harness-desktop) ⭐9 — DeepSeek Harness Desktop: self-contained Windows desktop shell (Electron) that auto-starts dsh web, plus a subtle Codex-flavored theme plugin.（✅ 活跃）
+- [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) ⭐9 — 基于 grok-build 构建的 TUI。（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/omdsh-dev/deepseek-harness-desktop) ⭐8 — DSH 桌面应用打包器（✅ 活跃）
+- [deepseek-harness-fnos](https://github.com/techysy/deepseek-harness-fnos) ⭐8 — DeepSeek Harness (DeepSeek 官方 agent 浏览器 UI) fnOS 应用 — 本地常驻服务, 官方统一网关接入（✅ 活跃）
+- [dsh-melody-launcher](https://github.com/rirko/dsh-melody-launcher) ⭐8 — dsh-旋律启动器：DeepSeek Harness 桌面启动器与插件管理器（✅ 活跃）
+- [dsh-mobile-for-android](https://github.com/Hongtwenfive1226/DSH-Mobile-for-Android) ⭐8 — The Android mobile version of DeepSeek Harness that relies on Tailscale.（✅ 活跃）
+- [deepseek-harness-tui (gxinxing)](https://github.com/gxinxing/deepseek-harness-tui) ⭐7 — 基于 Ink（终端 React）构建的终端原生交互 TUI。（✅ 活跃）
+- [dsh-desktop](https://github.com/foolgry/dsh-desktop) ⭐7 — Download-and-run desktop build of DeepSeek Harness — Electron shell with embedded Node, no npm required.（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/RZX00/deepseek-harness-desktop) ⭐6 — DeepSeek Harness with a Windows desktop build: an Electron shell over the dsh web profile, packaged as an installer（✅ 活跃）
+- [deepseek-harness-tui (boxeryao)](https://github.com/boxeryao/deepseek-harness-tui) ⭐6 — 轻量快速终端插件，直连 DSH 运行时。（✅ 活跃）
 - [deepseek-harness-cli](https://github.com/Richard-Yang0130/deepseek-harness-cli) ⭐5 — Claude Code-style terminal interface for DeepSeek Harness（✅ 活跃）
-- [deepseek-harness-desktop](https://github.com/RZX00/deepseek-harness-desktop) ⭐5 — DeepSeek Harness with a Windows desktop build: an Electron shell over the dsh web profile, packaged as an installer（✅ 活跃）
-- [deepseek-harness-tui (boxeryao)](https://github.com/boxeryao/deepseek-harness-tui) ⭐5 — 轻量快速终端插件，直连 DSH 运行时。（✅ 活跃）
-- [deepseek-harness-fnos](https://github.com/techysy/deepseek-harness-fnos) ⭐4 — DeepSeek Harness (DeepSeek 官方 agent 浏览器 UI) fnOS 应用 — 本地常驻服务, 官方统一网关接入（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) ⭐4 — Windows desktop app for DeepSeek Harness: installer, themes, in-app plugin marketplace, model routing, and updates.（✅ 活跃）
 - [dsh-desktop-electron](https://github.com/Void0312Aurora/dsh-desktop-electron) ⭐4 — 跨平台 Electron 桌面壳：托盘常驻独立窗口。（✅ 活跃）
+- [dshcockpit](https://github.com/Lxiayu/DshCockpit) ⭐4 — DshCockpit — DeepSeek Harness 桌面驾驶舱 (desktop cockpit)：运行时自动更新、成本控制、全局快捷问询、定时任务、会话全文检索、数据安全。自动更新 / 成本中心 / Quick Ask / 定时任务 / 会话搜索（✅ 活跃）
+- [deepseek-harness-workbench](https://github.com/xuan-ao-1/deepseek-harness-workbench) ⭐3 — DeepSeek Harness 官方架构的 Windows 桌面发行版 (Desktop distribution of the official DeepSeek Harness)（✅ 活跃）
+- [dsh-portable-launcher](https://github.com/15828148/dsh-portable-launcher) ⭐2 — One-click portable launcher for DeepSeek Harness (dsh) Web UI on Windows. Auto-installs Node.js and dsh with China mirror fallback, 3-stage progress with retries and resume, zero-download fast path when ready. No admin needed.（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop-windows) ⭐1 — Unofficial in-process desktop app for DeepSeek Harness: the host composition boots inside the Electron main process with zero ports and an IPC bridge. Not affiliated with DeepSeek.（✅ 活跃）
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) ⭐1 — Pi TUI 前端：流式 Markdown、思考折叠、工具卡片、斜杠命令与审批浮层。（✅ 活跃）
-- [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui)  — 基于 grok-build 构建的 TUI。（✅ 活跃）
+- [dsh-desktop-launcher](https://github.com/becomeless/dsh-desktop-launcher)  — Windows/macOS desktop launcher for DeepSeek Harness: double-click to launch, zero console windows, auto-stop on close | 双击图标一键启动 DeepSeek Harness 的桌面启动器（Windows / macOS）（✅ 活跃）
+- [dsh-quickstart](https://github.com/qzhqzh/dsh-quickstart)  — Desktop launcher for DeepSeek Harness - start dsh web with no console window and auto-open the browser. Tested on Windows; macOS/Linux in progress.（✅ 活跃）
 
 ### MCP & Integrations
 
@@ -495,42 +575,52 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) | ⭐758 | 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。 | ✅ 活跃 |
-| 2 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | ⭐64 | OpenPencil 设计预览与编辑集成。 | ✅ 活跃 |
-| 3 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | ⭐14 | Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 | ✅ 活跃 |
-| 4 | [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) | ⭐6 | DeepSeek Harness 的 ACP 服务器实现：复用凭据与会话，将完整 DSH Agent 暴露给 ACP 客户端。 | ✅ 活跃 |
-| 5 | [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) | ⭐6 | @deepseek-ai/dsh 的社区 Docker/K8s 打包，加固镜像。 | ✅ 活跃 |
-| 6 | [dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | ⭐6 | OAuth 2.1 Streamable HTTP MCP 客户端插件。 | ✅ 活跃 |
-| 7 | [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) | ⭐5 | 社区 GitHub Action：AI 代码审查、CI 诊断、自动修复、Issue 转 PR。 | ✅ 活跃 |
-| 8 | [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) | ⭐5 | MCP 服务器管理器：设置页 OAuth（PKCE + 动态客户端注册）或静态 Token 认证。 | ✅ 活跃 |
-| 9 | [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) | ⭐4 | DeepSeek Harness for VS Code as extension | ✅ 活跃 |
-| 10 | [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) | ⭐4 | 把 Telegram 变成 DSH 远程对话渠道并接收通知。 | ✅ 活跃 |
+| 1 | [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) | ⭐787 | 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。 | ✅ 活跃 |
+| 2 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | ⭐74 | OpenPencil 设计预览与编辑集成。 | ✅ 活跃 |
+| 3 | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | ⭐48 | 上下文注入增强插件（cordis）。 | ✅ 活跃 |
+| 4 | [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot) | ⭐32 | 让 QQ 机器人接入 DeepSeek Harness（dsh）的官方插件 | ✅ 活跃 |
+| 5 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | ⭐16 | Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 | ✅ 活跃 |
+| 6 | [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) | ⭐11 | 社区 GitHub Action：AI 代码审查、CI 诊断、自动修复、Issue 转 PR。 | ✅ 活跃 |
+| 7 | [ikanban](https://github.com/isomoes/ikanban) | ⭐10 | Monorepo for the iKanban browser-surface fork for DeepSeek Harness. | ✅ 活跃 |
+| 8 | [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) | ⭐8 | @deepseek-ai/dsh 的社区 Docker/K8s 打包，加固镜像。 | ✅ 活跃 |
+| 9 | [dsh-git-graph](https://github.com/1841220388zzzcccxxx-star/dsh-git-graph) | ⭐8 | Embedded git repository graph visualizer for the DeepSeek Harness Web GUI | 嵌入式 Git 仓库图谱可视化插件（提交历史图 / 分支过滤 / 文件 diff / VSCode 式未提交改动） | ✅ 活跃 |
+| 10 | [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) | ⭐8 | 用搜索 MCP 服务器（Tavily/Brave/Exa/Perplexity/DDG）替换 DSH 内置搜索。 | ✅ 活跃 |
 
-#### 完整列表（25）
+#### 完整列表（35）
 
-- [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐758 — 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。（✅ 活跃）
-- [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) ⭐64 — OpenPencil 设计预览与编辑集成。（✅ 活跃）
-- [dsh-lark](https://github.com/omdsh-dev/dsh-lark) ⭐14 — Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件（✅ 活跃）
-- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) ⭐6 — DeepSeek Harness 的 ACP 服务器实现：复用凭据与会话，将完整 DSH Agent 暴露给 ACP 客户端。（✅ 活跃）
-- [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) ⭐6 — @deepseek-ai/dsh 的社区 Docker/K8s 打包，加固镜像。（✅ 活跃）
+- [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐787 — 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。（✅ 活跃）
+- [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) ⭐74 — OpenPencil 设计预览与编辑集成。（✅ 活跃）
+- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) ⭐48 — 上下文注入增强插件（cordis）。（✅ 活跃）
+- [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot) ⭐32 — 让 QQ 机器人接入 DeepSeek Harness（dsh）的官方插件（✅ 活跃）
+- [dsh-lark](https://github.com/omdsh-dev/dsh-lark) ⭐16 — Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件（✅ 活跃）
+- [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) ⭐11 — 社区 GitHub Action：AI 代码审查、CI 诊断、自动修复、Issue 转 PR。（✅ 活跃）
+- [ikanban](https://github.com/isomoes/ikanban) ⭐10 — Monorepo for the iKanban browser-surface fork for DeepSeek Harness.（✅ 活跃）
+- [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) ⭐8 — @deepseek-ai/dsh 的社区 Docker/K8s 打包，加固镜像。（✅ 活跃）
+- [dsh-git-graph](https://github.com/1841220388zzzcccxxx-star/dsh-git-graph) ⭐8 — Embedded git repository graph visualizer for the DeepSeek Harness Web GUI | 嵌入式 Git 仓库图谱可视化插件（提交历史图 / 分支过滤 / 文件 diff / VSCode 式未提交改动）（✅ 活跃）
+- [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) ⭐8 — 用搜索 MCP 服务器（Tavily/Brave/Exa/Perplexity/DDG）替换 DSH 内置搜索。（✅ 活跃）
+- [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) ⭐8 — DeepSeek Harness 插件：DeepSeek 大脑 + 自动识图。GUI 附加图片自动经 OpenAI 兼容 VLM 转译成文字后交给 DeepSeek 作答；支持百炼/智谱/OpenRouter 等任意 OpenAI 兼容端点（默认 qwen3.7-flash），无 key 自动探测本地 Ollama（图片不出本机）；安装时有一问式确认（✅ 活跃）
+- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) ⭐7 — DeepSeek Harness 的 ACP 服务器实现：复用凭据与会话，将完整 DSH Agent 暴露给 ACP 客户端。（✅ 活跃）
+- [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) ⭐7 — DeepSeek Harness for VS Code as extension（✅ 活跃）
+- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) ⭐6 — MCP 服务器管理器：设置页 OAuth（PKCE + 动态客户端注册）或静态 Token 认证。（✅ 活跃）
 - [dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) ⭐6 — OAuth 2.1 Streamable HTTP MCP 客户端插件。（✅ 活跃）
-- [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) ⭐5 — 社区 GitHub Action：AI 代码审查、CI 诊断、自动修复、Issue 转 PR。（✅ 活跃）
-- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) ⭐5 — MCP 服务器管理器：设置页 OAuth（PKCE + 动态客户端注册）或静态 Token 认证。（✅ 活跃）
-- [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) ⭐4 — DeepSeek Harness for VS Code as extension（✅ 活跃）
-- [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) ⭐4 — 把 Telegram 变成 DSH 远程对话渠道并接收通知。（✅ 活跃）
-- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) ⭐4 — Telegram 手机远程控制 DSH 实时会话：会话选择、绑定/解绑，轨迹与桌面一致。（✅ 活跃）
+- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) ⭐6 — Telegram 手机远程控制 DSH 实时会话：会话选择、绑定/解绑，轨迹与桌面一致。（✅ 活跃）
+- [telegram](https://github.com/LoserFox/telegram) ⭐6 — Telegram Bot API 桥接插件：长轮询、per-chat 会话、HTML 格式化（✅ 活跃）
+- [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) ⭐5 — 把 Telegram 变成 DSH 远程对话渠道并接收通知。（✅ 活跃）
+- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) ⭐5 — 将 DSH Agent 能力暴露为 MCP 服务器（大脑=Hermes，双手=Harness）。（✅ 活跃）
+- [dsh-browser](https://github.com/xylt369/dsh-browser) ⭐4 — Browser capability for DeepSeek Harness: headed Edge/Playwright provider, SSRF-safe navigation, a11y-ref clicking, permission gate with auto-remember, gated evaluate（✅ 活跃）
+- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) ⭐4 — Web GUI 局域网访问：0.0.0.0 绑定 + 非安全上下文 polyfill。（✅ 活跃）
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) ⭐4 — 官方 DSH MCP 客户端的只读运行时管理面板：/mcp 命令 + 设置 Tab。（✅ 活跃）
+- [dsh-subscription-auth](https://github.com/Khellendros97/dsh-subscription-auth) ⭐4 — dsh对接openai、grok、anthropic、kimi订阅渠道（✅ 活跃）
 - [PicGo DSH Plugin](https://github.com/PicGo/dsh-plugin) ⭐4 — PicGo 官方插件：从 DSH 上传图片/文件到图床并获取公网 URL。（✅ 活跃）
-- [dsh-browser](https://github.com/xylt369/dsh-browser) ⭐3 — Browser capability for DeepSeek Harness: headed Edge/Playwright provider, SSRF-safe navigation, a11y-ref clicking, permission gate with auto-remember, gated evaluate（✅ 活跃）
-- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) ⭐3 — 官方 DSH MCP 客户端的只读运行时管理面板：/mcp 命令 + 设置 Tab。（✅ 活跃）
-- [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) ⭐3 — 用搜索 MCP 服务器（Tavily/Brave/Exa/Perplexity/DDG）替换 DSH 内置搜索。（✅ 活跃）
-- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) ⭐2 — 将 DSH Agent 能力暴露为 MCP 服务器（大脑=Hermes，双手=Harness）。（✅ 活跃）
+- [dsh-agentlink](https://github.com/hootandy321/dsh-Agentlink) ⭐3 — Caller-side bridge from Codex and other agent frameworks to DeepSeek Harness, with observable sessions, follow-up, cancellation, and human-gated approvals.（✅ 活跃）
+- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) ⭐3 — DeepSeek Harness subagent delegation enhancement（✅ 活跃）
+- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode) ⭐3 — 由 DSH Agent 驱动的 VS Code 聊天窗口：OpenCode 风格独立会话，模型自动路由。（✅ 活跃）
+- [dsh-github-integration](https://github.com/omdsh-dev/dsh-github-integration) ⭐2 — DSH 的 GitHub 集成插件。（✅ 活跃）
+- [dsh-plugin-acn](https://github.com/acnlabs/dsh-plugin-acn) ⭐2 — DeepSeek Harness plugin: join ACN so this agent can discover, message, and collaborate with other agents. Defaults to the China region.（✅ 活跃）
+- [vscode-deepseek-harness](https://github.com/kalynnka/vscode-deepseek-harness) ⭐2 — 非官方：把 dsh 作为 VS Code 原生聊天 Agent 使用。（✅ 活跃）
+- [deepseek-harness-rs](https://github.com/Tokimorphling/deepseek-harness-rs) ⭐1 — DeepSeek Harness 的 Rust 移植。（🧪 实验性）
 - [dsh-chrome](https://github.com/YJSoooooo/dsh-chrome) ⭐1 — Chrome 配置档桥接：通过 CDP 操控已登录的 Chrome。（✅ 活跃）
-- [vscode-deepseek-harness](https://github.com/kalynnka/vscode-deepseek-harness) ⭐1 — 非官方：把 dsh 作为 VS Code 原生聊天 Agent 使用。（✅ 活跃）
-- [deepseek-harness-rs](https://github.com/Tokimorphling/deepseek-harness-rs)  — DeepSeek Harness 的 Rust 移植。（🧪 实验性）
-- [dsh-github-integration](https://github.com/omdsh-dev/dsh-github-integration)  — DSH 的 GitHub 集成插件。（✅ 活跃）
-- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access)  — Web GUI 局域网访问：0.0.0.0 绑定 + 非安全上下文 polyfill。（✅ 活跃）
-- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector)  — 上下文注入增强插件（cordis）。（✅ 活跃）
-- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode)  — 由 DSH Agent 驱动的 VS Code 聊天窗口：OpenCode 风格独立会话，模型自动路由。（✅ 活跃）
+- [dsh-plugin-vision](https://github.com/tdf1995/dsh-plugin-vision)  — Vision for text-only LLMs in DeepSeek Harness (DSH): describe images / OCR / VQA via free Gemini & GLM vision APIs（✅ 活跃）
 - [opendsh](https://github.com/TheChengXi/opendsh)  — 在 VS Code 内打开 DSH Web UI，一键启停。（✅ 活跃）
 - [URL Manager MCP](https://github.com/Piccolo123/url-manager-mcp)  — URL Manager 的 MCP 伴生服务器：21 个工具用于保存/搜索/分类/共享与魔法链接投递。（✅ 活跃）
 
@@ -541,23 +631,23 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [hello-dsh](https://github.com/pingfanfan/hello-dsh) | ⭐37 | 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。 | ✅ 活跃 |
+| 1 | [hello-dsh](https://github.com/pingfanfan/hello-dsh) | ⭐48 | 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。 | ✅ 活跃 |
 | 2 | [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) | ⭐16 | DeepSeek Harness 插件开发模板。 | ✅ 活跃 |
 | 3 | [turtle-ui](https://github.com/turtle1999/turtle-ui) | ⭐6 | 官方 UI 插件参考实现。 | ✅ 活跃 |
-| 4 | [dsh-101](https://github.com/bill9109/dsh-101) | ⭐2 | DSH 文档阅读模式。 | ✅ 活跃 |
-| 5 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐2 | 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。 | ✅ 活跃 |
-| 6 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world 风格 DSH 起步插件。 | ✅ 活跃 |
-| 7 | [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) |  | 基于原 turtle-ui 官方仓库创建的插件模板。 | ✅ 活跃 |
+| 4 | [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) | ⭐5 | 基于原 turtle-ui 官方仓库创建的插件模板。 | ✅ 活跃 |
+| 5 | [dsh-101](https://github.com/bill9109/dsh-101) | ⭐3 | DSH 文档阅读模式。 | ✅ 活跃 |
+| 6 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐3 | 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。 | ✅ 活跃 |
+| 7 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world 风格 DSH 起步插件。 | ✅ 活跃 |
 
 #### 完整列表（7）
 
-- [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐37 — 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。（✅ 活跃）
+- [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐48 — 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。（✅ 活跃）
 - [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) ⭐16 — DeepSeek Harness 插件开发模板。（✅ 活跃）
 - [turtle-ui](https://github.com/turtle1999/turtle-ui) ⭐6 — 官方 UI 插件参考实现。（✅ 活跃）
-- [dsh-101](https://github.com/bill9109/dsh-101) ⭐2 — DSH 文档阅读模式。（✅ 活跃）
-- [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐2 — 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。（✅ 活跃）
+- [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) ⭐5 — 基于原 turtle-ui 官方仓库创建的插件模板。（✅ 活跃）
+- [dsh-101](https://github.com/bill9109/dsh-101) ⭐3 — DSH 文档阅读模式。（✅ 活跃）
+- [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐3 — 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。（✅ 活跃）
 - [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello)  — Hello-world 风格 DSH 起步插件。（✅ 活跃）
-- [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template)  — 基于原 turtle-ui 官方仓库创建的插件模板。（✅ 活跃）
 
 ### Tutorials & Learning
 
@@ -566,30 +656,31 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) | ⭐465 | 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。 | ✅ 活跃 |
-| 2 | [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) | ⭐167 | 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。 | ✅ 活跃 |
-| 3 | [dshfind](https://github.com/hikariming/dshfind) | ⭐56 | DSH 原理学习、插件市场与最佳实践：从 Cordis 论文逐章精读到插件自动聚合市场。 | ✅ 活跃 |
-| 4 | [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) | ⭐32 | DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） | ✅ 活跃 |
-| 5 | [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) | ⭐17 | DeepSeek Harness 中文详细学习教程。 | ✅ 活跃 |
-| 6 | [dsh-explain](https://github.com/yuezengwu/dsh-explain) | ⭐9 | 本地优先学习模式：跨会话全局学习线程、按来源讲解、ExplainContext、压缩与可诊断设置。 | ✅ 活跃 |
-| 7 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | 不同模式下的 DeepSeek Harness 提示词集。 | ✅ 活跃 |
-| 8 | [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) | ⭐5 | 基于 deepseek-harness 仓库系统化拆解的学习网站：面向想了解 AI Agent 框架如何工作的开发者。 | ✅ 活跃 |
-| 9 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐5 | 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。 | ✅ 活跃 |
-| 10 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | ⭐3 | 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。 | ✅ 活跃 |
+| 1 | [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) | ⭐706 | 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。 | ✅ 活跃 |
+| 2 | [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) | ⭐273 | 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。 | ✅ 活跃 |
+| 3 | [dshfind](https://github.com/hikariming/dshfind) | ⭐80 | DSH 原理学习、插件市场与最佳实践：从 Cordis 论文逐章精读到插件自动聚合市场。 | ✅ 活跃 |
+| 4 | [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) | ⭐43 | DeepSeek Harness 中文详细学习教程。 | ✅ 活跃 |
+| 5 | [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) | ⭐40 | DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） | ✅ 活跃 |
+| 6 | [dsh-explain](https://github.com/yuezengwu/dsh-explain) | ⭐11 | 本地优先学习模式：跨会话全局学习线程、按来源讲解、ExplainContext、压缩与可诊断设置。 | ✅ 活跃 |
+| 7 | [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) | ⭐7 | 基于 deepseek-harness 仓库系统化拆解的学习网站：面向想了解 AI Agent 框架如何工作的开发者。 | ✅ 活跃 |
+| 8 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | 不同模式下的 DeepSeek Harness 提示词集。 | ✅ 活跃 |
+| 9 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐6 | 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。 | ✅ 活跃 |
+| 10 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | ⭐4 | 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。 | ✅ 活跃 |
 
-#### 完整列表（11）
+#### 完整列表（12）
 
-- [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐465 — 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。（✅ 活跃）
-- [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐167 — 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。（✅ 活跃）
-- [dshfind](https://github.com/hikariming/dshfind) ⭐56 — DSH 原理学习、插件市场与最佳实践：从 Cordis 论文逐章精读到插件自动聚合市场。（✅ 活跃）
-- [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) ⭐32 — DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目）（✅ 活跃）
-- [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) ⭐17 — DeepSeek Harness 中文详细学习教程。（✅ 活跃）
-- [dsh-explain](https://github.com/yuezengwu/dsh-explain) ⭐9 — 本地优先学习模式：跨会话全局学习线程、按来源讲解、ExplainContext、压缩与可诊断设置。（✅ 活跃）
+- [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐706 — 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。（✅ 活跃）
+- [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐273 — 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。（✅ 活跃）
+- [dshfind](https://github.com/hikariming/dshfind) ⭐80 — DSH 原理学习、插件市场与最佳实践：从 Cordis 论文逐章精读到插件自动聚合市场。（✅ 活跃）
+- [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) ⭐43 — DeepSeek Harness 中文详细学习教程。（✅ 活跃）
+- [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) ⭐40 — DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目）（✅ 活跃）
+- [dsh-explain](https://github.com/yuezengwu/dsh-explain) ⭐11 — 本地优先学习模式：跨会话全局学习线程、按来源讲解、ExplainContext、压缩与可诊断设置。（✅ 活跃）
+- [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) ⭐7 — 基于 deepseek-harness 仓库系统化拆解的学习网站：面向想了解 AI Agent 框架如何工作的开发者。（✅ 活跃）
 - [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) ⭐6 — 不同模式下的 DeepSeek Harness 提示词集。（✅ 活跃）
-- [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) ⭐5 — 基于 deepseek-harness 仓库系统化拆解的学习网站：面向想了解 AI Agent 框架如何工作的开发者。（✅ 活跃）
-- [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) ⭐5 — 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。（✅ 活跃）
-- [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐3 — 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。（✅ 活跃）
-- [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐1 — 检查 DeepSeek 工具循环、reasoning_content、严格 schema 与捕获的 SSE，也可作为 DSH 插件。（✅ 活跃）
+- [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) ⭐6 — 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。（✅ 活跃）
+- [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐4 — 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。（✅ 活跃）
+- [gitlearnos](https://github.com/Guojiz/gitlearnos) ⭐3 — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory.（✅ 活跃）
+- [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐2 — 检查 DeepSeek 工具循环、reasoning_content、严格 schema 与捕获的 SSE，也可作为 DSH 插件。（✅ 活跃）
 
 ### Awesome Lists & Registries
 
@@ -598,44 +689,53 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | ⭐751 | 大型 DSH 插件精选目录（双语）。 | ✅ 活跃 |
-| 2 | [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) | ⭐751 | 雷达索引仓库：自动扫描发现的所有 dsh 插件候选，带证据驱动的兼容性矩阵。 | ✅ 活跃 |
-| 3 | [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) | ⭐360 | DSH 生态目录：来自 dsh-external/hub 与公开 dsh-plugin 主题的插件、工具与基础设施精选。 | ✅ 活跃 |
-| 4 | [notes (zhaoolee)](https://github.com/zhaoolee/notes) | ⭐138 | 开源版锤子便签：一键 Docker 私有化部署、skill 调用、dsh plugin 支持、一键生成公众号格式。 | ✅ 活跃 |
-| 5 | [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) | ⭐86 | 用 30 秒找到适合你的 DSH 插件：不仅列仓库，还说明插件解决什么问题、适合谁、从哪开始。 | ✅ 活跃 |
-| 6 | [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) | ⭐47 | DeepSeek Harness 插件精选列表。 | ✅ 活跃 |
-| 7 | [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | ⭐47 | 精心整理的 DSH 插件、扩展、工具与开发资源列表。 | ✅ 活跃 |
-| 8 | [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | ⭐43 | 面向 DSH 的插件生态：700+ 插件，只通过扩展接缝注册，不修改 agent-loop 骨架。 | ✅ 活跃 |
-| 9 | [plugin-registry](https://github.com/vlln/plugin-registry) | ⭐31 | DSH 插件生态基建：薄控制台管理官方 repository 插件（0 patch）+ make-dsh-plugin 技能。 | ✅ 活跃 |
-| 10 | [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) | ⭐30 | DSH 插件、技能、MCP 服务器、patch/profile 层、编排器与 UI 精选列表。 | ✅ 活跃 |
+| 1 | [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent) | ⭐5,853 | 官方精选：将 DeepSeek 模型集成到主流 Agent/编码助手工具的指南（AstrBot、Cherry Studio、Claude Code、Codex、DeepSeek-TUI、Reasonix 等）。 | ✅ 活跃 |
+| 2 | [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | ⭐2,516 | 大型 DSH 插件精选目录（双语）。 | ✅ 活跃 |
+| 3 | [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) | ⭐942 | 雷达索引仓库：自动扫描发现的所有 dsh 插件候选，带证据驱动的兼容性矩阵。 | ✅ 活跃 |
+| 4 | [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) | ⭐465 | DSH 生态目录：来自 dsh-external/hub 与公开 dsh-plugin 主题的插件、工具与基础设施精选。 | ✅ 活跃 |
+| 5 | [notes (zhaoolee)](https://github.com/zhaoolee/notes) | ⭐142 | 开源版锤子便签：一键 Docker 私有化部署、skill 调用、dsh plugin 支持、一键生成公众号格式。 | ✅ 活跃 |
+| 6 | [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) | ⭐139 | 用 30 秒找到适合你的 DSH 插件：不仅列仓库，还说明插件解决什么问题、适合谁、从哪开始。 | ✅ 活跃 |
+| 7 | [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) | ⭐62 | 终极指南：快速入门、资源推荐、精选插件与实用工具。 | ✅ 活跃 |
+| 8 | [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | ⭐62 | 精心整理的 DSH 插件、扩展、工具与开发资源列表。 | ✅ 活跃 |
+| 9 | [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) | ⭐61 | DeepSeek Harness 插件精选列表。 | ✅ 活跃 |
+| 10 | [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) | ⭐47 | DSH 插件、技能、MCP 服务器、patch/profile 层、编排器与 UI 精选列表。 | ✅ 活跃 |
 
-#### 完整列表（25）
+#### 完整列表（34）
 
-- [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐751 — 大型 DSH 插件精选目录（双语）。（✅ 活跃）
-- [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐751 — 雷达索引仓库：自动扫描发现的所有 dsh 插件候选，带证据驱动的兼容性矩阵。（✅ 活跃）
-- [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) ⭐360 — DSH 生态目录：来自 dsh-external/hub 与公开 dsh-plugin 主题的插件、工具与基础设施精选。（✅ 活跃）
-- [notes (zhaoolee)](https://github.com/zhaoolee/notes) ⭐138 — 开源版锤子便签：一键 Docker 私有化部署、skill 调用、dsh plugin 支持、一键生成公众号格式。（✅ 活跃）
-- [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) ⭐86 — 用 30 秒找到适合你的 DSH 插件：不仅列仓库，还说明插件解决什么问题、适合谁、从哪开始。（✅ 活跃）
-- [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) ⭐47 — DeepSeek Harness 插件精选列表。（✅ 活跃）
-- [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) ⭐47 — 精心整理的 DSH 插件、扩展、工具与开发资源列表。（✅ 活跃）
-- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) ⭐43 — 面向 DSH 的插件生态：700+ 插件，只通过扩展接缝注册，不修改 agent-loop 骨架。（✅ 活跃）
-- [plugin-registry](https://github.com/vlln/plugin-registry) ⭐31 — DSH 插件生态基建：薄控制台管理官方 repository 插件（0 patch）+ make-dsh-plugin 技能。（✅ 活跃）
-- [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) ⭐30 — DSH 插件、技能、MCP 服务器、patch/profile 层、编排器与 UI 精选列表。（✅ 活跃）
-- [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) ⭐29 — 终极指南：快速入门、资源推荐、精选插件与实用工具。（✅ 活跃）
-- [oh-my-dsh](https://github.com/like-study1/Oh-My-DSH) ⭐21 — 🐳 DeepSeek Harness 插件聚合社区 — 自动同步 dsh-plugin 生态 · 精选目录 · 每 8 小时自动维护 | Oh-My-DSH: a community-maintained catalog of DeepSeek Harness plugins, auto-synced from the dsh-plugin topic（✅ 活跃）
-- [deepseek-plugin-store](https://github.com/Ericwong5021/deepseek-plugin-store) ⭐12 — DeepSeek Harness 独立社区插件商店：发现、安装并提交经过验证的插件、工具与扩展。 | Independent community plugin directory.（✅ 活跃）
-- [dsh-suite](https://github.com/whyihaveyou/dsh-suite) ⭐11 — 活体插件目录（785+ 插件，每小时刷新）：每日兼容性 CI、双语目录站与应用内插件商店。（✅ 活跃）
-- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) ⭐9 — 社区整活插件导航（皮肤、桌宠、小游戏），双语。（✅ 活跃）
-- [awesome-dsh-plugins (white0dew)](https://github.com/white0dew/awesome-dsh-plugins) ⭐7 — DSH 插件公开目录，含安装命令。（✅ 活跃）
-- [awesome-deepseek-harness (jiji262)](https://github.com/jiji262/awesome-deepseek-harness) ⭐6 — DeepSeek Harness 资源精选。（✅ 活跃）
-- [awesome-dsh-plugin (billLiao)](https://github.com/billLiao/awesome-dsh-plugin) ⭐5 — DeepSeek Harness 插件精选列表。（✅ 活跃）
-- [awesome-dsh-plugins (kejixiaoliang)](https://github.com/kejixiaoliang/awesome-dsh-plugins) ⭐5 — DSH 插件精选目录：14 类 280+ 个社区插件，覆盖 MCP/Skill/TUI/多 Agent/上下文记忆/UI 皮肤。（✅ 活跃）
-- [dsh-plugin-marketplace](https://github.com/YELEBAI/dsh-plugin-marketplace) ⭐4 — Verified plugin marketplace and autonomous registry for DeepSeek Harness（✅ 活跃）
-- [dsh-plugins](https://github.com/HackSing/dsh-plugins) ⭐4 — A bilingual, continuously maintained directory of plugins for DeepSeek Harness (DSH).（✅ 活跃）
-- [zat-dsh-engine](https://github.com/mishibeikejie/zat-dsh-engine) ⭐4 — Visual plugin marketplace for DeepSeek Harness — browse, search and install community plugins（✅ 活跃）
-- [dsh-market](https://github.com/2BingLing/dsh-market) ⭐3 — DeepSeek Harness 插件市场 · 持续收录 500+ DSH 插件：中文搜索 + 实用五维评分 + 一键安装。Web 版与 DSH 侧边栏插件双形态。Plugin marketplace for DeepSeek Harness: 500+ plugins, Chinese search, 5-dim scoring, one-click install.（✅ 活跃）
+- [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent) ⭐5,853 — 官方精选：将 DeepSeek 模型集成到主流 Agent/编码助手工具的指南（AstrBot、Cherry Studio、Claude Code、Codex、DeepSeek-TUI、Reasonix 等）。（✅ 活跃）
+- [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐2,516 — 大型 DSH 插件精选目录（双语）。（✅ 活跃）
+- [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐942 — 雷达索引仓库：自动扫描发现的所有 dsh 插件候选，带证据驱动的兼容性矩阵。（✅ 活跃）
+- [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) ⭐465 — DSH 生态目录：来自 dsh-external/hub 与公开 dsh-plugin 主题的插件、工具与基础设施精选。（✅ 活跃）
+- [notes (zhaoolee)](https://github.com/zhaoolee/notes) ⭐142 — 开源版锤子便签：一键 Docker 私有化部署、skill 调用、dsh plugin 支持、一键生成公众号格式。（✅ 活跃）
+- [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) ⭐139 — 用 30 秒找到适合你的 DSH 插件：不仅列仓库，还说明插件解决什么问题、适合谁、从哪开始。（✅ 活跃）
+- [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) ⭐62 — 终极指南：快速入门、资源推荐、精选插件与实用工具。（✅ 活跃）
+- [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) ⭐62 — 精心整理的 DSH 插件、扩展、工具与开发资源列表。（✅ 活跃）
+- [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) ⭐61 — DeepSeek Harness 插件精选列表。（✅ 活跃）
+- [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) ⭐47 — DSH 插件、技能、MCP 服务器、patch/profile 层、编排器与 UI 精选列表。（✅ 活跃）
+- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) ⭐47 — 面向 DSH 的插件生态：700+ 插件，只通过扩展接缝注册，不修改 agent-loop 骨架。（✅ 活跃）
+- [plugin-registry](https://github.com/vlln/plugin-registry) ⭐40 — DSH 插件生态基建：薄控制台管理官方 repository 插件（0 patch）+ make-dsh-plugin 技能。（✅ 活跃）
+- [oh-my-dsh](https://github.com/like-study1/Oh-My-DSH) ⭐31 — 🐳 DeepSeek Harness 插件聚合社区 — 自动同步 dsh-plugin 生态 · 精选目录 · 每 8 小时自动维护 | Oh-My-DSH: a community-maintained catalog of DeepSeek Harness plugins, auto-synced from the dsh-plugin topic（✅ 活跃）
+- [zat-dsh-engine](https://github.com/mishibeikejie/zat-dsh-engine) ⭐29 — Visual plugin marketplace for DeepSeek Harness — browse, search and install community plugins（✅ 活跃）
+- [awesome-dsh-plugin](https://github.com/beancookie/awesome-dsh-plugin) ⭐25 — Awesome DeepSeek Harness (DSH) Plugin（✅ 活跃）
+- [dsh-suite](https://github.com/whyihaveyou/dsh-suite) ⭐23 — 活体插件目录（785+ 插件，每小时刷新）：每日兼容性 CI、双语目录站与应用内插件商店。（✅ 活跃）
+- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) ⭐20 — 社区整活插件导航（皮肤、桌宠、小游戏），双语。（✅ 活跃）
+- [dsh-plugin-marketplace](https://github.com/YELEBAI/dsh-plugin-marketplace) ⭐17 — Verified plugin marketplace and autonomous registry for DeepSeek Harness（✅ 活跃）
+- [dsh-plugin-hub](https://github.com/cclank/dsh-plugin-hub) ⭐15 — DeepSeek Harness community plugin registry with evidence-based screening（✅ 活跃）
+- [deepseek-plugin-store](https://github.com/Ericwong5021/deepseek-plugin-store) ⭐13 — DeepSeek Harness 独立社区插件商店：发现、安装并提交经过验证的插件、工具与扩展。 | Independent community plugin directory.（✅ 活跃）
+- [dsh-plugin-marketplace](https://github.com/AwesomeHou/dsh-plugin-marketplace) ⭐13 — Plugin marketplace for DeepSeek Harness — live-syncs the GitHub dsh-plugin topic (1800+ repos) into a searchable, paginated settings tab with one-click install and agent tools (market_search / market_install).（✅ 活跃）
+- [awesome-dsh-plugins (kejixiaoliang)](https://github.com/kejixiaoliang/awesome-dsh-plugins) ⭐12 — DSH 插件精选目录：14 类 280+ 个社区插件，覆盖 MCP/Skill/TUI/多 Agent/上下文记忆/UI 皮肤。（✅ 活跃）
+- [dsh-market](https://github.com/2BingLing/dsh-market) ⭐11 — DeepSeek Harness 插件市场 · 持续收录 500+ DSH 插件：中文搜索 + 实用五维评分 + 一键安装。Web 版与 DSH 侧边栏插件双形态。Plugin marketplace for DeepSeek Harness: 500+ plugins, Chinese search, 5-dim scoring, one-click install.（✅ 活跃）
+- [awesome-deepseek-harness (jiji262)](https://github.com/jiji262/awesome-deepseek-harness) ⭐10 — DeepSeek Harness 资源精选。（✅ 活跃）
+- [awesome-deepseek-harness-plugins](https://github.com/imsai-sh/awesome-deepseek-harness-plugins) ⭐9 — Curated community plugin directory and live marketplace for DeepSeek Harness.（✅ 活跃）
+- [awesome-dsh-plugins (white0dew)](https://github.com/white0dew/awesome-dsh-plugins) ⭐9 — DSH 插件公开目录，含安装命令。（✅ 活跃）
+- [awesome-dsh-plugin (billLiao)](https://github.com/billLiao/awesome-dsh-plugin) ⭐7 — DeepSeek Harness 插件精选列表。（✅ 活跃）
+- [dsh-plugins](https://github.com/HackSing/dsh-plugins) ⭐5 — A bilingual, continuously maintained directory of plugins for DeepSeek Harness (DSH).（✅ 活跃）
+- [awesome-deepseek-harness-plugins](https://github.com/walkinglabs/awesome-deepseek-harness-plugins) ⭐4 — A curated, bilingual list of verified plugins, tools, design workflows, and learning resources for DeepSeek Harness (DSH).（✅ 活跃）
+- [dsh-marketplace](https://github.com/ouyangyipeng/dsh-marketplace) ⭐3 — A safe, live plugin marketplace for DeepSeek Harness（✅ 活跃）
+- [dsh-plugin-market](https://github.com/chnjames/dsh-plugin-market) ⭐3 — DSH 插件市场 — DeepSeek Harness 设置内一键安装社区插件，并提供公开目录站（浏览 / 复制安装命令）（✅ 活跃）
+- [dsh-plugin-market](https://github.com/TheYoungChen/dsh-plugin-market) ⭐3 — DeepSeek Harness plugin market - browse, search & install dsh-plugin topic plugins (dsh 插件市场：浏览/搜索/安装插件)（✅ 活跃）
 - [dsh-plugins](https://github.com/lwmxiaobei/dsh-plugins) ⭐3 — DeepSeek Harness 社区插件目录，自动汇总并基础校验 GitHub 插件，支持搜索、筛选、双语详情与最新版本安装命令复制。Community directory for DeepSeek Harness plugins with automated discovery, basic validation, search, filters, bilingual details, and latest version install commands.（✅ 活跃）
-- [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent)  — 官方精选：将 DeepSeek 模型集成到主流 Agent/编码助手工具的指南（AstrBot、Cherry Studio、Claude Code、Codex、DeepSeek-TUI、Reasonix 等）。（✅ 活跃）
+- [sandbase-skills](https://github.com/sandbaseai/sandbase-skills) ⭐3 — 88 installable open-source Agent Skills for research, social intelligence, marketing, and business workflows—compatible with Codex, Claude Code, Cursor, Gemini CLI, and DeepSeek Harness.（✅ 活跃）
 
 ### Related Agent Harnesses
 
@@ -644,24 +744,24 @@ dsh web
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [DeerFlow](https://github.com/bytedance/deer-flow) | ⭐80,001 | 字节跳动开源的长时间跨度 SuperAgent harness：技能、记忆、沙箱、子代理、工具与消息网关。 | ✅ 活跃 |
-| 2 | [Cordis](https://github.com/cordiverse/cordis) | ⭐3,182 | 时空可组合性元框架——DeepSeek Harness 底层的插件运行时。 | ✅ 活跃 |
-| 3 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐573 | 开源 CMA 兼容的任意模型 Agent 运行时：MCP 工具、沙箱会话、审计与回放。 | ✅ 活跃 |
-| 4 | [mnemon](https://github.com/mnemon-dev/mnemon) | ⭐430 | LLM 监督的 Agent 持久记忆：图召回与跨会话知识，单二进制。 | ✅ 活跃 |
-| 5 | [claude-paper](https://github.com/alaliqing/claude-paper) | ⭐294 | 跨 Agent 论文研究工具包：快速摘要与深度精读，支持 Claude Code/Codex/OpenCode/DSH。 | ✅ 活跃 |
-| 6 | [Axern](https://github.com/cofy-x/axern) | ⭐272 | 面向 AI Agent 的开源沙箱：不可信代码执行与持久服务。 | ✅ 活跃 |
-| 7 | [open-managed-agents](https://github.com/openma-ai/open-managed-agents) | ⭐235 | 开源 Claude Managed Agents API 实现与自托管 Claude Tag 风格 Agent 运行时。 | ✅ 活跃 |
+| 1 | [DeerFlow](https://github.com/bytedance/deer-flow) | ⭐80,038 | 字节跳动开源的长时间跨度 SuperAgent harness：技能、记忆、沙箱、子代理、工具与消息网关。 | ✅ 活跃 |
+| 2 | [Cordis](https://github.com/cordiverse/cordis) | ⭐3,780 | 时空可组合性元框架——DeepSeek Harness 底层的插件运行时。 | ✅ 活跃 |
+| 3 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐586 | 开源 CMA 兼容的任意模型 Agent 运行时：MCP 工具、沙箱会话、审计与回放。 | ✅ 活跃 |
+| 4 | [mnemon](https://github.com/mnemon-dev/mnemon) | ⭐449 | LLM 监督的 Agent 持久记忆：图召回与跨会话知识，单二进制。 | ✅ 活跃 |
+| 5 | [claude-paper](https://github.com/alaliqing/claude-paper) | ⭐301 | 跨 Agent 论文研究工具包：快速摘要与深度精读，支持 Claude Code/Codex/OpenCode/DSH。 | ✅ 活跃 |
+| 6 | [open-managed-agents](https://github.com/openma-ai/open-managed-agents) | ⭐236 | 开源 Claude Managed Agents API 实现与自托管 Claude Tag 风格 Agent 运行时。 | ✅ 活跃 |
+| 7 | [Axern](https://github.com/cofy-x/axern) | ⭐167 | 面向 AI Agent 的开源沙箱：不可信代码执行与持久服务。 | ✅ 活跃 |
 | 8 | [deepseek-auto-evolving-harness](https://github.com/liuchen6667/deepseek-auto-evolving-harness) | ⭐28 | 自进化 LLM Agent Harness：通过 Claude Code 与 self_evolution.md 指南进行基准驱动进化。 | ✅ 活跃 |
 
 #### 完整列表（8）
 
-- [DeerFlow](https://github.com/bytedance/deer-flow) ⭐80,001 — 字节跳动开源的长时间跨度 SuperAgent harness：技能、记忆、沙箱、子代理、工具与消息网关。（✅ 活跃）
-- [Cordis](https://github.com/cordiverse/cordis) ⭐3,182 — 时空可组合性元框架——DeepSeek Harness 底层的插件运行时。（✅ 活跃）
-- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) ⭐573 — 开源 CMA 兼容的任意模型 Agent 运行时：MCP 工具、沙箱会话、审计与回放。（✅ 活跃）
-- [mnemon](https://github.com/mnemon-dev/mnemon) ⭐430 — LLM 监督的 Agent 持久记忆：图召回与跨会话知识，单二进制。（✅ 活跃）
-- [claude-paper](https://github.com/alaliqing/claude-paper) ⭐294 — 跨 Agent 论文研究工具包：快速摘要与深度精读，支持 Claude Code/Codex/OpenCode/DSH。（✅ 活跃）
-- [Axern](https://github.com/cofy-x/axern) ⭐272 — 面向 AI Agent 的开源沙箱：不可信代码执行与持久服务。（✅ 活跃）
-- [open-managed-agents](https://github.com/openma-ai/open-managed-agents) ⭐235 — 开源 Claude Managed Agents API 实现与自托管 Claude Tag 风格 Agent 运行时。（✅ 活跃）
+- [DeerFlow](https://github.com/bytedance/deer-flow) ⭐80,038 — 字节跳动开源的长时间跨度 SuperAgent harness：技能、记忆、沙箱、子代理、工具与消息网关。（✅ 活跃）
+- [Cordis](https://github.com/cordiverse/cordis) ⭐3,780 — 时空可组合性元框架——DeepSeek Harness 底层的插件运行时。（✅ 活跃）
+- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) ⭐586 — 开源 CMA 兼容的任意模型 Agent 运行时：MCP 工具、沙箱会话、审计与回放。（✅ 活跃）
+- [mnemon](https://github.com/mnemon-dev/mnemon) ⭐449 — LLM 监督的 Agent 持久记忆：图召回与跨会话知识，单二进制。（✅ 活跃）
+- [claude-paper](https://github.com/alaliqing/claude-paper) ⭐301 — 跨 Agent 论文研究工具包：快速摘要与深度精读，支持 Claude Code/Codex/OpenCode/DSH。（✅ 活跃）
+- [open-managed-agents](https://github.com/openma-ai/open-managed-agents) ⭐236 — 开源 Claude Managed Agents API 实现与自托管 Claude Tag 风格 Agent 运行时。（✅ 活跃）
+- [Axern](https://github.com/cofy-x/axern) ⭐167 — 面向 AI Agent 的开源沙箱：不可信代码执行与持久服务。（✅ 活跃）
 - [deepseek-auto-evolving-harness](https://github.com/liuchen6667/deepseek-auto-evolving-harness) ⭐28 — 自进化 LLM Agent Harness：通过 Claude Code 与 self_evolution.md 指南进行基准驱动进化。（✅ 活跃）
 <!-- AUTO:resources:END -->
 
@@ -767,157 +867,213 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [petdex](https://github.com/crafter-station/petdex) | ⭐3,777 | A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. | ✅ 活跃 |
-| 2 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | ⭐1,697 | DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。 | ✅ 活跃 |
-| 3 | [modlens](https://github.com/liustack/modlens) | ⭐1,158 | DSH 首个视觉插件，也是所有纯文本编码 Agent 的视觉桥梁：粘贴图片即可用。 | ✅ 活跃 |
-| 4 | [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | ⭐684 | 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。 | ✅ 活跃 |
-| 5 | [museai](https://github.com/yejiming/MuseAI) | ⭐538 | 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） | ✅ 活跃 |
-| 6 | [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | ⭐506 | DSH Web 鲸鱼娘皮肤系列（CC BY-NC-SA 4.0）。 | ✅ 活跃 |
-| 7 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐309 | 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。 | ✅ 活跃 |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐302 | 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。 | ✅ 活跃 |
-| 9 | [whale-girl](https://github.com/vlln/whale-girl) | ⭐118 | QQ 宠物形态桌面宠物：DSH Web 右下角悬浮，可拖拽/投喂/玩耍。 | ✅ 活跃 |
-| 10 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | ⭐116 | Codex 风格 @file 提及：在 DSH 输入框中搜索工作区文件并附加内容到提示词。 | ✅ 活跃 |
+| 1 | [petdex](https://github.com/crafter-station/petdex) | ⭐3,825 | A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. | ✅ 活跃 |
+| 2 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | ⭐2,484 | DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。 | ✅ 活跃 |
+| 3 | [dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) | ⭐1,831 | Two-phase DeepSeek Harness preset: Minimal-aligned bootstrap, then full Standard tools (Project2 98/99) | ✅ 活跃 |
+| 4 | [modlens](https://github.com/liustack/modlens) | ⭐1,736 | DSH 首个视觉插件，也是所有纯文本编码 Agent 的视觉桥梁：粘贴图片即可用。 | ✅ 活跃 |
+| 5 | [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | ⭐1,065 | 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。 | ✅ 活跃 |
+| 6 | [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | ⭐834 | DSH Web 鲸鱼娘皮肤系列（CC BY-NC-SA 4.0）。 | ✅ 活跃 |
+| 7 | [museai](https://github.com/yejiming/MuseAI) | ⭐556 | 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用） | ✅ 活跃 |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐409 | 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。 | ✅ 活跃 |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐396 | 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。 | ✅ 活跃 |
+| 10 | [dsh-market](https://github.com/dsh-market/dsh-market) | ⭐218 | DSH 内置可视化插件市场：浏览、搜索、一键安装。 | ✅ 活跃 |
 
-#### 完整列表（138）
+#### 完整列表（194）
 
-- [petdex](https://github.com/crafter-station/petdex) ⭐3,777 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more.（✅ 活跃）
-- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐1,697 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
-- [modlens](https://github.com/liustack/modlens) ⭐1,158 — DSH 首个视觉插件，也是所有纯文本编码 Agent 的视觉桥梁：粘贴图片即可用。（✅ 活跃）
-- [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) ⭐684 — 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。（✅ 活跃）
-- [museai](https://github.com/yejiming/MuseAI) ⭐538 — 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用）（✅ 活跃）
-- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) ⭐506 — DSH Web 鲸鱼娘皮肤系列（CC BY-NC-SA 4.0）。（✅ 活跃）
-- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) ⭐309 — 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。（✅ 活跃）
-- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) ⭐302 — 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。（✅ 活跃）
-- [whale-girl](https://github.com/vlln/whale-girl) ⭐118 — QQ 宠物形态桌面宠物：DSH Web 右下角悬浮，可拖拽/投喂/玩耍。（✅ 活跃）
-- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) ⭐116 — Codex 风格 @file 提及：在 DSH 输入框中搜索工作区文件并附加内容到提示词。（✅ 活跃）
-- [modsearch](https://github.com/liustack/modsearch) ⭐85 — DSH 网页插件：为没有原生联网能力的模型提供搜索桥梁。（✅ 活跃）
-- [dsh-browser](https://github.com/Lum1104/dsh-browser) ⭐78 — Chrome 侧栏扩展：让 DSH 直接操控你的浏览器，无需视觉能力。（✅ 活跃）
-- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐74 — 对话内交互式 HTML UI：流式预览与沙箱渲染。（✅ 活跃）
-- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐71 — 对话内生成式 UI：布局、图表、表单、测验、Mermaid 与交互事件内联渲染。（✅ 活跃）
-- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐67 — DSH 生态插件发现工具。（✅ 活跃）
-- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐47 — 跨会话长期记忆 + 后台自我进化：五轨记忆、git 分支感知、回合内自我审查、技能自我进化。（✅ 活跃）
-- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) ⭐39 — DSH Web 选中批注：选文字→批注→随消息发送，回复按批注逐条对照。（✅ 活跃）
-- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) ⭐39 — 从 Web GUI 直接在工作区中打开 VS Code 目录/文件。（✅ 活跃）
-- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) ⭐37 — 回合完成桌面通知，按结果分控 + 关键词包含/排除过滤。（✅ 活跃）
-- [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐35 — 对话与代码状态回退插件，基于持久化变更账本。（✅ 活跃）
-- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) ⭐29 — 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。（✅ 活跃）
-- [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) ⭐28 — 在 DSH Web GUI 中一键浏览、安装与更新全部 GitHub dsh-plugin 插件。（✅ 活跃）
-- [ui-status-label](https://github.com/alingalingling/ui-status-label) ⭐28 — 把鲸鱼娘思考时的 deep diving 状态自定义成任意文字。（✅ 活跃）
-- [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) ⭐27 — 会话标题栏全手绘像素鲸鱼伙伴：眨眼、摆尾、回合完成喷水，零核心改动。（✅ 活跃）
-- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) ⭐22 — 用 Monaco 编辑器创建和管理 DSH 沙箱化 JavaScript 工具，模型驱动工具列表。（✅ 活跃）
-- [dskin](https://github.com/dancingmemory/dskin) ⭐22 — 卡通像素皮肤插件：原始界面不动，像素宠物散步、眨眼、跳跃。（✅ 活跃）
-- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐20 — 从 Claude Code、Codex、ChatGPT、Cursor、Gemini、Reasonix、OpenCode 导入历史消息并在 DSH 中继续对话。（✅ 活跃）
-- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) ⭐18 — 换肤系统：21 套内置皮肤 + 一张图生成整套配色，构建期校验可读性。（✅ 活跃）
-- [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) ⭐18 — 为 DeepSeek Harness 提供电脑控制插件：新鲜 Accessibility 观测、过期状态拒绝、作用域权限与安全输入（目前支持macos）｜Accessibility-first macOS Computer Use bundle for DSH with fresh observations, stale-state rejection, scoped permissions, and safe input.（✅ 活跃）
-- [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) ⭐18 — 紧凑侧边栏：文件浏览器、终端与 Git 审查。（✅ 活跃）
-- [anysearch-dsh](https://github.com/anysearch-team/anysearch-dsh) ⭐17 — AnySearch 网页搜索 provider 与高级搜索工具。（✅ 活跃）
-- [deepseek-harness-snowsalt](https://github.com/KYZHXL/deepseek-harness-snowsalt) ⭐17 — 雪盐主题皮肤。（✅ 活跃）
+- [petdex](https://github.com/crafter-station/petdex) ⭐3,825 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more.（✅ 活跃）
+- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐2,484 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
+- [dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) ⭐1,831 — Two-phase DeepSeek Harness preset: Minimal-aligned bootstrap, then full Standard tools (Project2 98/99)（✅ 活跃）
+- [modlens](https://github.com/liustack/modlens) ⭐1,736 — DSH 首个视觉插件，也是所有纯文本编码 Agent 的视觉桥梁：粘贴图片即可用。（✅ 活跃）
+- [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) ⭐1,065 — 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。（✅ 活跃）
+- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) ⭐834 — DSH Web 鲸鱼娘皮肤系列（CC BY-NC-SA 4.0）。（✅ 活跃）
+- [museai](https://github.com/yejiming/MuseAI) ⭐556 — 创建你的 AI 角色，进入你的故事世界。和角色聊天、冒险、穿书，让每一次互动都留下羁绊（支持 DeepSeek Harness 插件，欢迎使用）（✅ 活跃）
+- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) ⭐409 — 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。（✅ 活跃）
+- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) ⭐396 — 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。（✅ 活跃）
+- [dsh-market](https://github.com/dsh-market/dsh-market) ⭐218 — DSH 内置可视化插件市场：浏览、搜索、一键安装。（✅ 活跃）
+- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) ⭐198 — Codex 风格 @file 提及：在 DSH 输入框中搜索工作区文件并附加内容到提示词。（✅ 活跃）
+- [whale-girl](https://github.com/vlln/whale-girl) ⭐160 — QQ 宠物形态桌面宠物：DSH Web 右下角悬浮，可拖拽/投喂/玩耍。（✅ 活跃）
+- [dsh-browser](https://github.com/Lum1104/dsh-browser) ⭐140 — Chrome 侧栏扩展：让 DSH 直接操控你的浏览器，无需视觉能力。（✅ 活跃）
+- [v4-flash-godmode-opencode-go](https://github.com/SheberDavid/v4-flash-godmode-opencode-go) ⭐127 — V4 Flash 神模式 (opencode-go)：让 opencode-go 的 DeepSeek V4 Flash 从鬼模式切换到神模式的 dsh agent preset（✅ 活跃）
+- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) ⭐111 — 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。（✅ 活跃）
+- [modsearch](https://github.com/liustack/modsearch) ⭐104 — DSH 网页插件：为没有原生联网能力的模型提供搜索桥梁。（✅ 活跃）
+- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐100 — 对话内交互式 HTML UI：流式预览与沙箱渲染。（✅ 活跃）
+- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐99 — 对话内生成式 UI：布局、图表、表单、测验、Mermaid 与交互事件内联渲染。（✅ 活跃）
+- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐89 — DSH 生态插件发现工具。（✅ 活跃）
+- [dsh-gitbash-preset](https://github.com/liceses/dsh-gitbash-preset) ⭐86 — DeepSeek Harness 插件：一键安装「极简模式 (Git Bash)」agent preset —— 把 DSH 自带极简模式中的 bash 调用映射到 Git for Windows 的 bash（MSYS），让 Windows 上的极简模式真正可用。（✅ 活跃）
+- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐82 — 跨会话长期记忆 + 后台自我进化：五轨记忆、git 分支感知、回合内自我审查、技能自我进化。（✅ 活跃）
+- [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) ⭐64 — 在 DSH Web GUI 中一键浏览、安装与更新全部 GitHub dsh-plugin 插件。（✅ 活跃）
+- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) ⭐50 — DSH Web 选中批注：选文字→批注→随消息发送，回复按批注逐条对照。（✅ 活跃）
+- [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐50 — 对话与代码状态回退插件，基于持久化变更账本。（✅ 活跃）
+- [dsh-auto-mode](https://github.com/NanmiCoder/dsh-auto-mode) ⭐48 — Safe automatic permissions for DeepSeek Harness.（✅ 活跃）
+- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) ⭐47 — 回合完成桌面通知，按结果分控 + 关键词包含/排除过滤。（✅ 活跃）
+- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) ⭐42 — 从 Web GUI 直接在工作区中打开 VS Code 目录/文件。（✅ 活跃）
+- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) ⭐42 — dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin.com 目录，一键安装/卸载到 profile。（✅ 活跃）
+- [dsh-context](https://github.com/bowenliang123/dsh-context) ⭐40 — A DeepSeek Harness plugin for  Context insight dashboard — showing what the model's context window is made of and how it evolves.（✅ 活跃）
+- [dsh-pet](https://github.com/PC2005-cloud/dsh-pet) ⭐38 — DeepSeek Harness 桌面宠物插件 + 完整素材生成链：AI 提示词 → 绿幕视频 → 透明动画 → 可安装插件，从零到宠物全流程可复现（✅ 活跃）
+- [dsh-plugins-store](https://github.com/ZASENJC/dsh-plugins-store) ⭐38 — 自动收录与分类 GitHub dsh-plugin Topic 项目的静态目录网站。（✅ 活跃）
+- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) ⭐34 — 换肤系统：21 套内置皮肤 + 一张图生成整套配色，构建期校验可读性。（✅ 活跃）
+- [dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) ⭐33 — Web UI 中一键管理 DSH 插件：查看、实时启停、安装/卸载、环境管理、插件市场。（✅ 活跃）
+- [ui-status-label](https://github.com/alingalingling/ui-status-label) ⭐32 — 把鲸鱼娘思考时的 deep diving 状态自定义成任意文字。（✅ 活跃）
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) ⭐31 — DeepSeek Harness 会话费用统计插件:本会话费用、当日费用、历史记录与官方价格同步（✅ 活跃）
+- [anysearch-dsh](https://github.com/anysearch-team/anysearch-dsh) ⭐30 — AnySearch 网页搜索 provider 与高级搜索工具。（✅ 活跃）
+- [dsh-kun-like-pet](https://github.com/liyupi/dsh-kun-like-pet) ⭐30 — Kun Like 桌宠 —— DeepSeek Harness 桌面宠物插件：右下角小坤宠随 Agent 工作状态切换 9 种动作，任务完成播放「你干嘛~哎哟」（✅ 活跃）
+- [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) ⭐30 — 会话标题栏全手绘像素鲸鱼伙伴：眨眼、摆尾、回合完成喷水，零核心改动。（✅ 活跃）
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐29 — 从 Claude Code、Codex、ChatGPT、Cursor、Gemini、Reasonix、OpenCode 导入历史消息并在 DSH 中继续对话。（✅ 活跃）
+- [dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) ⭐29 — Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the DeepSeek Harness Web GUI (dsh web).（✅ 活跃）
+- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) ⭐26 — 三层本地记忆系统：运行时热记忆、项目文档、长期记忆空间，监督式写回。（✅ 活跃）
+- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) ⭐24 — 用 Monaco 编辑器创建和管理 DSH 沙箱化 JavaScript 工具，模型驱动工具列表。（✅ 活跃）
+- [dsh-transparent-ui-plugin](https://github.com/WYH66666666/DSH-Transparent-UI-Plugin) ⭐24 — 是一层高自由度的玻璃质感主题，套在 DeepSeek Harness 网页端。顶栏、侧边栏、输入框、统计行、轨迹视图都成了磨砂玻璃片。玻璃模糊度、磨砂度、背景（流体或自定义壁纸，壁纸还能单独调模糊和磨砂）全都能在设置卡片里自由调节。关掉开关就回到原生界面，不改 DSH 任何一行源码。（✅ 活跃）
+- [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) ⭐23 — 会话内插件发现：直接在 DSH 中搜索 GitHub dsh-plugin 主题的实时插件。（✅ 活跃）
+- [dsh-navbar](https://github.com/vlln/dsh-navbar) ⭐23 — DSH 插件：对话节点导航条（右缘节点串快速跳转 user 消息）。官方 bundle 插件，dsh plugin --profile web add 安装（✅ 活跃）
+- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) ⭐23 — 插件管理面板：一键启停已装插件 + GitHub dsh-plugin 市场，带详情与一键安装。（✅ 活跃）
+- [dsh-vision (william-jin-cmu)](https://github.com/william-jin-cmu/dsh-vision) ⭐23 — 视觉桥接：view_image 工具桥接任意 OpenAI 兼容 VLM，默认智谱免费档。（✅ 活跃）
+- [deepseek-harness-snowsalt](https://github.com/KYZHXL/deepseek-harness-snowsalt) ⭐21 — 雪盐主题皮肤。（✅ 活跃）
+- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) ⭐21 — 分支式消息编辑、重掷、重试与版本时间线。（✅ 活跃）
+- [dskin](https://github.com/dancingmemory/dskin) ⭐21 — 卡通像素皮肤插件：原始界面不动，像素宠物散步、眨眼、跳跃。（✅ 活跃）
+- [dsh-computer-use](https://github.com/Anionex/dsh-computer-use) ⭐20 — 为 DeepSeek Harness 提供电脑控制插件：新鲜 Accessibility 观测、过期状态拒绝、作用域权限与安全输入（目前支持macos）｜Accessibility-first macOS Computer Use bundle for DSH with fresh observations, stale-state rejection, scoped permissions, and safe input.（✅ 活跃）
+- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) ⭐20 — 向模型暴露 MinerU 文档解析：PDF/图片/DOCX/PPTX/XLSX 转结构化 Markdown/JSON。（✅ 活跃）
+- [dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) ⭐20 — Steam 创意工坊风格插件浏览器：零服务器、GitHub 驱动搜索、一键安装。（✅ 活跃）
+- [dsh-share](https://github.com/hellodigua/dsh-share) ⭐19 — DSH 对话一键分享。（✅ 活跃）
+- [dsh-minigames](https://github.com/lhh010/dsh-minigames) ⭐18 — DSH Web UI 右侧小游戏面板：18 款离线小游戏（恐龙跳一跳 / 俄罗斯方块 / 坦克大战 / 扫雷 / 2048 / 数独 / 吃豆人 / 跟枪练习等），可扩展游戏注册表，等待模型回复或修 bug 时的摸鱼神器（✅ 活跃）
+- [dsh-plugin](https://github.com/Tabbit-Browser/dsh-plugin) ⭐18 — Tabbit Broser plugins for Deepseek Harness（✅ 活跃）
+- [dsh-emoji](https://github.com/hellodigua/dsh-emoji) ⭐17 — 让 AI 回复加入自定义表情。（✅ 活跃）
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) ⭐17 — 插件健康检查：清单协议、patch 格式、构建陷阱与 hub 收录状态，零依赖只读。（✅ 活跃）
-- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) ⭐16 — 分支式消息编辑、重掷、重试与版本时间线。（✅ 活跃）
-- [dsh-share](https://github.com/hellodigua/dsh-share) ⭐16 — DSH 对话一键分享。（✅ 活跃）
-- [dsh-usage-stats](https://github.com/Ychris12138/dsh-usage-stats) ⭐16 — Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the DeepSeek Harness Web GUI (dsh web).（✅ 活跃）
-- [dsh-vision (william-jin-cmu)](https://github.com/william-jin-cmu/dsh-vision) ⭐16 — 视觉桥接：view_image 工具桥接任意 OpenAI 兼容 VLM，默认智谱免费档。（✅ 活跃）
-- [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) ⭐15 — 零依赖工具包：计算器、CSV、diff、编码、JSON、Markdown、正则、时间。（✅ 活跃）
-- [dsh-group-photo](https://github.com/SenmuuuuW/dsh-group-photo) ⭐14 — DSH 内测收官合影墙：GitHub OAuth 零权限登录 + 冻结白名单校验的拍立得合影站（含 DSH Skill 包装）（✅ 活跃）
-- [dsh-navbar](https://github.com/vlln/dsh-navbar) ⭐14 — DSH 插件：对话节点导航条（右缘节点串快速跳转 user 消息）。官方 bundle 插件，dsh plugin --profile web add 安装（✅ 活跃）
-- [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) ⭐13 — DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。（✅ 活跃）
-- [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) ⭐12 — 为 dsh 提供新的「聚焦会话」精简会话视图，更轻松易于阅读，只关注最终产出结果。（✅ 活跃）
-- [dsh-kun-like-pet](https://github.com/liyupi/dsh-kun-like-pet) ⭐12 — Kun Like 桌宠 —— DeepSeek Harness 桌面宠物插件：右下角小坤宠随 Agent 工作状态切换 9 种动作，任务完成播放「你干嘛~哎哟」（✅ 活跃）
-- [dsh-market](https://github.com/dsh-market/dsh-market) ⭐12 — DSH 内置可视化插件市场：浏览、搜索、一键安装。（✅ 活跃）
-- [dsh-minigames](https://github.com/lhh010/dsh-minigames) ⭐12 — DSH Web UI 右侧小游戏面板：18 款离线小游戏（恐龙跳一跳 / 俄罗斯方块 / 坦克大战 / 扫雷 / 2048 / 数独 / 吃豆人 / 跟枪练习等），可扩展游戏注册表，等待模型回复或修 bug 时的摸鱼神器（✅ 活跃）
-- [dsh-plugins-store](https://github.com/ZASENJC/dsh-plugins-store) ⭐12 — 自动收录与分类 GitHub dsh-plugin Topic 项目的静态目录网站。（✅ 活跃）
-- [ego-browser](https://github.com/Fisfzy/ego-browser) ⭐12 — 把 ego-lite 智能体浏览器（为 AI Agent 打造的 Chromium）接入 DSH，13 个结构化工具。（✅ 活跃）
-- [DeepSeek-Harness-Web-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Web-Tools) ⭐11 — 免费免密钥的 web_search/web_fetch，DuckDuckGo 驱动，无需注册。（✅ 活跃）
-- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) ⭐11 — DeepSeek account balance and session cost readout for the DeepSeek Harness Web GUI（✅ 活跃）
-- [dsh-emoji](https://github.com/hellodigua/dsh-emoji) ⭐11 — 让 AI 回复加入自定义表情。（✅ 活跃）
-- [dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) ⭐11 — 会话内插件发现：直接在 DSH 中搜索 GitHub dsh-plugin 主题的实时插件。（✅ 活跃）
-- [dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) ⭐11 — 在 DSH 中与 AI 下五子棋，也可以让 AI 对局比试模型强弱。（✅ 活跃）
-- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) ⭐11 — 三层本地记忆系统：运行时热记忆、项目文档、长期记忆空间，监督式写回。（✅ 活跃）
+- [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) ⭐17 — 零依赖工具包：计算器、CSV、diff、编码、JSON、Markdown、正则、时间。（✅ 活跃）
+- [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) ⭐16 — 为 dsh 提供新的「聚焦会话」精简会话视图，更轻松易于阅读，只关注最终产出结果。（✅ 活跃）
+- [dsh-group-photo](https://github.com/SenmuuuuW/dsh-group-photo) ⭐16 — DSH 内测收官合影墙：GitHub OAuth 零权限登录 + 冻结白名单校验的拍立得合影站（含 DSH Skill 包装）（✅ 活跃）
+- [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) ⭐16 — 紧凑侧边栏：文件浏览器、终端与 Git 审查。（💤 停更）
+- [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) ⭐16 — DSH WebUI sticker plugin for bidirectional user and agent reactions（✅ 活跃）
+- [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) ⭐15 — DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。（✅ 活跃）
+- [dsh-balance](https://github.com/crazywoola/dsh-balance) ⭐14 — 设置页余额插件。（✅ 活跃）
+- [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) ⭐14 — Git 风格里程碑时间线：悬停查看元数据，点击跳转任意消息。（✅ 活跃）
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) ⭐13 — DeepSeek account balance and session cost readout for the DeepSeek Harness Web GUI（✅ 活跃）
+- [dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) ⭐13 — 在 DSH 中与 AI 下五子棋，也可以让 AI 对局比试模型强弱。（✅ 活跃）
+- [ego-browser](https://github.com/Fisfzy/ego-browser) ⭐13 — 把 ego-lite 智能体浏览器（为 AI Agent 打造的 Chromium）接入 DSH，13 个结构化工具。（✅ 活跃）
+- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) ⭐12 — 模型驱动的上下文管理（Active Context Pruning）：由模型决定何时压缩、压缩什么。（✅ 活跃）
+- [DeepSeek-Harness-Web-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Web-Tools) ⭐12 — 免费免密钥的 web_search/web_fetch，DuckDuckGo 驱动，无需注册。（✅ 活跃）
+- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) ⭐12 — PiUI 风格 Web diff 查看器，替代默认 diff 视图。（✅ 活跃）
+- [dsh-plugin-pet-rs](https://github.com/HuanLinOTO/dsh-plugin-pet-rs) ⭐12 — Rust 桌宠：5 态鲸鱼 + 双 SSE 实时推送 + 透明置顶窗 + 系统托盘，三端支持。（✅ 活跃）
+- [dsh-remote](https://github.com/flymysql/dsh-remote) ⭐12 — 远程工作区：SSH 连接远程主机，用 rw_pick_workspace/rw_read_file/rw_exec 等工具远程操作。（✅ 活跃）
+- [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) ⭐12 — 为 DSH 增加桌面通知提醒。（✅ 活跃）
+- [dsh-recommend](https://github.com/zp-home/dsh-recommend) ⭐11 — 透明插件排行榜与推荐：每日自动抓取 dsh-plugin 主题数据，开放评分模型。（✅ 活跃）
 - [dsh-sdk-platform-rs](https://github.com/kpn-dsh/dsh-sdk-platform-rs) ⭐11 — A Rust SDK to interact with the DSH Platform. This library provides convenient building blocks for services that need to connect to DSH Kafka, fetch tokens for various protocols, manage Prometheus metrics, and more.（✅ 活跃）
-- [dsh-web-plugin-manager](https://github.com/LX2000WASD/dsh-web-plugin-manager) ⭐11 — Web UI 中一键管理 DSH 插件：查看、实时启停、安装/卸载、环境管理、插件市场。（✅ 活跃）
-- [dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) ⭐10 — Steam 创意工坊风格插件浏览器：零服务器、GitHub 驱动搜索、一键安装。（✅ 活跃）
-- [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) ⭐10 — DSH 本机安全审计插件：配置/插件来源/会话/网络暴露面，只读脱敏风险报告（✅ 活跃）
-- [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) ⭐10 — 股票行情插件（整活：有效解决了写代码时账户不能同时亏钱的 BUG）。（✅ 活跃）
-- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) ⭐10 — dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin.com 目录，一键安装/卸载到 profile。（✅ 活跃）
-- [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) ⭐9 — Git 风格里程碑时间线：悬停查看元数据，点击跳转任意消息。（✅ 活跃）
-- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) ⭐9 — 向模型暴露 MinerU 文档解析：PDF/图片/DOCX/PPTX/XLSX 转结构化 Markdown/JSON。（✅ 活跃）
+- [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) ⭐11 — DSH 本机安全审计插件：配置/插件来源/会话/网络暴露面，只读脱敏风险报告（✅ 活跃）
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) ⭐11 — Codex 风格皮肤切换器 + 自定义半透明壁纸，支持透明度/模糊控制。（✅ 活跃）
+- [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) ⭐11 — 股票行情插件（整活：有效解决了写代码时账户不能同时亏钱的 BUG）。（✅ 活跃）
+- [DeepSeek-Harness-Vision-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Vision-Tools) ⭐10 — 视觉代理：任意文本模型 + 任意视觉模型即可让 DSH 看图。（✅ 活跃）
+- [dsh-mneme](https://github.com/modusensus/dsh-mneme) ⭐10 — 记忆主权归用户的本地跨会话记忆：SQLite + 可人工编辑的 Markdown 镜像，autoDream 后台巩固。（✅ 活跃）
+- [touhou-hakurei](https://github.com/xiake595/touhou-hakurei) ⭐10 — 灵梦（Reimu）·博丽神社（东方Project）美化版皮肤：神社昼夜实景背景、灵梦立绘、画框侧边栏与输入框、纸白透明界面 — DeepSeek Harness Web GUI skin（✅ 活跃）
+- [DeepSeek-Harness-billing-plugin](https://github.com/WilliamLIiii/DeepSeek-Harness-billing-plugin) ⭐9 — 账户余额 + 按模型剩余任务估算，带会话费用台账。（✅ 活跃）
+- [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) ⭐9 — 🐋 DSH 有声桌宠：悬浮桌面的 DeepSeek 小鲸鱼，不打开 DSH 也能实时感知会话状态（需要确认/工作中/完成/空闲/离线），支持音效提醒与零代码定制素材（✅ 活跃）
+- [dsh-plugin-better-sidebar-plugin-office](https://github.com/HuanLinOTO/dsh-plugin-better-sidebar-plugin-office) ⭐9 — 为 better-sidebar 提供 Office 三件套预览（.docx/.xlsx/.pptx），独立瘦身 bundle。（✅ 活跃）
 - [dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) ⭐9 — 多帧 zstd 会话文件的帧级扫描诊断：撕裂/损坏/空会话检测，零依赖只读。（✅ 活跃）
-- [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) ⭐9 — 为 DSH 增加桌面通知提醒。（✅ 活跃）
 - [deepseek-harness-SupportVisionModel](https://github.com/TryDing-T/deepseek-harness-SupportVisionModel) ⭐8 — 基于 deepseek-harness 二次开发：支持单独配置视觉模型读图。（✅ 活跃）
-- [DeepSeek-Harness-Vision-Tools](https://github.com/tonyd2wild/DeepSeek-Harness-Vision-Tools) ⭐8 — 视觉代理：任意文本模型 + 任意视觉模型即可让 DSH 看图。（✅ 活跃）
-- [dsh-mneme](https://github.com/modusensus/dsh-mneme) ⭐8 — 记忆主权归用户的本地跨会话记忆：SQLite + 可人工编辑的 Markdown 镜像，autoDream 后台巩固。（✅ 活跃）
+- [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) ⭐8 — Excel 风格电子表格皮肤。（✅ 活跃）
 - [dsh-paste-input](https://github.com/lhh010/dsh-paste-input) ⭐8 — DSH WebUI 文件输入增强：Ctrl+V 粘贴、拖拽、选择文件，发送时复制进会话工作区。（✅ 活跃）
-- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) ⭐7 — 模型驱动的上下文管理（Active Context Pruning）：由模型决定何时压缩、压缩什么。（✅ 活跃）
-- [DeepSeek-Harness-billing-plugin](https://github.com/WilliamLIiii/DeepSeek-Harness-billing-plugin) ⭐7 — 账户余额 + 按模型剩余任务估算，带会话费用台账。（✅ 活跃）
+- [dsh-plugin-ya-workspace-sidebar](https://github.com/HuanLinOTO/dsh-plugin-ya-workspace-sidebar) ⭐8 — DSH Web 工作区侧栏替代，顶部全局最近会话 + Workspace→Session 二级菜单 + 面包屑 | DSH Web workspace sidebar replacement: top global recent sessions + Workspace→Session two-level menu + breadcrumbs（✅ 活跃）
+- [dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) ⭐8 — 将 'Deep diving…' 状态替换为阶段感知的打字机消息。（✅ 活跃）
+- [dsh-undo-plugin](https://github.com/lire1131/dsh-undo-plugin) ⭐8 — DSH plugin: snapshot & rollback your plugin/skin/settings configs. Auto-save on change, undo/redo stack, snapshot manager panel, keyboard shortcuts, plus an offline PowerShell CLI & GUI that work even when DSH won't boot.（✅ 活跃）
+- [dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) ⭐7 — DSH 自动记忆插件:三层记忆(用户级/项目笔记/每日日志)自动注入与检索、每日反思、可视化面板与设置页,支持继承其他 AI 工具的历史记忆。An auto-memory plugin for the DeepSeek Harness Web GUI: three-layer memory (user-level / project notes / daily logs) with automatic injection and retrieval, daily reflections, a visual panel and settings page, and inheritance of memories from other AI tools.（✅ 活跃）
+- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) ⭐7 — 上下文注入审计插件：统计 AGENTS.md 指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。（✅ 活跃）
 - [dsh-director-toolkit](https://github.com/lhmd/dsh-director-toolkit) ⭐7 — DSH Director Toolkit is a DeepSeek Harness plugin for 3D artists, technical designers, and creative coders. Paste a half-formed idea, a reference note, or a portfolio caption and get a compact direction pack for Blender, Three.js, Houdini, or C4D.（✅ 活跃）
-- [dsh-plugin-better-sidebar-plugin-office](https://github.com/HuanLinOTO/dsh-plugin-better-sidebar-plugin-office) ⭐7 — 为 better-sidebar 提供 Office 三件套预览（.docx/.xlsx/.pptx），独立瘦身 bundle。（✅ 活跃）
-- [dsh-plugin-pet-rs](https://github.com/HuanLinOTO/dsh-plugin-pet-rs) ⭐7 — Rust 桌宠：5 态鲸鱼 + 双 SSE 实时推送 + 透明置顶窗 + 系统托盘，三端支持。（✅ 活跃）
-- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) ⭐6 — 上下文注入审计插件：统计 AGENTS.md 指令链/技能目录/工具 schema 的 token 成本，检测重复与冲突。（✅ 活跃）
-- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) ⭐6 — PiUI 风格 Web diff 查看器，替代默认 diff 视图。（✅ 活跃）
-- [dsh-skin](https://github.com/KinGao294/dsh-skin) ⭐6 — Codex 风格皮肤切换器 + 自定义半透明壁纸，支持透明度/模糊控制。（✅ 活跃）
-- [dsh-balance](https://github.com/crazywoola/dsh-balance) ⭐5 — 设置页余额插件。（✅ 活跃）
-- [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) ⭐5 — Excel 风格电子表格皮肤。（✅ 活跃）
+- [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) ⭐7 — DSH Web UI 跨平台文件拖拽与原始路径插入，无需复制文件。（✅ 活跃）
+- [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) ⭐7 — DSH 插件：git 提交固定使用环境自身作者身份（优先 gh CLI 登录账号，GitHub noreply 邮箱），GIT_AUTHOR_*/GIT_COMMITTER_* 环境变量注入压过一切 git config（✅ 活跃）
+- [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) ⭐7 — 左下角便签：随手记点子/感想/TODO，实时保存到归档目录，清单+悬浮归档（✅ 活跃）
+- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) ⭐7 — 多引擎持久搜索：DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/推特/Reddit/RSS，SQLite+LRU 缓存 + Playwright 渲染。（✅ 活跃）
+- [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) ⭐6 — provider-agnostic AIGC HTTP 桥 + 无限画布 + ffmpeg 后处理，13 个工具含画布连边/reroll/媒体编辑 | Provider-agnostic AIGC HTTP bridge + infinite canvas + ffmpeg post-processing; 13 tools incl. canvas linking/reroll/media-edit（✅ 活跃）
+- [dsh-plugin-anti-ads](https://github.com/HuanLinOTO/dsh-plugin-anti-ads) ⭐6 — DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin（✅ 活跃）
+- [dsh-plugin-auto-blame](https://github.com/HuanLinOTO/dsh-plugin-auto-blame) ⭐6 — 模型回合结束后用 LLM 生成 3 条批判性跟进建议，点击即发送 | After a model turn, an LLM generates 3 critical follow-up suggestions shown as click-to-send chips（✅ 活跃）
+- [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) ⭐6 — 将 DSH 接入 GitHub 插件生态的市场插件。（✅ 活跃）
+- [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) ⭐6 — 暴露 run_python/run_node 工具，通过 stdin 执行代码返回 stdout/stderr/exit。（✅ 活跃）
+- [dsh-token-panel](https://github.com/juhe291/dsh-token-panel) ⭐6 — A corner HUD for DeepSeek Harness that shows your session's token pressure, per-model cost, and daily/monthly usage at a glance — with an editable budget & balance that tracks spending for you. 右下角常驻的 Token 仪表盘：实时查看会话压力、按模型估算花费，预算和余额点一下就能改，每天每月用了多少都有记录。（✅ 活跃）
+- [dsh-usage-chart](https://github.com/Max-Samson/dsh-usage-chart) ⭐6 — A DeepSeek Harness Web plugin for real-time Token usage, cost estimates, per-round charts, and DeepSeek API balance.（✅ 活跃）
+- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) ⭐6 — DSH Web 中英文金额 Token 计费：官方策略自动定价（含高峰/低谷），逐条消息费用台账。（✅ 活跃）
+- [weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) ⭐6 — Native WeShop Cordis plugin for DeepSeek Harness. Allow you to use infinite canvas with infinite creative skills.（✅ 活跃）
+- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) ⭐5 — 官方 DSH Web 内置功能可读目录 + 安全 UI 开关。（✅ 活跃）
+- [dsh-cost-plugin](https://github.com/RoxsLee/dsh-cost-plugin) ⭐5 — DSH 费用/余额读数插件：在输入框统计行旁实时显示「本次 ≈¥x · 会话 ≈¥x · 余额 ¥x」，内置 DeepSeek 官方价目表，支持 2026-08-17 起生效的峰谷定价（按节点时间戳自动选档），余额经官方 /user/balance 实时查询，失败静默降级。（✅ 活跃）
+- [dsh-cue-plugin](https://github.com/unnnnoooo/dsh-cue-plugin) ⭐5 — DeepSeek Harness 的跨会话引用(cue)插件（✅ 活跃）
 - [dsh-ohos-patch](https://github.com/shenjackyuanjie/dsh-ohos-patch) ⭐5 — 让deepseek harness能在 ohos上跑！（✅ 活跃）
+- [dsh-opencode-go-usage](https://github.com/Xenia0922/dsh-opencode-go-usage) ⭐5 — DeepSeek Harness 插件:OpenCode Go 用量与花费悬浮仪表盘(配额、逐请求成本、模型/来源分布)（✅ 活跃）
+- [dsh-plugin-anydoc](https://github.com/beancookie/dsh-plugin-anydoc) ⭐5 — 基于 @firecrawl/anydoc 将 Word/PPT/Excel/PDF/EPUB/CSV 等文档转换为 GFM Markdown。（✅ 活跃）
 - [dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) ⭐5 — 模型生成时右下角弹出小游戏菜单：Wordle/消消乐/192 款参数化小游戏。（✅ 活跃）
-- [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) ⭐5 — 将 DSH 接入 GitHub 插件生态的市场插件。（✅ 活跃）
-- [dsh-plugin-ya-workspace-sidebar](https://github.com/HuanLinOTO/dsh-plugin-ya-workspace-sidebar) ⭐5 — DSH Web 工作区侧栏替代，顶部全局最近会话 + Workspace→Session 二级菜单 + 面包屑 | DSH Web workspace sidebar replacement: top global recent sessions + Workspace→Session two-level menu + breadcrumbs（✅ 活跃）
-- [dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) ⭐5 — 将 'Deep diving…' 状态替换为阶段感知的打字机消息。（✅ 活跃）
+- [dsh-spend](https://github.com/nonewind/dsh-spend) ⭐5 — Token 用量与费用估算：悬浮面板，按模型/天/会话统计，自动识别计费套餐。（✅ 活跃）
+- [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) ⭐5 — DSH Web 键盘优先命令面板。（✅ 活跃）
 - [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) ⭐5 — 将 Nowledge Mem 记忆服务接入 DeepSeek Harness 的社区插件包。（✅ 活跃）
-- [dsh-cost-plugin](https://github.com/RoxsLee/dsh-cost-plugin) ⭐4 — DSH 费用/余额读数插件：在输入框统计行旁实时显示「本次 ≈¥x · 会话 ≈¥x · 余额 ¥x」，内置 DeepSeek 官方价目表，支持 2026-08-17 起生效的峰谷定价（按节点时间戳自动选档），余额经官方 /user/balance 实时查询，失败静默降级。（✅ 活跃）
-- [dsh-cue-plugin](https://github.com/unnnnoooo/dsh-cue-plugin) ⭐4 — DeepSeek Harness 的跨会话引用(cue)插件（✅ 活跃）
+- [zotero-harvest](https://github.com/Fisfzy/zotero-harvest) ⭐5 — Zotero 文献采集入库插件（DSH external plugin）：多源检索（OpenAlex/arXiv/Crossref/Europe PMC/Semantic Scholar）+ OA 下载链接解析（Unpaywall）+ 充分性审计 + 入库本地 Zotero + 触发 zotero-wave-rag 重建（✅ 活跃）
+- [codex-eyes-hands](https://github.com/651002/codex-eyes-hands) ⭐4 — 专为 DeepSeek Harness 打造：把本机 Codex CLI 变成纯文本 AI agent 的眼睛和手——看图/读文件/画图/监督执行/双通道容灾（✅ 活跃）
+- [context-vista](https://github.com/GooodWei/context-vista) ⭐4 — 上下文/Token 实时监控：悬浮面板 + /context 命令，环形图展示用量、分配与估算费用。（✅ 活跃）
+- [deepseek-harness-zh_pro](https://github.com/magian1127/deepseek-harness-zh_pro) ⭐4 — Chinese enhancement plugin for DeepSeek Harness (DSH) - DSH 中文增强插件（✅ 活跃）
+- [dsh-calculator](https://github.com/bobcat848/dsh-calculator) ⭐4 — Calculate the real-time cost of DeepSeek API calls made by DeepSeek Harness.（✅ 活跃）
 - [dsh-input-history](https://github.com/lhh010/dsh-input-history) ⭐4 — 终端风格输入历史：Ctrl+Up/Down 召回与切换已发送消息。（✅ 活跃）
-- [dsh-pet](https://github.com/PC2005-cloud/dsh-pet) ⭐4 — DeepSeek Harness 桌面宠物插件 + 完整素材生成链：AI 提示词 → 绿幕视频 → 透明动画 → 可安装插件，从零到宠物全流程可复现（✅ 活跃）
-- [dsh-plugin-anti-ads](https://github.com/HuanLinOTO/dsh-plugin-anti-ads) ⭐4 — DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin（✅ 活跃）
+- [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) ⭐4 — PDF 工具箱：pdfjs-dist 本地提取文本、元数据与页区间，无需 API Key。（✅ 活跃）
 - [dsh-plugin-deepeye](https://github.com/Favio8/dsh-plugin-deepeye) ⭐4 — DeepEye vision plugin for DeepSeek Harness (DSH): image description, OCR, VQA, UI layout, and clipboard analysis.（✅ 活跃）
-- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) ⭐4 — 插件管理面板：一键启停已装插件 + GitHub dsh-plugin 市场，带详情与一键安装。（✅ 活跃）
-- [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) ⭐4 — 暴露 run_python/run_node 工具，通过 stdin 执行代码返回 stdout/stderr/exit。（✅ 活跃）
-- [dsh-remote](https://github.com/flymysql/dsh-remote) ⭐4 — 远程工作区：SSH 连接远程主机，用 rw_pick_workspace/rw_read_file/rw_exec 等工具远程操作。（✅ 活跃）
-- [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) ⭐4 — DSH Web 键盘优先命令面板。（✅ 活跃）
-- [weshop-dsh-plugin](https://github.com/weshopai/weshop-dsh-plugin) ⭐4 — Native WeShop Cordis plugin for DeepSeek Harness. Allow you to use infinite canvas with infinite creative skills.（✅ 活跃）
-- [context-vista](https://github.com/GooodWei/context-vista) ⭐3 — 上下文/Token 实时监控：悬浮面板 + /context 命令，环形图展示用量、分配与估算费用。（✅ 活跃）
-- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) ⭐3 — 官方 DSH Web 内置功能可读目录 + 安全 UI 开关。（✅ 活跃）
-- [dsh-calculator](https://github.com/bobcat848/dsh-calculator) ⭐3 — Calculate the real-time cost of DeepSeek API calls made by DeepSeek Harness.（✅ 活跃）
-- [dsh-opencode-go-usage](https://github.com/Xenia0922/dsh-opencode-go-usage) ⭐3 — DeepSeek Harness 插件:OpenCode Go 用量与花费悬浮仪表盘(配额、逐请求成本、模型/来源分布)（✅ 活跃）
+- [dsh-prompt-enhancer](https://github.com/Fishsb/dsh-prompt-enhancer) ⭐4 — DeepSeek Harness DSH 提示词增强插件：✨ 一键优化草稿，增强提示词。（✅ 活跃）
+- [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) ⭐4 — 为 DeepSeek Harness 提供会话删除能力，支持侧边栏 ⋮ 菜单入口（✅ 活跃）
+- [dsh-split-panes](https://github.com/lehhair/dsh-split-panes) ⭐4 — Split panes.（✅ 活跃）
+- [dsh-usage-dashboard](https://github.com/Cassius0924/dsh-usage-dashboard) ⭐4 — DeepSeek 额度与用量仪表盘 — DSH (DeepSeek Harness) 动态 Cordis 插件（✅ 活跃）
+- [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) ⭐4 — Privacy-minimal heuristic per-turn verification summaries for DeepSeek Harness（✅ 活跃）
+- [dsh-weather](https://github.com/sunshine-lang/dsh-weather) ⭐4 — 天气工具：Open-Meteo 当前天气与多日预报，免费免密钥。（✅ 活跃）
+- [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) ⭐4 — Attention reminders for the DeepSeek Harness Web UI: frame badge, (N) tab title and whale-favicon recolor for sessions waiting for input or finished unopened.（✅ 活跃）
+- [dsh-web-search-exa](https://github.com/TonyDua/dsh-web-search-exa) ⭐4 — 零配置 Exa 网页搜索：免密钥匿名 MCP 回退 + API Key REST 搜索。（✅ 活跃）
+- [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐4 — 输入框旁常用词箱：全局/项目词桶，一键插入。（✅ 活跃）
+- [dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) ⭐4 — VS Code 风格工作区关键词搜索：Better Sidebar 生态的搜索 Tab。（✅ 活跃）
+- [deepseek-harness-plugin-manager](https://github.com/hrhgit/deepseek-harness-plugin-manager) ⭐3 — Web plugin manager for DeepSeek Harness (DSH): inspect, search, group, enable, and disable Cordis plugins.（✅ 活跃）
+- [dsh-agentmemory](https://github.com/elementor-i/dsh-agentmemory) ⭐3 — agentmemory for DeepSeek Harness (dsh): full memory_* tools, capture hooks, and context injection over the local REST server（✅ 活跃）
+- [dsh-browser](https://github.com/anweat/dsh-browser) ⭐3 — Self-contained browser runtime plugin for DeepSeek Harness — bundles Playwright (chromium) and OpenCLI as plugin-local dependencies, exposes a browser service and interactive browser tools.（✅ 活跃）
+- [dsh-doctor](https://github.com/astra3294/dsh-doctor) ⭐3 — Deterministic diagnostics and recovery for DeepSeek Harness（✅ 活跃）
+- [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) ⭐3 — 并行 Agent 会话的文件归属/认领系统：认领/释放、心跳过期接管、异步三路合并。（✅ 活跃）
+- [dsh-file-mount](https://github.com/acefun29/dsh-file-mount) ⭐3 — 增量文件挂载 + 行区间去重：相同文件内容不再重复发送给模型。（✅ 活跃）
+- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud) ⭐3 — HUD 状态面板：浮动侧栏展示 git 状态、MCP 服务器、技能、模型与 token 用量。（✅ 活跃）
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) ⭐3 — 有界分层、审批门控、可审计的跨会话记忆，支持冻结快照注入。（✅ 活跃）
+- [dsh-memory-evidence](https://github.com/LeslieWylie/dsh-memory-evidence) ⭐3 — Git-first memory navigation and bounded evidence tools for DeepSeek Harness.（💤 停更）
+- [dsh-notebooks](https://github.com/havingautism/dsh-notebooks) ⭐3 — Notebooks plugin (cordis).（✅ 活跃）
+- [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) ⭐3 — DSH Windows 原生通知，零依赖。（✅ 活跃）
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) ⭐3 — dsh-passwords: DeepSeek Harness login gateway - first-run setup, at-rest encryption, brute-force lockout, audit log, HTTPS（✅ 活跃）
+- [dsh-plugin-diff-review](https://github.com/Civitasv/dsh-plugin-diff-review) ⭐3 — Diff Review Plugin for DeepSeek Harness（✅ 活跃）
 - [dsh-plugins-raincode](https://github.com/rainforest888/dsh-plugins-raincode) ⭐3 — dsh plugin: DeepSeek Harness 的模型层 = raincode(模型池/缓存/重试) + /skills 浏览（✅ 活跃）
-- [dsh-token-panel](https://github.com/juhe291/dsh-token-panel) ⭐3 — A corner HUD for DeepSeek Harness that shows your session's token pressure, per-model cost, and daily/monthly usage at a glance — with an editable budget & balance that tracks spending for you. 右下角常驻的 Token 仪表盘：实时查看会话压力、按模型估算花费，预算和余额点一下就能改，每天每月用了多少都有记录。（✅ 活跃）
+- [dsh-restart](https://github.com/anweat/dsh-restart) ⭐3 — Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.（✅ 活跃）
+- [dsh-suggested-replies](https://github.com/Anionex/dsh-suggested-replies) ⭐3 — DSH Web 预测回复插件：AI 回复后在输入框上方生成可点击填入草稿的候选。（✅ 活跃）
+- [dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) ⭐3 — Agent memory for DeepSeek Harness | DeepSeek Harness 记忆插件（✅ 活跃）
+- [dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) ⭐3 — Fail-closed export-copy redaction for DeepSeek Harness session telemetry（✅ 活跃）
+- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) ⭐3 — 结构化安全 Git 工具：status/diff/log/branch/stage/commit/stash/show，带破坏性命令防护。（✅ 活跃）
+- [dsh-ui-appearance](https://github.com/TQSY114514/dsh-ui-appearance) ⭐3 — Appearance customization plugin for DeepSeek Harness: theme color palette, background image, opacity/blur, glass effect（✅ 活跃）
+- [dsh-ultra-ui](https://github.com/havingautism/dsh-ultra-ui) ⭐3 — Ultra UI plugin (cordis).（✅ 活跃）
 - [dsh-usage-plugin](https://github.com/Yihong89/dsh-usage-plugin) ⭐3 — DeepSeek Harness (DSH) plugins. First: dsh-usage-report — per-session token usage & estimated cost (/usage + usage_report), priced from the DeepSeek pricing table.（✅ 活跃）
-- [dsh-weather](https://github.com/sunshine-lang/dsh-weather) ⭐3 — 天气工具：Open-Meteo 当前天气与多日预报，免费免密钥。（✅ 活跃）
-- [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) ⭐3 — 多引擎持久搜索：DeepSeek/Exa/DDG/Bing/Jina + GitHub/B站/YouTube/V2EX/小红书/推特/Reddit/RSS，SQLite+LRU 缓存 + Playwright 渲染。（✅ 活跃）
 - [dsh-webbridge](https://github.com/bill9109/dsh-webbridge) ⭐3 — DSH 结合 Kimi WebBridge 操控真实浏览器。（✅ 活跃）
-- [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐3 — 输入框旁常用词箱：全局/项目词桶，一键插入。（✅ 活跃）
-- [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) ⭐2 — DSH Web UI 跨平台文件拖拽与原始路径插入，无需复制文件。（✅ 活跃）
-- [dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) ⭐2 — 并行 Agent 会话的文件归属/认领系统：认领/释放、心跳过期接管、异步三路合并。（✅ 活跃）
-- [dsh-file-mount](https://github.com/acefun29/dsh-file-mount) ⭐2 — 增量文件挂载 + 行区间去重：相同文件内容不再重复发送给模型。（✅ 活跃）
+- [tokenledger](https://github.com/zh667/TokenLedger) ⭐3 — Token usage accounting for DeepSeek Harness, reconciled against New API and Sub2API relay-site billing（✅ 活跃）
+- [zotero-wave-rag](https://github.com/Fisfzy/zotero-wave-rag) ⭐3 — 面向 Zotero 论文库的浪潮式 RAG 细节检索系统 —— DSH 外部插件。移植 VCPToolBox 浪潮语义动力学思想（标签河道图传播/虫洞跳转/钟型阻尼/Ω重排），配 BM25+RRF 混合检索、claim-evidence 忠实度校验、两级增量索引（✅ 活跃）
+- [dsh-adb](https://github.com/SamXiaBing/dsh-adb) ⭐2 — ADB device & bench operations: device discovery, structured logcat (background streaming), apk install, file pull/push, dumpsys performance snapshots.（✅ 活跃）
+- [dsh-deepseek-quota](https://github.com/yingjunnan/dsh-deepseek-quota) ⭐2 — DeepSeek API quota (balance) widget for the DSH web GUI: a floating bottom-right card showing remaining DeepSeek API balance.（✅ 活跃）
+- [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) ⭐2 — 回复中文件路径可点击：内联打开、文件管理器揭示、提及文件芯片列表。（✅ 活跃）
 - [dsh-memory (Jesse-njx)](https://github.com/Jesse-njx/dsh-memory) ⭐2 — 基于 DSH 无损会话日志的引用式记忆：可人工审计的蒸馏事实，带引用来源。（✅ 活跃）
-- [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) ⭐2 — DSH Windows 原生通知，零依赖。（✅ 活跃）
-- [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) ⭐2 — PDF 工具箱：pdfjs-dist 本地提取文本、元数据与页区间，无需 API Key。（✅ 活跃）
+- [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) ⭐2 — 从操作条固定助手回复，并在下一轮召回（/pin /recall）。（✅ 活跃）
+- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) ⭐2 — mount one row in the composition and every plugin card on the Web Settings plugin list page gets a bilingual (zh/en) description; it also publishes the pluginDescriptions service so other plugins can register their own descriptions.（✅ 活跃）
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) ⭐2 — 带实时预览编辑用户与内置系统提示词片段。（✅ 活跃）
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) ⭐2 — 增量代码审查：基于检查点的审查队列 + Web UI 面板 + /review 命令。（✅ 活跃）
+- [dsh-scout](https://github.com/omdsh-dev/dsh-scout) ⭐2 — 面向 DeepSeek Harness 的只读环境探测插件，为智能体提供运行环境、软件版本、系统资源、端口、服务、硬件及工作区信息。（✅ 活跃）
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) ⭐2 — 免索引跨 Agent 会话搜索。（✅ 活跃）
-- [dsh-suggested-replies](https://github.com/Anionex/dsh-suggested-replies) ⭐2 — DSH Web 预测回复插件：AI 回复后在输入框上方生成可点击填入草稿的候选。（✅ 活跃）
-- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) ⭐2 — DSH Web 中英文金额 Token 计费：官方策略自动定价（含高峰/低谷），逐条消息费用台账。（✅ 活跃）
+- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) ⭐2 — 结构化测试运行工具：自动识别 vitest/jest/pytest/node:test，运行并解析失败摘要。（✅ 活跃）
+- [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) ⭐2 — 按 Agent 按需工具发现与渐进式 schema 披露。（✅ 活跃）
 - [URL Manager](https://github.com/Piccolo123/url-manager) ⭐2 — Agent 优先的 URL 与知识收集系统：自动分类、标签、全文检索与共享收藏。（✅ 活跃）
 - [dsh-computer-use](https://github.com/xiaoheizi1212/dsh-computer-use) ⭐1 — 模型无关的 Computer Use：隔离浏览器、Windows 原生助手与第三方桥接。（✅ 活跃）
-- [dsh-memento](https://github.com/PerryLink/dsh-memento) ⭐1 — 有界分层、审批门控、可审计的跨会话记忆，支持冻结快照注入。（✅ 活跃）
+- [dsh-doctor](https://github.com/asdf17128/dsh-doctor) ⭐1 — Find what your DeepSeek Harness (dsh) patches silently broke — dead patches, config fields dropped by whole-config replacement, unmaintained plugins. Read-only, zero deps.（✅ 活跃）
+- [dsh-news-plugin](https://github.com/canghai666x/dsh-news-plugin) ⭐1 — RSS/新闻摄入插件：返回结构化的标题/链接/来源/日期/摘要，供模型排序与简报。（✅ 活跃）
 - [dsh-payload-capture](https://github.com/Moeblack/dsh-payload-capture) ⭐1 — 捕捉每次上行模型 API payload，JSON 落盘，用于调试与可观测性。（✅ 活跃）
-- [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) ⭐1 — 从操作条固定助手回复，并在下一轮召回（/pin /recall）。（✅ 活跃）
-- [dsh-plugin-anydoc](https://github.com/beancookie/dsh-plugin-anydoc) ⭐1 — 基于 @firecrawl/anydoc 将 Word/PPT/Excel/PDF/EPUB/CSV 等文档转换为 GFM Markdown。（✅ 活跃）
-- [dsh-spend](https://github.com/nonewind/dsh-spend) ⭐1 — Token 用量与费用估算：悬浮面板，按模型/天/会话统计，自动识别计费套餐。（✅ 活跃）
-- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) ⭐1 — 结构化测试运行工具：自动识别 vitest/jest/pytest/node:test，运行并解析失败摘要。（✅ 活跃）
+- [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) ⭐1 — @dsh-pm/registry — discover dsh plugins by merging the awesome-dsh-plugin list, GitHub dsh-plugin-topic search, and npm keyword search into one deduped, offline-tolerant registry (the discovery engine of dsh pm)（✅ 活跃）
+- [dsh-plugin-quote-reply](https://github.com/yangYzc/dsh-plugin-quote-reply) ⭐1 — DSH plugin: select text in a conversation, then quote it into the composer or reply in a new window. / DeepSeek Harness 划词引用插件：选中文字一键引用回复或新窗口回复。（✅ 活跃）
+- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) ⭐1 — 回合索引侧栏：每个用户回合一条，点击跳转，滚动监听高亮。（✅ 活跃）
+- [dsh-turn-navigator](https://github.com/vibeinging/dsh-turn-navigator) ⭐1 — Private DSH Web turn navigation plugin（✅ 活跃）
 - [dsh-view-modes](https://github.com/NigelYao/dsh-view-modes) ⭐1 — Verbose/Normal/Summary 三种输出模式，工具调用与思考语义分组。（✅ 活跃）
-- [dsh-web-search-exa](https://github.com/TonyDua/dsh-web-search-exa) ⭐1 — 零配置 Exa 网页搜索：免密钥匿名 MCP 回退 + API Key REST 搜索。（✅ 活跃）
-- [dsh-workspace-search](https://github.com/tsonglew/dsh-workspace-search) ⭐1 — VS Code 风格工作区关键词搜索：Better Sidebar 生态的搜索 Tab。（✅ 活跃）
-- [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions)  — 回复中文件路径可点击：内联打开、文件管理器揭示、提及文件芯片列表。（✅ 活跃）
+- [dshp](https://github.com/asdf17128/dshp) ⭐1 — Manage DeepSeek Harness profiles — list, create, clone, diff, and share a whole dsh setup as one portable file.（✅ 活跃）
+- [dsh-cost-meter](https://github.com/Sttrevens/dsh-cost-meter)  — dsh plugin: per-turn USD cost badge in the Web UI (session total + per-message footer, hover breakdown) from token usage x a configurable pricing table.（✅ 活跃）
 - [dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads)  — 从 Web 输入框上传任意本地文件，待传卡片显示，设置页统一管理。（✅ 活跃）
 - [dsh-git-branch-switcher](https://github.com/mixin-ai/dsh-git-branch-switcher)  — 会话头部 git 分支胶囊：显示并在 Web UI 中切换工作区分支。（✅ 活跃）
-- [dsh-hud](https://github.com/a903067276-rgb/dsh-hud)  — HUD 状态面板：浮动侧栏展示 git 状态、MCP 服务器、技能、模型与 token 用量。（✅ 活跃）
 - [dsh-memoria](https://github.com/jiayan-xu/dsh-memoria)  — 向量 + 图记忆后端：命名空间隔离、自动观察、召回、重要性处理与热重载。（🧪 实验性）
 - [dsh-memory](https://github.com/flymysql/dsh-memory)  — 跨会话记忆库：memory_remember / memory_recall / memory_forget 工具 + 设置页。（🧪 实验性）
-- [dsh-news-plugin](https://github.com/canghai666x/dsh-news-plugin)  — RSS/新闻摄入插件：返回结构化的标题/链接/来源/日期/摘要，供模型排序与简报。（✅ 活跃）
-- [dsh-recommend](https://github.com/zp-home/dsh-recommend)  — 透明插件排行榜与推荐：每日自动抓取 dsh-plugin 主题数据，开放评分模型。（✅ 活跃）
-- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git)  — 结构化安全 Git 工具：status/diff/log/branch/stage/commit/stash/show，带破坏性命令防护。（✅ 活跃）
-- [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search)  — 按 Agent 按需工具发现与渐进式 schema 披露。（✅ 活跃）
-- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index)  — 回合索引侧栏：每个用户回合一条，点击跳转，滚动监听高亮。（✅ 活跃）
+- [dsh-plugin-cost](https://github.com/yweilai77-dev/dsh-plugin-cost)  — Session cost estimate in the DSH Web composer dock (tokenUsage × configurable price table, one-click official-price refresh).（✅ 活跃）
+- [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces.（✅ 活跃）
+- [dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream)  — 丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 prefers-reduced-motion。（✅ 活跃）
+- [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech)  — Browser Web Speech API voice input for DSH: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).（✅ 活跃）
 
 ### Skills
 
@@ -926,33 +1082,40 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) | ⭐12 | DSH Web 技能设置区：热启停、删除与新增。 | ✅ 活跃 |
-| 2 | [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) | ⭐9 | 插件开发踩坑与做法档案（skill + 文档）：cordis 双副本、tsconfig 三件套、Windows junction、多帧 zstd 实测。 | ✅ 活跃 |
-| 3 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | ⭐7 | 构建与测试 DSH 插件的 Agent 技能：从脚手架到发布。 | ✅ 活跃 |
-| 4 | [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | ⭐3 | 书转技能插件：获取→解析→理解→生成→安装的五阶段长任务。 | ✅ 活跃 |
-| 5 | [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) | ⭐2 | Godot Engine 4.x 全栈游戏开发技能插件。 | ✅ 活跃 |
-| 6 | [dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) | ⭐2 | DSH 代码评审技能集。 | ✅ 活跃 |
-| 7 | [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) | ⭐1 | 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索、安装与管理。 | ✅ 活跃 |
-| 8 | [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | ⭐1 | 安全审计技能包：5 个 Agent 技能，覆盖密钥扫描、依赖审计等。 | ✅ 活跃 |
-| 9 | [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) | ⭐1 | 让 Claude Code、Codex、Cursor、Gemini CLI 已有的技能在 DSH 中直接可用。 | ✅ 活跃 |
-| 10 | [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) | ⭐1 | 扫描会话可见技能，按与近期对话的相关度排序。 | ✅ 活跃 |
+| 1 | [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) | ⭐224 | EasyEDA Pro automation: Go daemon + in-app connector + agent skill + stdio MCP server for typed schematic/PCB actions, workflow gates, and DRC. | ✅ 活跃 |
+| 2 | [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) | ⭐34 | DSH Web 技能设置区：热启停、删除与新增。 | ✅ 活跃 |
+| 3 | [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | ⭐12 | Complete reverse-skill (85 SKILL.md) as a DeepSeek Harness (dsh) Cordis plugin — reverse engineering, authorized pentesting and security research skill pack. | ✅ 活跃 |
+| 4 | [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) | ⭐10 | 插件开发踩坑与做法档案（skill + 文档）：cordis 双副本、tsconfig 三件套、Windows junction、多帧 zstd 实测。 | ✅ 活跃 |
+| 5 | [dsh-science](https://github.com/biociao/dsh-science) | ⭐10 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ 活跃 |
+| 6 | [dsh-plugin-development](https://github.com/w2112515/dsh-plugin-development) | ⭐8 | Portable Agent Skill for developing and auditing DeepSeek Harness plugins, with an optional profile-installable DSH bundle adapter. | ✅ 活跃 |
+| 7 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | ⭐7 | 构建与测试 DSH 插件的 Agent 技能：从脚手架到发布。 | ✅ 活跃 |
+| 8 | [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | ⭐4 | 书转技能插件：获取→解析→理解→生成→安装的五阶段长任务。 | ✅ 活跃 |
+| 9 | [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) | ⭐4 | Godot Engine 4.x 全栈游戏开发技能插件。 | ✅ 活跃 |
+| 10 | [dsh-humanize](https://github.com/zevorn/dsh-humanize) | ⭐3 | 去 AI 味写作技能：让 Agent 输出更自然。 | ✅ 活跃 |
 
-#### 完整列表（14）
+#### 完整列表（21）
 
-- [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) ⭐12 — DSH Web 技能设置区：热启停、删除与新增。（✅ 活跃）
-- [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) ⭐9 — 插件开发踩坑与做法档案（skill + 文档）：cordis 双副本、tsconfig 三件套、Windows junction、多帧 zstd 实测。（✅ 活跃）
+- [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) ⭐224 — EasyEDA Pro automation: Go daemon + in-app connector + agent skill + stdio MCP server for typed schematic/PCB actions, workflow gates, and DRC.（✅ 活跃）
+- [dsh-skill-viewer](https://github.com/Fishquito7/dsh-skill-viewer) ⭐34 — DSH Web 技能设置区：热启停、删除与新增。（✅ 活跃）
+- [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) ⭐12 — Complete reverse-skill (85 SKILL.md) as a DeepSeek Harness (dsh) Cordis plugin — reverse engineering, authorized pentesting and security research skill pack.（✅ 活跃）
+- [dsh-plugin-dev](https://github.com/omdsh-dev/dsh-plugin-dev) ⭐10 — 插件开发踩坑与做法档案（skill + 文档）：cordis 双副本、tsconfig 三件套、Windows junction、多帧 zstd 实测。（✅ 活跃）
+- [dsh-science](https://github.com/biociao/dsh-science) ⭐10 — Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.（✅ 活跃）
+- [dsh-plugin-development](https://github.com/w2112515/dsh-plugin-development) ⭐8 — Portable Agent Skill for developing and auditing DeepSeek Harness plugins, with an optional profile-installable DSH bundle adapter.（✅ 活跃）
 - [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) ⭐7 — 构建与测试 DSH 插件的 Agent 技能：从脚手架到发布。（✅ 活跃）
-- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) ⭐3 — 书转技能插件：获取→解析→理解→生成→安装的五阶段长任务。（✅ 活跃）
-- [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) ⭐2 — Godot Engine 4.x 全栈游戏开发技能插件。（✅ 活跃）
+- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) ⭐4 — 书转技能插件：获取→解析→理解→生成→安装的五阶段长任务。（✅ 活跃）
+- [dsh-godot-skill](https://github.com/akira399/dsh-godot-skill) ⭐4 — Godot Engine 4.x 全栈游戏开发技能插件。（✅ 活跃）
+- [dsh-humanize](https://github.com/zevorn/dsh-humanize) ⭐3 — 去 AI 味写作技能：让 Agent 输出更自然。（✅ 活跃）
+- [dsh-memoryhub](https://github.com/solknight48/dsh-memoryhub) ⭐3 — MemoryHub (mh) plugin for DeepSeek Harness (dsh): auto-loads checkpoint memory on session start, adds mh_* tools and the mh skill, and a Memory tab in the web UI（✅ 活跃）
+- [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) ⭐3 — 扫描会话可见技能，按与近期对话的相关度排序。（✅ 活跃）
+- [deepseek-harness-skillx](https://github.com/drowned-fish1/deepseek-harness-skillx) ⭐2 — DSH 工作流技能合集。（✅ 活跃）
+- [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) ⭐2 — 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索、安装与管理。（✅ 活跃）
+- [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) ⭐2 — DSH knowledge-base plugin: build audit-able KB packs (references + SQLite FTS5) from md/txt/docx/pdf, deterministic retrieval (kb_query) and original-text reading (kb_read), zero-script generated skills. Apache-2.0.（✅ 活跃）
 - [dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) ⭐2 — DSH 代码评审技能集。（✅ 活跃）
-- [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) ⭐1 — 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索、安装与管理。（✅ 活跃）
-- [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) ⭐1 — 安全审计技能包：5 个 Agent 技能，覆盖密钥扫描、依赖审计等。（✅ 活跃）
-- [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) ⭐1 — 让 Claude Code、Codex、Cursor、Gemini CLI 已有的技能在 DSH 中直接可用。（✅ 活跃）
-- [dsh-skillradar](https://github.com/hellosky983/dsh-skillradar) ⭐1 — 扫描会话可见技能，按与近期对话的相关度排序。（✅ 活跃）
-- [deepseek-harness-skillx](https://github.com/drowned-fish1/deepseek-harness-skillx)  — DSH 工作流技能合集。（✅ 活跃）
-- [dsh-humanize](https://github.com/zevorn/dsh-humanize)  — 去 AI 味写作技能：让 Agent 输出更自然。（✅ 活跃）
+- [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) ⭐2 — 安全审计技能包：5 个 Agent 技能，覆盖密钥扫描、依赖审计等。（✅ 活跃）
+- [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) ⭐2 — 让 Claude Code、Codex、Cursor、Gemini CLI 已有的技能在 DSH 中直接可用。（✅ 活跃）
+- [dsh-web-novel-research](https://github.com/canghai666x/dsh-web-novel-research) ⭐1 — 中文网文情节查证技能：免费镜像站流程，GBK 解码与跨卷重复章节消歧。（✅ 活跃）
 - [dsh-news-briefing](https://github.com/canghai666x/dsh-news-briefing)  — 新闻简报技能：多维故事评分、反标题党规则、内容优先级与中文编辑风格。（✅ 活跃）
-- [dsh-web-novel-research](https://github.com/canghai666x/dsh-web-novel-research)  — 中文网文情节查证技能：免费镜像站流程，GBK 解码与跨卷重复章节消歧。（✅ 活跃）
+- [mstar-workflow](https://github.com/btspoony/mstar-workflow)  — A Skill-driven Harness/Loop Engineering Workflow Agent Plugin（💤 停更）
 
 ### Workflows & Automation
 
@@ -961,38 +1124,39 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | ⭐54 | 把 Claude Code 的 UltraCode 模式带给 DSH：将一次性多 Agent 调度升级为可生成、可保存、可治理、可观察、可恢复的 Workflow 层。 | ✅ 活跃 |
-| 2 | [mstar-harness](https://github.com/btspoony/mstar-harness) | ⭐42 | 技能驱动的 Harness/Loop 工程工作流 Agent：把 Agent 循环调优作为一等工作流。 | ✅ 活跃 |
-| 3 | [dsh-automation](https://github.com/titanwings/dsh-automation) | ⭐27 | 让 Coding 任务按计划在全新 Agent Session 中运行，由用户或 Agent 创建和管理定时任务。 | ✅ 活跃 |
-| 4 | [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | ⭐9 | 自动恢复中断的请求：失败分类、自适应退避重试、可配置续写消息与浏览器通知。 | ✅ 活跃 |
-| 5 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | ⭐9 | 基于官方 workflow 引擎的自适应深度研究编排器。 | ✅ 活跃 |
-| 6 | [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) | ⭐7 | 运维工具箱：官方每日快照 A/B 双槽轮换、原子切换、一键回滚、守护进程自动拉起。 | ✅ 活跃 |
-| 7 | [dsh-track](https://github.com/fakechris/dsh-track) | ⭐5 | 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。 | ✅ 活跃 |
-| 8 | [engineer-software](https://github.com/KirschBluteX/engineer-software) | ⭐5 | 与运行时无关、证据驱动的软件工程工作流，适用于 Codex 与 DeepSeek Harness。 | ✅ 活跃 |
-| 9 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | ⭐4 | 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场。 | ✅ 活跃 |
-| 10 | [dsh-plans](https://github.com/Optim-Agent/dsh-plans) | ⭐4 | 从 prime-plans 移植的人机协同规划预设：调研、评审、执行。 | ✅ 活跃 |
+| 1 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | ⭐56 | 把 Claude Code 的 UltraCode 模式带给 DSH：将一次性多 Agent 调度升级为可生成、可保存、可治理、可观察、可恢复的 Workflow 层。 | ✅ 活跃 |
+| 2 | [mstar-harness](https://github.com/btspoony/mstar-harness) | ⭐46 | 技能驱动的 Harness/Loop 工程工作流 Agent：把 Agent 循环调优作为一等工作流。 | ✅ 活跃 |
+| 3 | [dsh-automation](https://github.com/titanwings/dsh-automation) | ⭐39 | 让 Coding 任务按计划在全新 Agent Session 中运行，由用户或 Agent 创建和管理定时任务。 | ✅ 活跃 |
+| 4 | [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | ⭐15 | 自动恢复中断的请求：失败分类、自适应退避重试、可配置续写消息与浏览器通知。 | ✅ 活跃 |
+| 5 | [dsh-plans](https://github.com/Optim-Agent/dsh-plans) | ⭐13 | 从 prime-plans 移植的人机协同规划预设：调研、评审、执行。 | ✅ 活跃 |
+| 6 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | ⭐12 | 基于官方 workflow 引擎的自适应深度研究编排器。 | ✅ 活跃 |
+| 7 | [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) | ⭐9 | 运维工具箱：官方每日快照 A/B 双槽轮换、原子切换、一键回滚、守护进程自动拉起。 | ✅ 活跃 |
+| 8 | [dsh-track](https://github.com/fakechris/dsh-track) | ⭐6 | 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。 | ✅ 活跃 |
+| 9 | [engineer-software](https://github.com/KirschBluteX/engineer-software) | ⭐6 | 与运行时无关、证据驱动的软件工程工作流，适用于 Codex 与 DeepSeek Harness。 | ✅ 活跃 |
+| 10 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | ⭐5 | 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场。 | ✅ 活跃 |
 
-#### 完整列表（20）
+#### 完整列表（21）
 
-- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐54 — 把 Claude Code 的 UltraCode 模式带给 DSH：将一次性多 Agent 调度升级为可生成、可保存、可治理、可观察、可恢复的 Workflow 层。（✅ 活跃）
-- [mstar-harness](https://github.com/btspoony/mstar-harness) ⭐42 — 技能驱动的 Harness/Loop 工程工作流 Agent：把 Agent 循环调优作为一等工作流。（✅ 活跃）
-- [dsh-automation](https://github.com/titanwings/dsh-automation) ⭐27 — 让 Coding 任务按计划在全新 Agent Session 中运行，由用户或 Agent 创建和管理定时任务。（✅ 活跃）
-- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) ⭐9 — 自动恢复中断的请求：失败分类、自适应退避重试、可配置续写消息与浏览器通知。（✅ 活跃）
-- [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) ⭐9 — 基于官方 workflow 引擎的自适应深度研究编排器。（✅ 活跃）
-- [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) ⭐7 — 运维工具箱：官方每日快照 A/B 双槽轮换、原子切换、一键回滚、守护进程自动拉起。（✅ 活跃）
-- [dsh-track](https://github.com/fakechris/dsh-track) ⭐5 — 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。（✅ 活跃）
-- [engineer-software](https://github.com/KirschBluteX/engineer-software) ⭐5 — 与运行时无关、证据驱动的软件工程工作流，适用于 Codex 与 DeepSeek Harness。（✅ 活跃）
-- [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) ⭐4 — 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场。（✅ 活跃）
-- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) ⭐4 — 从 prime-plans 移植的人机协同规划预设：调研、评审、执行。（✅ 活跃）
-- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) ⭐3 — 面向 Harness 的 DeepResearch 插件（cordis）。（🧪 实验性）
-- [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) ⭐3 — 发现问题(checkup) → 修复交付(fix) → 质量复查(review) 的对抗式闭环。（✅ 活跃）
+- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐56 — 把 Claude Code 的 UltraCode 模式带给 DSH：将一次性多 Agent 调度升级为可生成、可保存、可治理、可观察、可恢复的 Workflow 层。（✅ 活跃）
+- [mstar-harness](https://github.com/btspoony/mstar-harness) ⭐46 — 技能驱动的 Harness/Loop 工程工作流 Agent：把 Agent 循环调优作为一等工作流。（✅ 活跃）
+- [dsh-automation](https://github.com/titanwings/dsh-automation) ⭐39 — 让 Coding 任务按计划在全新 Agent Session 中运行，由用户或 Agent 创建和管理定时任务。（✅ 活跃）
+- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) ⭐15 — 自动恢复中断的请求：失败分类、自适应退避重试、可配置续写消息与浏览器通知。（✅ 活跃）
+- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) ⭐13 — 从 prime-plans 移植的人机协同规划预设：调研、评审、执行。（✅ 活跃）
+- [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) ⭐12 — 基于官方 workflow 引擎的自适应深度研究编排器。（✅ 活跃）
+- [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) ⭐9 — 运维工具箱：官方每日快照 A/B 双槽轮换、原子切换、一键回滚、守护进程自动拉起。（✅ 活跃）
+- [dsh-track](https://github.com/fakechris/dsh-track) ⭐6 — 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储。（✅ 活跃）
+- [engineer-software](https://github.com/KirschBluteX/engineer-software) ⭐6 — 与运行时无关、证据驱动的软件工程工作流，适用于 Codex 与 DeepSeek Harness。（✅ 活跃）
+- [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) ⭐5 — 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场。（✅ 活跃）
+- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) ⭐5 — 面向 Harness 的 DeepResearch 插件（cordis）。（🧪 实验性）
+- [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) ⭐5 — 发现问题(checkup) → 修复交付(fix) → 质量复查(review) 的对抗式闭环。（✅ 活跃）
+- [dsh-agent-orchestration](https://github.com/LeslieWylie/dsh-agent-orchestration) ⭐3 — Evidence-first multi-agent workflow planning, handoff validation, and Loop Guard skills for DeepSeek Harness.（💤 停更）
 - [dsh-plugin-spur](https://github.com/HuanLinOTO/dsh-plugin-spur) ⭐3 — 聊天流中悬挂皮鞭：甩动鞭梢即向 agent 发送 go work 消息（整活）。（✅ 活跃）
 - [dsh-prime-agent](https://github.com/yoke233/dsh-prime-agent) ⭐3 — Prime Agent 启发的持久 RLM 控制平面，面向 DSH Code 模式。（✅ 活跃）
-- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) ⭐1 — 工程纪律循环：编辑前需求拷问、红/绿测试证据门、对抗式交付审查。（✅ 活跃）
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) ⭐2 — 工程纪律循环：编辑前需求拷问、红/绿测试证据门、对抗式交付审查。（✅ 活跃）
+- [dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) ⭐2 — 工作流运行、子代理、状态与依赖的持久化实时 DAG 可视化。（✅ 活跃）
 - [dsh-governance](https://github.com/tappass/dsh-governance) ⭐1 — Agentic AI 的权威层插件：按你的策略治理每次工具调用。（✅ 活跃）
+- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) ⭐1 — 把 DSH 会话变成可交付工作报告（日报/周报/交接/文章），带可验证凭证。（✅ 活跃）
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval)  — Agent 评测平台：benchmark YAML、无头 dsh 运行、基于 trace 的指标、脚本评分与运行对比。（✅ 活跃）
-- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio)  — 把 DSH 会话变成可交付工作报告（日报/周报/交接/文章），带可验证凭证。（✅ 活跃）
-- [dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag)  — 工作流运行、子代理、状态与依赖的持久化实时 DAG 可视化。（✅ 活跃）
 - [dsh-trajectory-debug](https://github.com/devmom/dsh-trajectory-debug)  — 轨迹瀑布流、确定性回放、断点、编辑重跑、fork 对比与性能分析。（✅ 活跃）
 
 ### Agents & Multi-Agent
@@ -1002,41 +1166,41 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) | ⭐2,324 | 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） | ✅ 活跃 |
-| 2 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | ⭐222 | 面向团队的 DSH 多 Agent 扩展。 | ✅ 活跃 |
-| 3 | [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) | ⭐101 | SillyTavern 迁移与下一代 Agent 角色扮演。 | ✅ 活跃 |
-| 4 | [allinluna](https://github.com/zenx0x/allinluna) | ⭐25 | 面向 Codex 与 DeepSeek Harness 的资源感知多 Agent 编排。 | ✅ 活跃 |
-| 5 | [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | ⭐24 | 跨实例消息/事件交接插件（interconnect 服务 + 工具）。 | ✅ 活跃 |
-| 6 | [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) | ⭐19 | OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 | ✅ 活跃 |
-| 7 | [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) | ⭐19 | DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 | ✅ 活跃 |
-| 8 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | ⭐17 | 会话级数据库连接 + 专用数据 Agent：让模型连数据库、写 SQL。 | ✅ 活跃 |
-| 9 | [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | ⭐12 | 将 DSH 桥接到 Claude Code：审查、批判、委托与会话导入。 | ✅ 活跃 |
-| 10 | [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) | ⭐8 | 基于角色的 Codex/Claude Code/ACP 子代理提供方：可延续的子任务，带持久状态。 | ✅ 活跃 |
+| 1 | [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) | ⭐2,493 | 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin） | ✅ 活跃 |
+| 2 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | ⭐312 | 面向团队的 DSH 多 Agent 扩展。 | ✅ 活跃 |
+| 3 | [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) | ⭐121 | SillyTavern 迁移与下一代 Agent 角色扮演。 | ✅ 活跃 |
+| 4 | [allinluna](https://github.com/zenx0x/allinluna) | ⭐28 | 面向 Codex 与 DeepSeek Harness 的资源感知多 Agent 编排。 | ✅ 活跃 |
+| 5 | [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | ⭐27 | 跨实例消息/事件交接插件（interconnect 服务 + 工具）。 | ✅ 活跃 |
+| 6 | [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) | ⭐26 | OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。 | ✅ 活跃 |
+| 7 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | ⭐25 | 会话级数据库连接 + 专用数据 Agent：让模型连数据库、写 SQL。 | ✅ 活跃 |
+| 8 | [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) | ⭐23 | DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。 | ✅ 活跃 |
+| 9 | [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | ⭐15 | 将 DSH 桥接到 Claude Code：审查、批判、委托与会话导入。 | ✅ 活跃 |
+| 10 | [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) | ⭐9 | 配对第二模型被动审查每一回合并注入建议。 | ✅ 活跃 |
 
 #### 完整列表（23）
 
-- [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) ⭐2,324 — 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin）（✅ 活跃）
-- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) ⭐222 — 面向团队的 DSH 多 Agent 扩展。（✅ 活跃）
-- [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) ⭐101 — SillyTavern 迁移与下一代 Agent 角色扮演。（✅ 活跃）
-- [allinluna](https://github.com/zenx0x/allinluna) ⭐25 — 面向 Codex 与 DeepSeek Harness 的资源感知多 Agent 编排。（✅ 活跃）
-- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) ⭐24 — 跨实例消息/事件交接插件（interconnect 服务 + 工具）。（✅ 活跃）
-- [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) ⭐19 — OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。（✅ 活跃）
-- [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) ⭐19 — DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。（✅ 活跃）
-- [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) ⭐17 — 会话级数据库连接 + 专用数据 Agent：让模型连数据库、写 SQL。（✅ 活跃）
-- [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) ⭐12 — 将 DSH 桥接到 Claude Code：审查、批判、委托与会话导入。（✅ 活跃）
-- [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) ⭐8 — 基于角色的 Codex/Claude Code/ACP 子代理提供方：可延续的子任务，带持久状态。（✅ 活跃）
-- [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) ⭐5 — 配对第二模型被动审查每一回合并注入建议。（✅ 活跃）
+- [openbiliclaw](https://github.com/whiteguo233/OpenBiliClaw) ⭐2,493 — 本地私有、开源的自进化跨平台 AI 内容发现 Agent：先理解你，再主动从 B站、小红书、抖音、YouTube、X、知乎、Reddit、微博等平台与开放 Web 寻找内容。（支持 deepseek harness 插件） | Local-first open-source cross-platform AI content discovery agent: understands you, then proactively finds content across Bilibili, Xiaohongshu, Douyin, YouTube, X, Zhihu, Reddit, Weibo and the open web.（support deepseek harness plugin）（✅ 活跃）
+- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) ⭐312 — 面向团队的 DSH 多 Agent 扩展。（✅ 活跃）
+- [dsh-agent-rp](https://github.com/hewzhew/dsh-agent-rp) ⭐121 — SillyTavern 迁移与下一代 Agent 角色扮演。（✅ 活跃）
+- [allinluna](https://github.com/zenx0x/allinluna) ⭐28 — 面向 Codex 与 DeepSeek Harness 的资源感知多 Agent 编排。（✅ 活跃）
+- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) ⭐27 — 跨实例消息/事件交接插件（interconnect 服务 + 工具）。（✅ 活跃）
+- [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) ⭐26 — OpenBiliClaw 是本地运行的跨平台个性化内容推荐 Agent，持续理解你的兴趣并主动找内容。本仓库是它的 DeepSeek Harness 插件：DSH 界面常驻第四栏（推荐/内容库/对话/画像/设置），注册 22 个 Agent Bridge 工具，让 Agent 也能读推荐、答探测、闭环学习。（✅ 活跃）
+- [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) ⭐25 — 会话级数据库连接 + 专用数据 Agent：让模型连数据库、写 SQL。（✅ 活跃）
+- [dsh-tianshu-build](https://github.com/huiliyi37/dsh-tianshu-build) ⭐23 — DeepSeek X Tianshu  Harness build 是一款完全体开源 coding agent:在 dsh harness 基础之上带视觉、跨会话记忆、验证门、agent 路由、语义 + 图谱代码检索、文件回滚和全屏终端 UI——全部以插件组合。  它是 DeepSeek Harness(dsh)的友好 MIT fork, 它保留了上游一切皆插件的架构，并将以harness最佳形态和架构往下演进。（✅ 活跃）
+- [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) ⭐15 — 将 DSH 桥接到 Claude Code：审查、批判、委托与会话导入。（✅ 活跃）
+- [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) ⭐9 — 配对第二模型被动审查每一回合并注入建议。（✅ 活跃）
+- [dsh-plugin-product-subagents](https://github.com/shaokeyibb/dsh-plugin-product-subagents) ⭐9 — 基于角色的 Codex/Claude Code/ACP 子代理提供方：可延续的子任务，带持久状态。（✅ 活跃）
+- [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) ⭐7 — 可配置子代理 profile 系统：单一 subagent 工具 + profile 参数，含 Web UI 设置与实时进度。（✅ 活跃）
+- [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) ⭐7 — 侧会话：/side 持续性侧会话（Codex 风格）与 /btw 一次性侧问（Claude 风格），临时 fork 中运行。（✅ 活跃）
 - [dsh-plugin-claude-bridge](https://github.com/YYTbit/dsh-plugin-claude-bridge) ⭐5 — 把 Claude Code 的记忆、技能与配置桥接到 DSH。（✅ 活跃）
-- [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) ⭐5 — 可配置子代理 profile 系统：单一 subagent 工具 + profile 参数，含 Web UI 设置与实时进度。（✅ 活跃）
 - [Task Passport](https://github.com/dongsheng123132/task-passport) ⭐5 — 跨编码 Agent 环境的开放任务交接协议：交接可验证的状态而非聊天记录。（✅ 活跃）
+- [dsh-a2a](https://github.com/dpskh/dsh-a2a) ⭐4 — 面向 Harness 的 Agent2Agent 网状网络。（✅ 活跃）
 - [dsh-agent-messaging](https://github.com/happyren/dsh-agent-messaging) ⭐4 — 跨会话 Agent 互发消息：按名称寻址其他会话。（✅ 活跃）
-- [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) ⭐4 — 侧会话：/side 持续性侧会话（Codex 风格）与 /btw 一次性侧问（Claude 风格），临时 fork 中运行。（✅ 活跃）
-- [dsh-a2a](https://github.com/dpskh/dsh-a2a) ⭐2 — 面向 Harness 的 Agent2Agent 网状网络。（✅ 活跃）
-- [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) ⭐2 — 基于角色的模型重试与备用策略插件。（✅ 活跃）
+- [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) ⭐4 — 基于角色的模型重试与备用策略插件。（✅ 活跃）
+- [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) ⭐2 — 跨会话消息：同机 DSH 会话之间可发现、互发消息并协同。（✅ 活跃）
+- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) ⭐2 — 子代理委托的逐调用模型/provider/persona/toolFilter 覆盖，支持 @preset 引用。（✅ 活跃）
 - [dsh-cross-session](https://github.com/Wha1eChai/dsh-cross-session) ⭐1 — 同运行时跨会话发现与通信。（✅ 活跃）
-- [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) ⭐1 — 跨会话消息：同机 DSH 会话之间可发现、互发消息并协同。（✅ 活跃）
 - [dsh-slice-agent-loop](https://github.com/TT-Wang/dsh-slice-agent-loop) ⭐1 — 可替换的 Agent 循环：上下文引擎是有界切片而非不断增长的记录。（✅ 活跃）
-- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) ⭐1 — 子代理委托的逐调用模型/provider/persona/toolFilter 覆盖，支持 @preset 引用。（✅ 活跃）
 - [dsh-supervisor](https://github.com/Wha1eChai/dsh-supervisor) ⭐1 — 同运行时跨会话发现与通信。（✅ 活跃）
 
 ### Clients (Desktop & TUI)
@@ -1046,54 +1210,70 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) | ⭐962 | 为 DeepSeek Harness 生态打造的现代化桌面端体验（插件）。 | ✅ 活跃 |
-| 2 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | ⭐793 | Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表。 | ✅ 活跃 |
-| 3 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | ⭐160 | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，分层安装。 | ✅ 活跃 |
-| 4 | [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) | ⭐140 | DeepSeek Harness 桌面应用。 | ✅ 活跃 |
-| 5 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | ⭐125 | DSH 交互式终端 UI 插件：在官方基础上增加 TDD、证据门、视觉图像模块等工作流。 | ✅ 活跃 |
-| 6 | [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) | ⭐104 | 极简跨平台桌面端：免配置，开箱即用。 | ✅ 活跃 |
-| 7 | [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) | ⭐74 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch | ✅ 活跃 |
-| 8 | [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) | ⭐67 | DeepSeek Harness 桌面封装。 | ✅ 活跃 |
-| 9 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | ⭐65 | 轻量 Windows 启动器：登录静默自启 + 极简 WebView2 窗口。 | ✅ 活跃 |
-| 10 | [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) | ⭐63 | 一键桌面应用：全本地运行，核心自愈更新，零环境配置。Win/macOS/Linux。 | ✅ 活跃 |
+| 1 | [open-design](https://github.com/nexu-io/open-design) | ⭐86,741 | 🎨 The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode / Hermes & 20+ CLIs via BYOK. | ✅ 活跃 |
+| 2 | [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) | ⭐4,667 | 为 DeepSeek Harness 生态打造的现代化桌面端体验（插件）。 | ✅ 活跃 |
+| 3 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | ⭐1,156 | Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表。 | ✅ 活跃 |
+| 4 | [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) | ⭐227 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch | ✅ 活跃 |
+| 5 | [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) | ⭐221 | DeepSeek Harness 桌面应用。 | ✅ 活跃 |
+| 6 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | ⭐184 | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，分层安装。 | ✅ 活跃 |
+| 7 | [deepseek-harness-eac](https://github.com/zouyuxuan122/Deepseek-Harness-EAC) | ⭐158 | DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch, 10 built-in UI skins. EAC: Embracing All Creation 揽尽万象 | ✅ 活跃 |
+| 8 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | ⭐153 | DSH 交互式终端 UI 插件：在官方基础上增加 TDD、证据门、视觉图像模块等工作流。 | ✅ 活跃 |
+| 9 | [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) | ⭐143 | 一键桌面应用：全本地运行，核心自愈更新，零环境配置。Win/macOS/Linux。 | ✅ 活跃 |
+| 10 | [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) | ⭐139 | 极简跨平台桌面端：免配置，开箱即用。 | ✅ 活跃 |
 
-#### 完整列表（35）
+#### 完整列表（51）
 
-- [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) ⭐962 — 为 DeepSeek Harness 生态打造的现代化桌面端体验（插件）。（✅ 活跃）
-- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) ⭐793 — Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表。（✅ 活跃）
-- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) ⭐160 — 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，分层安装。（✅ 活跃）
-- [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) ⭐140 — DeepSeek Harness 桌面应用。（✅ 活跃）
-- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) ⭐125 — DSH 交互式终端 UI 插件：在官方基础上增加 TDD、证据门、视觉图像模块等工作流。（✅ 活跃）
-- [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) ⭐104 — 极简跨平台桌面端：免配置，开箱即用。（✅ 活跃）
-- [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) ⭐74 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch（✅ 活跃）
-- [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) ⭐67 — DeepSeek Harness 桌面封装。（✅ 活跃）
-- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) ⭐65 — 轻量 Windows 启动器：登录静默自启 + 极简 WebView2 窗口。（✅ 活跃）
-- [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) ⭐63 — 一键桌面应用：全本地运行，核心自愈更新，零环境配置。Win/macOS/Linux。（✅ 活跃）
-- [deepseek-harness-desktop (xiincs)](https://github.com/xiincs/deepseek-harness-desktop) ⭐53 — 基于 Tauri 2 的原生桌面版：内置 Node.js 运行时，托盘常驻，自动更新。（✅ 活跃）
-- [Deepseek-Harness-Desktop (ChisaAlter)](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) ⭐50 — Electron 桌面壳：支持主题与背景图等多种个性化配置。（✅ 活跃）
-- [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) ⭐27 — 在 Multica 上支持 dsh 运行时。（✅ 活跃）
-- [dsh-work](https://github.com/vibeinging/dsh-work) ⭐25 — Local-first AI workbench for DSH Plugins, combining Agent sessions, project files, data analysis, web research, MCP, and Office artifacts in an Electron desktop app.（✅ 活跃）
-- [deepseek-harness-app (ipfred)](https://github.com/ipfred/deepseek-harness-app) ⭐23 — DeepSeek Harness 桌面应用。（✅ 活跃）
-- [deepseek-harness-desktop (hongfeiyucode)](https://github.com/hongfeiyucode/deepseek-harness-desktop) ⭐23 — DeepSeek Harness 桌面封装。（✅ 活跃）
-- [deepseek-harness-desktop (ningbainb)](https://github.com/ningbainb/deepseek-harness-desktop) ⭐21 — 无损 Windows 桌面应用：完整 DSH Web UI、插件、皮肤与技能停靠栏。（✅ 活跃）
-- [DeepSeekHarnessDesktop (wess09)](https://github.com/wess09/DeepSeekHarnessDesktop) ⭐20 — DeepSeek Harness 桌面端打包。（✅ 活跃）
-- [dsh-desktop (bruc3van)](https://github.com/bruc3van/dsh-desktop) ⭐20 — 第三方桌面客户端：直接加载官方 Web UI，可复用本机实例或内置 dsh 运行时。（✅ 活跃）
-- [DeepSeek Harness TUI (openma-ai)](https://github.com/openma-ai/deepseek-harness-tui) ⭐15 — Rust/Ratatui 终端客户端，直接与 DSH 的 SDK JSON-RPC 协议通信。（✅ 活跃）
-- [deepseek-harness-desktop (cc1252)](https://github.com/cc1252/deepseek-harness-desktop) ⭐14 — 非官方 Windows Electron 封装。（✅ 活跃）
-- [DeepSeek-Harness-Desktop (sleep2agi)](https://github.com/sleep2agi/DeepSeek-Harness-Desktop) ⭐11 — 社区桌面壳。（✅ 活跃）
-- [awesome-deepseek-harness-desktop (ADHD)](https://github.com/omdsh-dev/awesome-deepseek-harness-desktop) ⭐10 — ADHD — 开箱即用的 Electron 桌面封装。（✅ 活跃）
+- [open-design](https://github.com/nexu-io/open-design) ⭐86,741 — 🎨 The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images & video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode / Hermes & 20+ CLIs via BYOK.（✅ 活跃）
+- [deepseek-harness-desktop (Anywhere Labs)](https://github.com/anywhere-labs/deepseek-harness-desktop) ⭐4,667 — 为 DeepSeek Harness 生态打造的现代化桌面端体验（插件）。（✅ 活跃）
+- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) ⭐1,156 — Claude Code 风格全屏交互终端插件：像素鲸鱼顶栏、实时状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表。（✅ 活跃）
+- [dsh_desktop](https://github.com/myYangyunfan/dsh_desktop) ⭐227 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch（✅ 活跃）
+- [dsh-desktop (DataElement)](https://github.com/dataelement/dsh-desktop) ⭐221 — DeepSeek Harness 桌面应用。（✅ 活跃）
+- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) ⭐184 — 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，分层安装。（✅ 活跃）
+- [deepseek-harness-eac](https://github.com/zouyuxuan122/Deepseek-Harness-EAC) ⭐158 — DeepSeek Harness (dsh) Windows desktop client - bundled Node.js + dsh CLI, one-click launch, 10 built-in UI skins. EAC: Embracing All Creation 揽尽万象（✅ 活跃）
+- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) ⭐153 — DSH 交互式终端 UI 插件：在官方基础上增加 TDD、证据门、视觉图像模块等工作流。（✅ 活跃）
+- [deepseek-harness-desktop (hairyf)](https://github.com/hairyf/deepseek-harness-desktop) ⭐143 — 一键桌面应用：全本地运行，核心自愈更新，零环境配置。Win/macOS/Linux。（✅ 活跃）
+- [deepseek-harness-desktop (steven-kid)](https://github.com/steven-kid/deepseek-harness-desktop) ⭐139 — 极简跨平台桌面端：免配置，开箱即用。（✅ 活跃）
+- [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) ⭐115 — DeepSeek Harness Desktop App: a local AI desktop workspace for DSH Sessions, projects, files, web research, plugins, and Office artifacts.（✅ 活跃）
+- [dsh-work](https://github.com/vibeinging/dsh-work) ⭐115 — Local-first AI workbench for DSH Plugins, combining Agent sessions, project files, data analysis, web research, MCP, and Office artifacts in an Electron desktop app.（✅ 活跃）
+- [deepseek-harness-desktop (salathleizhang)](https://github.com/salathleizhang/deepseek-harness-desktop) ⭐94 — DeepSeek Harness 桌面封装。（✅ 活跃）
+- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) ⭐92 — 轻量 Windows 启动器：登录静默自启 + 极简 WebView2 窗口。（✅ 活跃）
+- [Deepseek-Harness-Desktop (ChisaAlter)](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) ⭐81 — Electron 桌面壳：支持主题与背景图等多种个性化配置。（✅ 活跃）
+- [deepseek-harness-desktop (ningbainb)](https://github.com/ningbainb/deepseek-harness-desktop) ⭐44 — 无损 Windows 桌面应用：完整 DSH Web UI、插件、皮肤与技能停靠栏。（✅ 活跃）
+- [deepseek-harness-desktop (hongfeiyucode)](https://github.com/hongfeiyucode/deepseek-harness-desktop) ⭐37 — DeepSeek Harness 桌面封装。（✅ 活跃）
+- [DeepSeekHarnessDesktop (wess09)](https://github.com/wess09/DeepSeekHarnessDesktop) ⭐37 — DeepSeek Harness 桌面端打包。（✅ 活跃）
+- [deepseek-harness-desktop (xiincs)](https://github.com/xiincs/deepseek-harness-desktop) ⭐36 — 基于 Tauri 2 的原生桌面版：内置 Node.js 运行时，托盘常驻，自动更新。（✅ 活跃）
+- [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) ⭐34 — 在 Multica 上支持 dsh 运行时。（✅ 活跃）
+- [dsh-desktop (bruc3van)](https://github.com/bruc3van/dsh-desktop) ⭐29 — 第三方桌面客户端：直接加载官方 Web UI，可复用本机实例或内置 dsh 运行时。（✅ 活跃）
+- [deepseek-harness-app (ipfred)](https://github.com/ipfred/deepseek-harness-app) ⭐26 — DeepSeek Harness 桌面应用。（✅ 活跃）
+- [DeepSeek Harness TUI (openma-ai)](https://github.com/openma-ai/deepseek-harness-tui) ⭐25 — Rust/Ratatui 终端客户端，直接与 DSH 的 SDK JSON-RPC 协议通信。（✅ 活跃）
+- [deepseek-harness-desktop (cc1252)](https://github.com/cc1252/deepseek-harness-desktop) ⭐17 — 非官方 Windows Electron 封装。（✅ 活跃）
+- [deepseek-harness-termux](https://github.com/Vengisk/deepseek-harness-termux) ⭐15 — 在 Android/Termux 上运行 DeepSeek Harness。（✅ 活跃）
+- [dsh-plugin-session-delete](https://github.com/lsz-asd/dsh-plugin-session-delete) ⭐15 — Delete DeepSeek Harness sessions from the UI: header danger button + sidebar session-row menu item (no conversation jump), risk-consent dialog with session name/id, stops running agents first, in-place list refresh without page reload. Works in web and the desktop client.（✅ 活跃）
+- [DeepSeek-Harness-Desktop (sleep2agi)](https://github.com/sleep2agi/DeepSeek-Harness-Desktop) ⭐14 — 社区桌面壳。（✅ 活跃）
+- [dsh-usage-plugin](https://github.com/feiyang-dev/dsh-usage-plugin) ⭐14 — DeepSeek Harness 用量与消耗插件（dsh-usage）—— 每次调用的 token 用量/缓存命中统计、峰谷计费、余额查询、CSV/JSON/PNG 导出，可经桌面端一键安装或命令行 dsh plugin add 安装。（✅ 活跃）
+- [dsh-mobile](https://github.com/lehhair/dsh-mobile) ⭐12 — Mobile client plugin (cordis + dsh.plugin.json).（✅ 活跃）
+- [awesome-deepseek-harness-desktop (ADHD)](https://github.com/omdsh-dev/awesome-deepseek-harness-desktop) ⭐11 — ADHD — 开箱即用的 Electron 桌面封装。（✅ 活跃）
 - [deepseek-harness-desktop (chyra-moon)](https://github.com/chyra-moon/deepseek-harness-desktop) ⭐10 — Windows 原生桌面壳：官方 Web UI 1:1 复刻，内置服务、托盘与自动恢复。（✅ 活跃）
-- [deepseek-harness-termux](https://github.com/Vengisk/deepseek-harness-termux) ⭐9 — 在 Android/Termux 上运行 DeepSeek Harness。（✅ 活跃）
-- [deepseek-harness-desktop](https://github.com/omdsh-dev/deepseek-harness-desktop) ⭐7 — DSH 桌面应用打包器（✅ 活跃）
-- [deepseek-harness-desktop](https://github.com/qyqy-1109/deepseek-harness-desktop) ⭐6 — DeepSeek Harness Desktop: self-contained Windows desktop shell (Electron) that auto-starts dsh web, plus a subtle Codex-flavored theme plugin.（✅ 活跃）
-- [deepseek-harness-tui (gxinxing)](https://github.com/gxinxing/deepseek-harness-tui) ⭐6 — 基于 Ink（终端 React）构建的终端原生交互 TUI。（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/qyqy-1109/deepseek-harness-desktop) ⭐9 — DeepSeek Harness Desktop: self-contained Windows desktop shell (Electron) that auto-starts dsh web, plus a subtle Codex-flavored theme plugin.（✅ 活跃）
+- [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) ⭐9 — 基于 grok-build 构建的 TUI。（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/omdsh-dev/deepseek-harness-desktop) ⭐8 — DSH 桌面应用打包器（✅ 活跃）
+- [deepseek-harness-fnos](https://github.com/techysy/deepseek-harness-fnos) ⭐8 — DeepSeek Harness (DeepSeek 官方 agent 浏览器 UI) fnOS 应用 — 本地常驻服务, 官方统一网关接入（✅ 活跃）
+- [dsh-melody-launcher](https://github.com/rirko/dsh-melody-launcher) ⭐8 — dsh-旋律启动器：DeepSeek Harness 桌面启动器与插件管理器（✅ 活跃）
+- [dsh-mobile-for-android](https://github.com/Hongtwenfive1226/DSH-Mobile-for-Android) ⭐8 — The Android mobile version of DeepSeek Harness that relies on Tailscale.（✅ 活跃）
+- [deepseek-harness-tui (gxinxing)](https://github.com/gxinxing/deepseek-harness-tui) ⭐7 — 基于 Ink（终端 React）构建的终端原生交互 TUI。（✅ 活跃）
+- [dsh-desktop](https://github.com/foolgry/dsh-desktop) ⭐7 — Download-and-run desktop build of DeepSeek Harness — Electron shell with embedded Node, no npm required.（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/RZX00/deepseek-harness-desktop) ⭐6 — DeepSeek Harness with a Windows desktop build: an Electron shell over the dsh web profile, packaged as an installer（✅ 活跃）
+- [deepseek-harness-tui (boxeryao)](https://github.com/boxeryao/deepseek-harness-tui) ⭐6 — 轻量快速终端插件，直连 DSH 运行时。（✅ 活跃）
 - [deepseek-harness-cli](https://github.com/Richard-Yang0130/deepseek-harness-cli) ⭐5 — Claude Code-style terminal interface for DeepSeek Harness（✅ 活跃）
-- [deepseek-harness-desktop](https://github.com/RZX00/deepseek-harness-desktop) ⭐5 — DeepSeek Harness with a Windows desktop build: an Electron shell over the dsh web profile, packaged as an installer（✅ 活跃）
-- [deepseek-harness-tui (boxeryao)](https://github.com/boxeryao/deepseek-harness-tui) ⭐5 — 轻量快速终端插件，直连 DSH 运行时。（✅ 活跃）
-- [deepseek-harness-fnos](https://github.com/techysy/deepseek-harness-fnos) ⭐4 — DeepSeek Harness (DeepSeek 官方 agent 浏览器 UI) fnOS 应用 — 本地常驻服务, 官方统一网关接入（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) ⭐4 — Windows desktop app for DeepSeek Harness: installer, themes, in-app plugin marketplace, model routing, and updates.（✅ 活跃）
 - [dsh-desktop-electron](https://github.com/Void0312Aurora/dsh-desktop-electron) ⭐4 — 跨平台 Electron 桌面壳：托盘常驻独立窗口。（✅ 活跃）
+- [dshcockpit](https://github.com/Lxiayu/DshCockpit) ⭐4 — DshCockpit — DeepSeek Harness 桌面驾驶舱 (desktop cockpit)：运行时自动更新、成本控制、全局快捷问询、定时任务、会话全文检索、数据安全。自动更新 / 成本中心 / Quick Ask / 定时任务 / 会话搜索（✅ 活跃）
+- [deepseek-harness-workbench](https://github.com/xuan-ao-1/deepseek-harness-workbench) ⭐3 — DeepSeek Harness 官方架构的 Windows 桌面发行版 (Desktop distribution of the official DeepSeek Harness)（✅ 活跃）
+- [dsh-portable-launcher](https://github.com/15828148/dsh-portable-launcher) ⭐2 — One-click portable launcher for DeepSeek Harness (dsh) Web UI on Windows. Auto-installs Node.js and dsh with China mirror fallback, 3-stage progress with retries and resume, zero-download fast path when ready. No admin needed.（✅ 活跃）
+- [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop-windows) ⭐1 — Unofficial in-process desktop app for DeepSeek Harness: the host composition boots inside the Electron main process with zero ports and an IPC bridge. Not affiliated with DeepSeek.（✅ 活跃）
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) ⭐1 — Pi TUI 前端：流式 Markdown、思考折叠、工具卡片、斜杠命令与审批浮层。（✅ 活跃）
-- [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui)  — 基于 grok-build 构建的 TUI。（✅ 活跃）
+- [dsh-desktop-launcher](https://github.com/becomeless/dsh-desktop-launcher)  — Windows/macOS desktop launcher for DeepSeek Harness: double-click to launch, zero console windows, auto-stop on close | 双击图标一键启动 DeepSeek Harness 的桌面启动器（Windows / macOS）（✅ 活跃）
+- [dsh-quickstart](https://github.com/qzhqzh/dsh-quickstart)  — Desktop launcher for DeepSeek Harness - start dsh web with no console window and auto-open the browser. Tested on Windows; macOS/Linux in progress.（✅ 活跃）
 
 ### MCP & Integrations
 
@@ -1102,42 +1282,52 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) | ⭐758 | 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。 | ✅ 活跃 |
-| 2 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | ⭐64 | OpenPencil 设计预览与编辑集成。 | ✅ 活跃 |
-| 3 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | ⭐14 | Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 | ✅ 活跃 |
-| 4 | [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) | ⭐6 | DeepSeek Harness 的 ACP 服务器实现：复用凭据与会话，将完整 DSH Agent 暴露给 ACP 客户端。 | ✅ 活跃 |
-| 5 | [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) | ⭐6 | @deepseek-ai/dsh 的社区 Docker/K8s 打包，加固镜像。 | ✅ 活跃 |
-| 6 | [dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | ⭐6 | OAuth 2.1 Streamable HTTP MCP 客户端插件。 | ✅ 活跃 |
-| 7 | [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) | ⭐5 | 社区 GitHub Action：AI 代码审查、CI 诊断、自动修复、Issue 转 PR。 | ✅ 活跃 |
-| 8 | [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) | ⭐5 | MCP 服务器管理器：设置页 OAuth（PKCE + 动态客户端注册）或静态 Token 认证。 | ✅ 活跃 |
-| 9 | [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) | ⭐4 | DeepSeek Harness for VS Code as extension | ✅ 活跃 |
-| 10 | [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) | ⭐4 | 把 Telegram 变成 DSH 远程对话渠道并接收通知。 | ✅ 活跃 |
+| 1 | [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) | ⭐787 | 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。 | ✅ 活跃 |
+| 2 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | ⭐74 | OpenPencil 设计预览与编辑集成。 | ✅ 活跃 |
+| 3 | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | ⭐48 | 上下文注入增强插件（cordis）。 | ✅ 活跃 |
+| 4 | [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot) | ⭐32 | 让 QQ 机器人接入 DeepSeek Harness（dsh）的官方插件 | ✅ 活跃 |
+| 5 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | ⭐16 | Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件 | ✅ 活跃 |
+| 6 | [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) | ⭐11 | 社区 GitHub Action：AI 代码审查、CI 诊断、自动修复、Issue 转 PR。 | ✅ 活跃 |
+| 7 | [ikanban](https://github.com/isomoes/ikanban) | ⭐10 | Monorepo for the iKanban browser-surface fork for DeepSeek Harness. | ✅ 活跃 |
+| 8 | [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) | ⭐8 | @deepseek-ai/dsh 的社区 Docker/K8s 打包，加固镜像。 | ✅ 活跃 |
+| 9 | [dsh-git-graph](https://github.com/1841220388zzzcccxxx-star/dsh-git-graph) | ⭐8 | Embedded git repository graph visualizer for the DeepSeek Harness Web GUI | 嵌入式 Git 仓库图谱可视化插件（提交历史图 / 分支过滤 / 文件 diff / VSCode 式未提交改动） | ✅ 活跃 |
+| 10 | [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) | ⭐8 | 用搜索 MCP 服务器（Tavily/Brave/Exa/Perplexity/DDG）替换 DSH 内置搜索。 | ✅ 活跃 |
 
-#### 完整列表（25）
+#### 完整列表（35）
 
-- [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐758 — 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。（✅ 活跃）
-- [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) ⭐64 — OpenPencil 设计预览与编辑集成。（✅ 活跃）
-- [dsh-lark](https://github.com/omdsh-dev/dsh-lark) ⭐14 — Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件（✅ 活跃）
-- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) ⭐6 — DeepSeek Harness 的 ACP 服务器实现：复用凭据与会话，将完整 DSH Agent 暴露给 ACP 客户端。（✅ 活跃）
-- [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) ⭐6 — @deepseek-ai/dsh 的社区 Docker/K8s 打包，加固镜像。（✅ 活跃）
+- [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐787 — 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。（✅ 活跃）
+- [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) ⭐74 — OpenPencil 设计预览与编辑集成。（✅ 活跃）
+- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) ⭐48 — 上下文注入增强插件（cordis）。（✅ 活跃）
+- [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot) ⭐32 — 让 QQ 机器人接入 DeepSeek Harness（dsh）的官方插件（✅ 活跃）
+- [dsh-lark](https://github.com/omdsh-dev/dsh-lark) ⭐16 — Lark/Feishu IM bot channel for DeepSeek Harness | 飞书 DeepSeek Harness 插件（✅ 活跃）
+- [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) ⭐11 — 社区 GitHub Action：AI 代码审查、CI 诊断、自动修复、Issue 转 PR。（✅ 活跃）
+- [ikanban](https://github.com/isomoes/ikanban) ⭐10 — Monorepo for the iKanban browser-surface fork for DeepSeek Harness.（✅ 活跃）
+- [deepseek-harness-docker](https://github.com/runzhliu/deepseek-harness-docker) ⭐8 — @deepseek-ai/dsh 的社区 Docker/K8s 打包，加固镜像。（✅ 活跃）
+- [dsh-git-graph](https://github.com/1841220388zzzcccxxx-star/dsh-git-graph) ⭐8 — Embedded git repository graph visualizer for the DeepSeek Harness Web GUI | 嵌入式 Git 仓库图谱可视化插件（提交历史图 / 分支过滤 / 文件 diff / VSCode 式未提交改动）（✅ 活跃）
+- [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) ⭐8 — 用搜索 MCP 服务器（Tavily/Brave/Exa/Perplexity/DDG）替换 DSH 内置搜索。（✅ 活跃）
+- [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) ⭐8 — DeepSeek Harness 插件：DeepSeek 大脑 + 自动识图。GUI 附加图片自动经 OpenAI 兼容 VLM 转译成文字后交给 DeepSeek 作答；支持百炼/智谱/OpenRouter 等任意 OpenAI 兼容端点（默认 qwen3.7-flash），无 key 自动探测本地 Ollama（图片不出本机）；安装时有一问式确认（✅ 活跃）
+- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) ⭐7 — DeepSeek Harness 的 ACP 服务器实现：复用凭据与会话，将完整 DSH Agent 暴露给 ACP 客户端。（✅ 活跃）
+- [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) ⭐7 — DeepSeek Harness for VS Code as extension（✅ 活跃）
+- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) ⭐6 — MCP 服务器管理器：设置页 OAuth（PKCE + 动态客户端注册）或静态 Token 认证。（✅ 活跃）
 - [dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) ⭐6 — OAuth 2.1 Streamable HTTP MCP 客户端插件。（✅ 活跃）
-- [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) ⭐5 — 社区 GitHub Action：AI 代码审查、CI 诊断、自动修复、Issue 转 PR。（✅ 活跃）
-- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) ⭐5 — MCP 服务器管理器：设置页 OAuth（PKCE + 动态客户端注册）或静态 Token 认证。（✅ 活跃）
-- [deepseek-harness-vsc-extension](https://github.com/weinibuliu/deepseek-harness-vsc-extension) ⭐4 — DeepSeek Harness for VS Code as extension（✅ 活跃）
-- [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) ⭐4 — 把 Telegram 变成 DSH 远程对话渠道并接收通知。（✅ 活跃）
-- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) ⭐4 — Telegram 手机远程控制 DSH 实时会话：会话选择、绑定/解绑，轨迹与桌面一致。（✅ 活跃）
+- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) ⭐6 — Telegram 手机远程控制 DSH 实时会话：会话选择、绑定/解绑，轨迹与桌面一致。（✅ 活跃）
+- [telegram](https://github.com/LoserFox/telegram) ⭐6 — Telegram Bot API 桥接插件：长轮询、per-chat 会话、HTML 格式化（✅ 活跃）
+- [DSH Telegram Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) ⭐5 — 把 Telegram 变成 DSH 远程对话渠道并接收通知。（✅ 活跃）
+- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) ⭐5 — 将 DSH Agent 能力暴露为 MCP 服务器（大脑=Hermes，双手=Harness）。（✅ 活跃）
+- [dsh-browser](https://github.com/xylt369/dsh-browser) ⭐4 — Browser capability for DeepSeek Harness: headed Edge/Playwright provider, SSRF-safe navigation, a11y-ref clicking, permission gate with auto-remember, gated evaluate（✅ 活跃）
+- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) ⭐4 — Web GUI 局域网访问：0.0.0.0 绑定 + 非安全上下文 polyfill。（✅ 活跃）
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) ⭐4 — 官方 DSH MCP 客户端的只读运行时管理面板：/mcp 命令 + 设置 Tab。（✅ 活跃）
+- [dsh-subscription-auth](https://github.com/Khellendros97/dsh-subscription-auth) ⭐4 — dsh对接openai、grok、anthropic、kimi订阅渠道（✅ 活跃）
 - [PicGo DSH Plugin](https://github.com/PicGo/dsh-plugin) ⭐4 — PicGo 官方插件：从 DSH 上传图片/文件到图床并获取公网 URL。（✅ 活跃）
-- [dsh-browser](https://github.com/xylt369/dsh-browser) ⭐3 — Browser capability for DeepSeek Harness: headed Edge/Playwright provider, SSRF-safe navigation, a11y-ref clicking, permission gate with auto-remember, gated evaluate（✅ 活跃）
-- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) ⭐3 — 官方 DSH MCP 客户端的只读运行时管理面板：/mcp 命令 + 设置 Tab。（✅ 活跃）
-- [dsh-search-mcp](https://github.com/gxpppp/dsh-search-mcp) ⭐3 — 用搜索 MCP 服务器（Tavily/Brave/Exa/Perplexity/DDG）替换 DSH 内置搜索。（✅ 活跃）
-- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) ⭐2 — 将 DSH Agent 能力暴露为 MCP 服务器（大脑=Hermes，双手=Harness）。（✅ 活跃）
+- [dsh-agentlink](https://github.com/hootandy321/dsh-Agentlink) ⭐3 — Caller-side bridge from Codex and other agent frameworks to DeepSeek Harness, with observable sessions, follow-up, cancellation, and human-gated approvals.（✅ 活跃）
+- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) ⭐3 — DeepSeek Harness subagent delegation enhancement（✅ 活跃）
+- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode) ⭐3 — 由 DSH Agent 驱动的 VS Code 聊天窗口：OpenCode 风格独立会话，模型自动路由。（✅ 活跃）
+- [dsh-github-integration](https://github.com/omdsh-dev/dsh-github-integration) ⭐2 — DSH 的 GitHub 集成插件。（✅ 活跃）
+- [dsh-plugin-acn](https://github.com/acnlabs/dsh-plugin-acn) ⭐2 — DeepSeek Harness plugin: join ACN so this agent can discover, message, and collaborate with other agents. Defaults to the China region.（✅ 活跃）
+- [vscode-deepseek-harness](https://github.com/kalynnka/vscode-deepseek-harness) ⭐2 — 非官方：把 dsh 作为 VS Code 原生聊天 Agent 使用。（✅ 活跃）
+- [deepseek-harness-rs](https://github.com/Tokimorphling/deepseek-harness-rs) ⭐1 — DeepSeek Harness 的 Rust 移植。（🧪 实验性）
 - [dsh-chrome](https://github.com/YJSoooooo/dsh-chrome) ⭐1 — Chrome 配置档桥接：通过 CDP 操控已登录的 Chrome。（✅ 活跃）
-- [vscode-deepseek-harness](https://github.com/kalynnka/vscode-deepseek-harness) ⭐1 — 非官方：把 dsh 作为 VS Code 原生聊天 Agent 使用。（✅ 活跃）
-- [deepseek-harness-rs](https://github.com/Tokimorphling/deepseek-harness-rs)  — DeepSeek Harness 的 Rust 移植。（🧪 实验性）
-- [dsh-github-integration](https://github.com/omdsh-dev/dsh-github-integration)  — DSH 的 GitHub 集成插件。（✅ 活跃）
-- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access)  — Web GUI 局域网访问：0.0.0.0 绑定 + 非安全上下文 polyfill。（✅ 活跃）
-- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector)  — 上下文注入增强插件（cordis）。（✅ 活跃）
-- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode)  — 由 DSH Agent 驱动的 VS Code 聊天窗口：OpenCode 风格独立会话，模型自动路由。（✅ 活跃）
+- [dsh-plugin-vision](https://github.com/tdf1995/dsh-plugin-vision)  — Vision for text-only LLMs in DeepSeek Harness (DSH): describe images / OCR / VQA via free Gemini & GLM vision APIs（✅ 活跃）
 - [opendsh](https://github.com/TheChengXi/opendsh)  — 在 VS Code 内打开 DSH Web UI，一键启停。（✅ 活跃）
 - [URL Manager MCP](https://github.com/Piccolo123/url-manager-mcp)  — URL Manager 的 MCP 伴生服务器：21 个工具用于保存/搜索/分类/共享与魔法链接投递。（✅ 活跃）
 
@@ -1148,23 +1338,23 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [hello-dsh](https://github.com/pingfanfan/hello-dsh) | ⭐37 | 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。 | ✅ 活跃 |
+| 1 | [hello-dsh](https://github.com/pingfanfan/hello-dsh) | ⭐48 | 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。 | ✅ 活跃 |
 | 2 | [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) | ⭐16 | DeepSeek Harness 插件开发模板。 | ✅ 活跃 |
 | 3 | [turtle-ui](https://github.com/turtle1999/turtle-ui) | ⭐6 | 官方 UI 插件参考实现。 | ✅ 活跃 |
-| 4 | [dsh-101](https://github.com/bill9109/dsh-101) | ⭐2 | DSH 文档阅读模式。 | ✅ 活跃 |
-| 5 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐2 | 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。 | ✅ 活跃 |
-| 6 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world 风格 DSH 起步插件。 | ✅ 活跃 |
-| 7 | [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) |  | 基于原 turtle-ui 官方仓库创建的插件模板。 | ✅ 活跃 |
+| 4 | [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) | ⭐5 | 基于原 turtle-ui 官方仓库创建的插件模板。 | ✅ 活跃 |
+| 5 | [dsh-101](https://github.com/bill9109/dsh-101) | ⭐3 | DSH 文档阅读模式。 | ✅ 活跃 |
+| 6 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐3 | 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。 | ✅ 活跃 |
+| 7 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world 风格 DSH 起步插件。 | ✅ 活跃 |
 
 #### 完整列表（7）
 
-- [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐37 — 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。（✅ 活跃）
+- [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐48 — 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。（✅ 活跃）
 - [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) ⭐16 — DeepSeek Harness 插件开发模板。（✅ 活跃）
 - [turtle-ui](https://github.com/turtle1999/turtle-ui) ⭐6 — 官方 UI 插件参考实现。（✅ 活跃）
-- [dsh-101](https://github.com/bill9109/dsh-101) ⭐2 — DSH 文档阅读模式。（✅ 活跃）
-- [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐2 — 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。（✅ 活跃）
+- [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) ⭐5 — 基于原 turtle-ui 官方仓库创建的插件模板。（✅ 活跃）
+- [dsh-101](https://github.com/bill9109/dsh-101) ⭐3 — DSH 文档阅读模式。（✅ 活跃）
+- [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐3 — 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。（✅ 活跃）
 - [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello)  — Hello-world 风格 DSH 起步插件。（✅ 活跃）
-- [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template)  — 基于原 turtle-ui 官方仓库创建的插件模板。（✅ 活跃）
 
 ### Tutorials & Learning
 
@@ -1173,30 +1363,31 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) | ⭐465 | 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。 | ✅ 活跃 |
-| 2 | [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) | ⭐167 | 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。 | ✅ 活跃 |
-| 3 | [dshfind](https://github.com/hikariming/dshfind) | ⭐56 | DSH 原理学习、插件市场与最佳实践：从 Cordis 论文逐章精读到插件自动聚合市场。 | ✅ 活跃 |
-| 4 | [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) | ⭐32 | DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） | ✅ 活跃 |
-| 5 | [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) | ⭐17 | DeepSeek Harness 中文详细学习教程。 | ✅ 活跃 |
-| 6 | [dsh-explain](https://github.com/yuezengwu/dsh-explain) | ⭐9 | 本地优先学习模式：跨会话全局学习线程、按来源讲解、ExplainContext、压缩与可诊断设置。 | ✅ 活跃 |
-| 7 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | 不同模式下的 DeepSeek Harness 提示词集。 | ✅ 活跃 |
-| 8 | [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) | ⭐5 | 基于 deepseek-harness 仓库系统化拆解的学习网站：面向想了解 AI Agent 框架如何工作的开发者。 | ✅ 活跃 |
-| 9 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐5 | 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。 | ✅ 活跃 |
-| 10 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | ⭐3 | 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。 | ✅ 活跃 |
+| 1 | [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) | ⭐706 | 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。 | ✅ 活跃 |
+| 2 | [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) | ⭐273 | 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。 | ✅ 活跃 |
+| 3 | [dshfind](https://github.com/hikariming/dshfind) | ⭐80 | DSH 原理学习、插件市场与最佳实践：从 Cordis 论文逐章精读到插件自动聚合市场。 | ✅ 活跃 |
+| 4 | [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) | ⭐43 | DeepSeek Harness 中文详细学习教程。 | ✅ 活跃 |
+| 5 | [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) | ⭐40 | DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目） | ✅ 活跃 |
+| 6 | [dsh-explain](https://github.com/yuezengwu/dsh-explain) | ⭐11 | 本地优先学习模式：跨会话全局学习线程、按来源讲解、ExplainContext、压缩与可诊断设置。 | ✅ 活跃 |
+| 7 | [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) | ⭐7 | 基于 deepseek-harness 仓库系统化拆解的学习网站：面向想了解 AI Agent 框架如何工作的开发者。 | ✅ 活跃 |
+| 8 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | 不同模式下的 DeepSeek Harness 提示词集。 | ✅ 活跃 |
+| 9 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐6 | 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。 | ✅ 活跃 |
+| 10 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | ⭐4 | 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。 | ✅ 活跃 |
 
-#### 完整列表（11）
+#### 完整列表（12）
 
-- [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐465 — 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。（✅ 活跃）
-- [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐167 — 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。（✅ 活跃）
-- [dshfind](https://github.com/hikariming/dshfind) ⭐56 — DSH 原理学习、插件市场与最佳实践：从 Cordis 论文逐章精读到插件自动聚合市场。（✅ 活跃）
-- [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) ⭐32 — DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目）（✅ 活跃）
-- [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) ⭐17 — DeepSeek Harness 中文详细学习教程。（✅ 活跃）
-- [dsh-explain](https://github.com/yuezengwu/dsh-explain) ⭐9 — 本地优先学习模式：跨会话全局学习线程、按来源讲解、ExplainContext、压缩与可诊断设置。（✅ 活跃）
+- [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐706 — 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。（✅ 活跃）
+- [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐273 — 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。（✅ 活跃）
+- [dshfind](https://github.com/hikariming/dshfind) ⭐80 — DSH 原理学习、插件市场与最佳实践：从 Cordis 论文逐章精读到插件自动聚合市场。（✅ 活跃）
+- [deepseek-harness-tutorial](https://github.com/ht426/deepseek-harness-tutorial) ⭐43 — DeepSeek Harness 中文详细学习教程。（✅ 活跃）
+- [dsh-harness-tutorial](https://github.com/yanhua1010/dsh-harness-tutorial) ⭐40 — DeepSeek Harness Agent 的原理与实现：从零到一实现一个 AI Agent —— 一切皆插件的中文教程（VitePress 站点 + 8 个 Demo + mini-harness 教学项目）（✅ 活跃）
+- [dsh-explain](https://github.com/yuezengwu/dsh-explain) ⭐11 — 本地优先学习模式：跨会话全局学习线程、按来源讲解、ExplainContext、压缩与可诊断设置。（✅ 活跃）
+- [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) ⭐7 — 基于 deepseek-harness 仓库系统化拆解的学习网站：面向想了解 AI Agent 框架如何工作的开发者。（✅ 活跃）
 - [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) ⭐6 — 不同模式下的 DeepSeek Harness 提示词集。（✅ 活跃）
-- [deepseek-harness-learning](https://github.com/Lucky2024-pllove/deepseek-harness-learning) ⭐5 — 基于 deepseek-harness 仓库系统化拆解的学习网站：面向想了解 AI Agent 框架如何工作的开发者。（✅ 活跃）
-- [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) ⭐5 — 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。（✅ 活跃）
-- [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐3 — 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。（✅ 活跃）
-- [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐1 — 检查 DeepSeek 工具循环、reasoning_content、严格 schema 与捕获的 SSE，也可作为 DSH 插件。（✅ 活跃）
+- [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) ⭐6 — 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。（✅ 活跃）
+- [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐4 — 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。（✅ 活跃）
+- [gitlearnos](https://github.com/Guojiz/gitlearnos) ⭐3 — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory.（✅ 活跃）
+- [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐2 — 检查 DeepSeek 工具循环、reasoning_content、严格 schema 与捕获的 SSE，也可作为 DSH 插件。（✅ 活跃）
 
 ### Awesome Lists & Registries
 
@@ -1205,44 +1396,53 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | ⭐751 | 大型 DSH 插件精选目录（双语）。 | ✅ 活跃 |
-| 2 | [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) | ⭐751 | 雷达索引仓库：自动扫描发现的所有 dsh 插件候选，带证据驱动的兼容性矩阵。 | ✅ 活跃 |
-| 3 | [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) | ⭐360 | DSH 生态目录：来自 dsh-external/hub 与公开 dsh-plugin 主题的插件、工具与基础设施精选。 | ✅ 活跃 |
-| 4 | [notes (zhaoolee)](https://github.com/zhaoolee/notes) | ⭐138 | 开源版锤子便签：一键 Docker 私有化部署、skill 调用、dsh plugin 支持、一键生成公众号格式。 | ✅ 活跃 |
-| 5 | [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) | ⭐86 | 用 30 秒找到适合你的 DSH 插件：不仅列仓库，还说明插件解决什么问题、适合谁、从哪开始。 | ✅ 活跃 |
-| 6 | [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) | ⭐47 | DeepSeek Harness 插件精选列表。 | ✅ 活跃 |
-| 7 | [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | ⭐47 | 精心整理的 DSH 插件、扩展、工具与开发资源列表。 | ✅ 活跃 |
-| 8 | [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | ⭐43 | 面向 DSH 的插件生态：700+ 插件，只通过扩展接缝注册，不修改 agent-loop 骨架。 | ✅ 活跃 |
-| 9 | [plugin-registry](https://github.com/vlln/plugin-registry) | ⭐31 | DSH 插件生态基建：薄控制台管理官方 repository 插件（0 patch）+ make-dsh-plugin 技能。 | ✅ 活跃 |
-| 10 | [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) | ⭐30 | DSH 插件、技能、MCP 服务器、patch/profile 层、编排器与 UI 精选列表。 | ✅ 活跃 |
+| 1 | [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent) | ⭐5,853 | 官方精选：将 DeepSeek 模型集成到主流 Agent/编码助手工具的指南（AstrBot、Cherry Studio、Claude Code、Codex、DeepSeek-TUI、Reasonix 等）。 | ✅ 活跃 |
+| 2 | [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | ⭐2,516 | 大型 DSH 插件精选目录（双语）。 | ✅ 活跃 |
+| 3 | [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) | ⭐942 | 雷达索引仓库：自动扫描发现的所有 dsh 插件候选，带证据驱动的兼容性矩阵。 | ✅ 活跃 |
+| 4 | [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) | ⭐465 | DSH 生态目录：来自 dsh-external/hub 与公开 dsh-plugin 主题的插件、工具与基础设施精选。 | ✅ 活跃 |
+| 5 | [notes (zhaoolee)](https://github.com/zhaoolee/notes) | ⭐142 | 开源版锤子便签：一键 Docker 私有化部署、skill 调用、dsh plugin 支持、一键生成公众号格式。 | ✅ 活跃 |
+| 6 | [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) | ⭐139 | 用 30 秒找到适合你的 DSH 插件：不仅列仓库，还说明插件解决什么问题、适合谁、从哪开始。 | ✅ 活跃 |
+| 7 | [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) | ⭐62 | 终极指南：快速入门、资源推荐、精选插件与实用工具。 | ✅ 活跃 |
+| 8 | [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | ⭐62 | 精心整理的 DSH 插件、扩展、工具与开发资源列表。 | ✅ 活跃 |
+| 9 | [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) | ⭐61 | DeepSeek Harness 插件精选列表。 | ✅ 活跃 |
+| 10 | [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) | ⭐47 | DSH 插件、技能、MCP 服务器、patch/profile 层、编排器与 UI 精选列表。 | ✅ 活跃 |
 
-#### 完整列表（25）
+#### 完整列表（34）
 
-- [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐751 — 大型 DSH 插件精选目录（双语）。（✅ 活跃）
-- [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐751 — 雷达索引仓库：自动扫描发现的所有 dsh 插件候选，带证据驱动的兼容性矩阵。（✅ 活跃）
-- [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) ⭐360 — DSH 生态目录：来自 dsh-external/hub 与公开 dsh-plugin 主题的插件、工具与基础设施精选。（✅ 活跃）
-- [notes (zhaoolee)](https://github.com/zhaoolee/notes) ⭐138 — 开源版锤子便签：一键 Docker 私有化部署、skill 调用、dsh plugin 支持、一键生成公众号格式。（✅ 活跃）
-- [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) ⭐86 — 用 30 秒找到适合你的 DSH 插件：不仅列仓库，还说明插件解决什么问题、适合谁、从哪开始。（✅ 活跃）
-- [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) ⭐47 — DeepSeek Harness 插件精选列表。（✅ 活跃）
-- [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) ⭐47 — 精心整理的 DSH 插件、扩展、工具与开发资源列表。（✅ 活跃）
-- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) ⭐43 — 面向 DSH 的插件生态：700+ 插件，只通过扩展接缝注册，不修改 agent-loop 骨架。（✅ 活跃）
-- [plugin-registry](https://github.com/vlln/plugin-registry) ⭐31 — DSH 插件生态基建：薄控制台管理官方 repository 插件（0 patch）+ make-dsh-plugin 技能。（✅ 活跃）
-- [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) ⭐30 — DSH 插件、技能、MCP 服务器、patch/profile 层、编排器与 UI 精选列表。（✅ 活跃）
-- [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) ⭐29 — 终极指南：快速入门、资源推荐、精选插件与实用工具。（✅ 活跃）
-- [oh-my-dsh](https://github.com/like-study1/Oh-My-DSH) ⭐21 — 🐳 DeepSeek Harness 插件聚合社区 — 自动同步 dsh-plugin 生态 · 精选目录 · 每 8 小时自动维护 | Oh-My-DSH: a community-maintained catalog of DeepSeek Harness plugins, auto-synced from the dsh-plugin topic（✅ 活跃）
-- [deepseek-plugin-store](https://github.com/Ericwong5021/deepseek-plugin-store) ⭐12 — DeepSeek Harness 独立社区插件商店：发现、安装并提交经过验证的插件、工具与扩展。 | Independent community plugin directory.（✅ 活跃）
-- [dsh-suite](https://github.com/whyihaveyou/dsh-suite) ⭐11 — 活体插件目录（785+ 插件，每小时刷新）：每日兼容性 CI、双语目录站与应用内插件商店。（✅ 活跃）
-- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) ⭐9 — 社区整活插件导航（皮肤、桌宠、小游戏），双语。（✅ 活跃）
-- [awesome-dsh-plugins (white0dew)](https://github.com/white0dew/awesome-dsh-plugins) ⭐7 — DSH 插件公开目录，含安装命令。（✅ 活跃）
-- [awesome-deepseek-harness (jiji262)](https://github.com/jiji262/awesome-deepseek-harness) ⭐6 — DeepSeek Harness 资源精选。（✅ 活跃）
-- [awesome-dsh-plugin (billLiao)](https://github.com/billLiao/awesome-dsh-plugin) ⭐5 — DeepSeek Harness 插件精选列表。（✅ 活跃）
-- [awesome-dsh-plugins (kejixiaoliang)](https://github.com/kejixiaoliang/awesome-dsh-plugins) ⭐5 — DSH 插件精选目录：14 类 280+ 个社区插件，覆盖 MCP/Skill/TUI/多 Agent/上下文记忆/UI 皮肤。（✅ 活跃）
-- [dsh-plugin-marketplace](https://github.com/YELEBAI/dsh-plugin-marketplace) ⭐4 — Verified plugin marketplace and autonomous registry for DeepSeek Harness（✅ 活跃）
-- [dsh-plugins](https://github.com/HackSing/dsh-plugins) ⭐4 — A bilingual, continuously maintained directory of plugins for DeepSeek Harness (DSH).（✅ 活跃）
-- [zat-dsh-engine](https://github.com/mishibeikejie/zat-dsh-engine) ⭐4 — Visual plugin marketplace for DeepSeek Harness — browse, search and install community plugins（✅ 活跃）
-- [dsh-market](https://github.com/2BingLing/dsh-market) ⭐3 — DeepSeek Harness 插件市场 · 持续收录 500+ DSH 插件：中文搜索 + 实用五维评分 + 一键安装。Web 版与 DSH 侧边栏插件双形态。Plugin marketplace for DeepSeek Harness: 500+ plugins, Chinese search, 5-dim scoring, one-click install.（✅ 活跃）
+- [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent) ⭐5,853 — 官方精选：将 DeepSeek 模型集成到主流 Agent/编码助手工具的指南（AstrBot、Cherry Studio、Claude Code、Codex、DeepSeek-TUI、Reasonix 等）。（✅ 活跃）
+- [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐2,516 — 大型 DSH 插件精选目录（双语）。（✅ 活跃）
+- [awesome-dsh-plugins (Radar)](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐942 — 雷达索引仓库：自动扫描发现的所有 dsh 插件候选，带证据驱动的兼容性矩阵。（✅ 活跃）
+- [awesome-deepseek-harness (0xsline)](https://github.com/0xsline/awesome-deepseek-harness) ⭐465 — DSH 生态目录：来自 dsh-external/hub 与公开 dsh-plugin 主题的插件、工具与基础设施精选。（✅ 活跃）
+- [notes (zhaoolee)](https://github.com/zhaoolee/notes) ⭐142 — 开源版锤子便签：一键 Docker 私有化部署、skill 调用、dsh plugin 支持、一键生成公众号格式。（✅ 活跃）
+- [awesome-dsh-plugin (bruc3van)](https://github.com/bruc3van/awesome-dsh-plugin) ⭐139 — 用 30 秒找到适合你的 DSH 插件：不仅列仓库，还说明插件解决什么问题、适合谁、从哪开始。（✅ 活跃）
+- [awesome-deepseek-harness (libukai)](https://github.com/libukai/awesome-deepseek-harness) ⭐62 — 终极指南：快速入门、资源推荐、精选插件与实用工具。（✅ 活跃）
+- [awesome-DSH-plugin (Alex-Yanggg)](https://github.com/Alex-Yanggg/awesome-DSH-plugin) ⭐62 — 精心整理的 DSH 插件、扩展、工具与开发资源列表。（✅ 活跃）
+- [Awesome-DeepSeek-Harness-Plugins](https://github.com/Zhiyuan-Fan/Awesome-DeepSeek-Harness-Plugins) ⭐61 — DeepSeek Harness 插件精选列表。（✅ 活跃）
+- [awesome-deepseek-harness (Dominic789654)](https://github.com/Dominic789654/awesome-deepseek-harness) ⭐47 — DSH 插件、技能、MCP 服务器、patch/profile 层、编排器与 UI 精选列表。（✅ 活跃）
+- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) ⭐47 — 面向 DSH 的插件生态：700+ 插件，只通过扩展接缝注册，不修改 agent-loop 骨架。（✅ 活跃）
+- [plugin-registry](https://github.com/vlln/plugin-registry) ⭐40 — DSH 插件生态基建：薄控制台管理官方 repository 插件（0 patch）+ make-dsh-plugin 技能。（✅ 活跃）
+- [oh-my-dsh](https://github.com/like-study1/Oh-My-DSH) ⭐31 — 🐳 DeepSeek Harness 插件聚合社区 — 自动同步 dsh-plugin 生态 · 精选目录 · 每 8 小时自动维护 | Oh-My-DSH: a community-maintained catalog of DeepSeek Harness plugins, auto-synced from the dsh-plugin topic（✅ 活跃）
+- [zat-dsh-engine](https://github.com/mishibeikejie/zat-dsh-engine) ⭐29 — Visual plugin marketplace for DeepSeek Harness — browse, search and install community plugins（✅ 活跃）
+- [awesome-dsh-plugin](https://github.com/beancookie/awesome-dsh-plugin) ⭐25 — Awesome DeepSeek Harness (DSH) Plugin（✅ 活跃）
+- [dsh-suite](https://github.com/whyihaveyou/dsh-suite) ⭐23 — 活体插件目录（785+ 插件，每小时刷新）：每日兼容性 CI、双语目录站与应用内插件商店。（✅ 活跃）
+- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) ⭐20 — 社区整活插件导航（皮肤、桌宠、小游戏），双语。（✅ 活跃）
+- [dsh-plugin-marketplace](https://github.com/YELEBAI/dsh-plugin-marketplace) ⭐17 — Verified plugin marketplace and autonomous registry for DeepSeek Harness（✅ 活跃）
+- [dsh-plugin-hub](https://github.com/cclank/dsh-plugin-hub) ⭐15 — DeepSeek Harness community plugin registry with evidence-based screening（✅ 活跃）
+- [deepseek-plugin-store](https://github.com/Ericwong5021/deepseek-plugin-store) ⭐13 — DeepSeek Harness 独立社区插件商店：发现、安装并提交经过验证的插件、工具与扩展。 | Independent community plugin directory.（✅ 活跃）
+- [dsh-plugin-marketplace](https://github.com/AwesomeHou/dsh-plugin-marketplace) ⭐13 — Plugin marketplace for DeepSeek Harness — live-syncs the GitHub dsh-plugin topic (1800+ repos) into a searchable, paginated settings tab with one-click install and agent tools (market_search / market_install).（✅ 活跃）
+- [awesome-dsh-plugins (kejixiaoliang)](https://github.com/kejixiaoliang/awesome-dsh-plugins) ⭐12 — DSH 插件精选目录：14 类 280+ 个社区插件，覆盖 MCP/Skill/TUI/多 Agent/上下文记忆/UI 皮肤。（✅ 活跃）
+- [dsh-market](https://github.com/2BingLing/dsh-market) ⭐11 — DeepSeek Harness 插件市场 · 持续收录 500+ DSH 插件：中文搜索 + 实用五维评分 + 一键安装。Web 版与 DSH 侧边栏插件双形态。Plugin marketplace for DeepSeek Harness: 500+ plugins, Chinese search, 5-dim scoring, one-click install.（✅ 活跃）
+- [awesome-deepseek-harness (jiji262)](https://github.com/jiji262/awesome-deepseek-harness) ⭐10 — DeepSeek Harness 资源精选。（✅ 活跃）
+- [awesome-deepseek-harness-plugins](https://github.com/imsai-sh/awesome-deepseek-harness-plugins) ⭐9 — Curated community plugin directory and live marketplace for DeepSeek Harness.（✅ 活跃）
+- [awesome-dsh-plugins (white0dew)](https://github.com/white0dew/awesome-dsh-plugins) ⭐9 — DSH 插件公开目录，含安装命令。（✅ 活跃）
+- [awesome-dsh-plugin (billLiao)](https://github.com/billLiao/awesome-dsh-plugin) ⭐7 — DeepSeek Harness 插件精选列表。（✅ 活跃）
+- [dsh-plugins](https://github.com/HackSing/dsh-plugins) ⭐5 — A bilingual, continuously maintained directory of plugins for DeepSeek Harness (DSH).（✅ 活跃）
+- [awesome-deepseek-harness-plugins](https://github.com/walkinglabs/awesome-deepseek-harness-plugins) ⭐4 — A curated, bilingual list of verified plugins, tools, design workflows, and learning resources for DeepSeek Harness (DSH).（✅ 活跃）
+- [dsh-marketplace](https://github.com/ouyangyipeng/dsh-marketplace) ⭐3 — A safe, live plugin marketplace for DeepSeek Harness（✅ 活跃）
+- [dsh-plugin-market](https://github.com/chnjames/dsh-plugin-market) ⭐3 — DSH 插件市场 — DeepSeek Harness 设置内一键安装社区插件，并提供公开目录站（浏览 / 复制安装命令）（✅ 活跃）
+- [dsh-plugin-market](https://github.com/TheYoungChen/dsh-plugin-market) ⭐3 — DeepSeek Harness plugin market - browse, search & install dsh-plugin topic plugins (dsh 插件市场：浏览/搜索/安装插件)（✅ 活跃）
 - [dsh-plugins](https://github.com/lwmxiaobei/dsh-plugins) ⭐3 — DeepSeek Harness 社区插件目录，自动汇总并基础校验 GitHub 插件，支持搜索、筛选、双语详情与最新版本安装命令复制。Community directory for DeepSeek Harness plugins with automated discovery, basic validation, search, filters, bilingual details, and latest version install commands.（✅ 活跃）
-- [awesome-deepseek-agent (official)](https://github.com/deepseek-ai/awesome-deepseek-agent)  — 官方精选：将 DeepSeek 模型集成到主流 Agent/编码助手工具的指南（AstrBot、Cherry Studio、Claude Code、Codex、DeepSeek-TUI、Reasonix 等）。（✅ 活跃）
+- [sandbase-skills](https://github.com/sandbaseai/sandbase-skills) ⭐3 — 88 installable open-source Agent Skills for research, social intelligence, marketing, and business workflows—compatible with Codex, Claude Code, Cursor, Gemini CLI, and DeepSeek Harness.（✅ 活跃）
 
 ### Related Agent Harnesses
 
@@ -1251,24 +1451,24 @@ awesome-deepseek-harness/
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
-| 1 | [DeerFlow](https://github.com/bytedance/deer-flow) | ⭐80,001 | 字节跳动开源的长时间跨度 SuperAgent harness：技能、记忆、沙箱、子代理、工具与消息网关。 | ✅ 活跃 |
-| 2 | [Cordis](https://github.com/cordiverse/cordis) | ⭐3,182 | 时空可组合性元框架——DeepSeek Harness 底层的插件运行时。 | ✅ 活跃 |
-| 3 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐573 | 开源 CMA 兼容的任意模型 Agent 运行时：MCP 工具、沙箱会话、审计与回放。 | ✅ 活跃 |
-| 4 | [mnemon](https://github.com/mnemon-dev/mnemon) | ⭐430 | LLM 监督的 Agent 持久记忆：图召回与跨会话知识，单二进制。 | ✅ 活跃 |
-| 5 | [claude-paper](https://github.com/alaliqing/claude-paper) | ⭐294 | 跨 Agent 论文研究工具包：快速摘要与深度精读，支持 Claude Code/Codex/OpenCode/DSH。 | ✅ 活跃 |
-| 6 | [Axern](https://github.com/cofy-x/axern) | ⭐272 | 面向 AI Agent 的开源沙箱：不可信代码执行与持久服务。 | ✅ 活跃 |
-| 7 | [open-managed-agents](https://github.com/openma-ai/open-managed-agents) | ⭐235 | 开源 Claude Managed Agents API 实现与自托管 Claude Tag 风格 Agent 运行时。 | ✅ 活跃 |
+| 1 | [DeerFlow](https://github.com/bytedance/deer-flow) | ⭐80,038 | 字节跳动开源的长时间跨度 SuperAgent harness：技能、记忆、沙箱、子代理、工具与消息网关。 | ✅ 活跃 |
+| 2 | [Cordis](https://github.com/cordiverse/cordis) | ⭐3,780 | 时空可组合性元框架——DeepSeek Harness 底层的插件运行时。 | ✅ 活跃 |
+| 3 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | ⭐586 | 开源 CMA 兼容的任意模型 Agent 运行时：MCP 工具、沙箱会话、审计与回放。 | ✅ 活跃 |
+| 4 | [mnemon](https://github.com/mnemon-dev/mnemon) | ⭐449 | LLM 监督的 Agent 持久记忆：图召回与跨会话知识，单二进制。 | ✅ 活跃 |
+| 5 | [claude-paper](https://github.com/alaliqing/claude-paper) | ⭐301 | 跨 Agent 论文研究工具包：快速摘要与深度精读，支持 Claude Code/Codex/OpenCode/DSH。 | ✅ 活跃 |
+| 6 | [open-managed-agents](https://github.com/openma-ai/open-managed-agents) | ⭐236 | 开源 Claude Managed Agents API 实现与自托管 Claude Tag 风格 Agent 运行时。 | ✅ 活跃 |
+| 7 | [Axern](https://github.com/cofy-x/axern) | ⭐167 | 面向 AI Agent 的开源沙箱：不可信代码执行与持久服务。 | ✅ 活跃 |
 | 8 | [deepseek-auto-evolving-harness](https://github.com/liuchen6667/deepseek-auto-evolving-harness) | ⭐28 | 自进化 LLM Agent Harness：通过 Claude Code 与 self_evolution.md 指南进行基准驱动进化。 | ✅ 活跃 |
 
 #### 完整列表（8）
 
-- [DeerFlow](https://github.com/bytedance/deer-flow) ⭐80,001 — 字节跳动开源的长时间跨度 SuperAgent harness：技能、记忆、沙箱、子代理、工具与消息网关。（✅ 活跃）
-- [Cordis](https://github.com/cordiverse/cordis) ⭐3,182 — 时空可组合性元框架——DeepSeek Harness 底层的插件运行时。（✅ 活跃）
-- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) ⭐573 — 开源 CMA 兼容的任意模型 Agent 运行时：MCP 工具、沙箱会话、审计与回放。（✅ 活跃）
-- [mnemon](https://github.com/mnemon-dev/mnemon) ⭐430 — LLM 监督的 Agent 持久记忆：图召回与跨会话知识，单二进制。（✅ 活跃）
-- [claude-paper](https://github.com/alaliqing/claude-paper) ⭐294 — 跨 Agent 论文研究工具包：快速摘要与深度精读，支持 Claude Code/Codex/OpenCode/DSH。（✅ 活跃）
-- [Axern](https://github.com/cofy-x/axern) ⭐272 — 面向 AI Agent 的开源沙箱：不可信代码执行与持久服务。（✅ 活跃）
-- [open-managed-agents](https://github.com/openma-ai/open-managed-agents) ⭐235 — 开源 Claude Managed Agents API 实现与自托管 Claude Tag 风格 Agent 运行时。（✅ 活跃）
+- [DeerFlow](https://github.com/bytedance/deer-flow) ⭐80,038 — 字节跳动开源的长时间跨度 SuperAgent harness：技能、记忆、沙箱、子代理、工具与消息网关。（✅ 活跃）
+- [Cordis](https://github.com/cordiverse/cordis) ⭐3,780 — 时空可组合性元框架——DeepSeek Harness 底层的插件运行时。（✅ 活跃）
+- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) ⭐586 — 开源 CMA 兼容的任意模型 Agent 运行时：MCP 工具、沙箱会话、审计与回放。（✅ 活跃）
+- [mnemon](https://github.com/mnemon-dev/mnemon) ⭐449 — LLM 监督的 Agent 持久记忆：图召回与跨会话知识，单二进制。（✅ 活跃）
+- [claude-paper](https://github.com/alaliqing/claude-paper) ⭐301 — 跨 Agent 论文研究工具包：快速摘要与深度精读，支持 Claude Code/Codex/OpenCode/DSH。（✅ 活跃）
+- [open-managed-agents](https://github.com/openma-ai/open-managed-agents) ⭐236 — 开源 Claude Managed Agents API 实现与自托管 Claude Tag 风格 Agent 运行时。（✅ 活跃）
+- [Axern](https://github.com/cofy-x/axern) ⭐167 — 面向 AI Agent 的开源沙箱：不可信代码执行与持久服务。（✅ 活跃）
 - [deepseek-auto-evolving-harness](https://github.com/liuchen6667/deepseek-auto-evolving-harness) ⭐28 — 自进化 LLM Agent Harness：通过 Claude Code 与 self_evolution.md 指南进行基准驱动进化。（✅ 活跃）
 <!-- AUTO:resources:END -->` 之间的资源表格由 `scripts/generate-readme.py` 产出。请编辑 JSON，不要手改表格。
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -3663,5 +3663,22 @@
     "stars": 0,
     "_updated": "2026-08-14",
     "subcategory": "sidebar-panels"
+  },
+  {
+    "id": "dsh-smooth-stream",
+    "name": "dsh-smooth-stream",
+    "type": "plugin",
+    "category": "ui",
+    "repository": "https://github.com/Laplace-bit/dsh-smooth-stream",
+    "description": "Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and respects prefers-reduced-motion.",
+    "description_zh": "丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 prefers-reduced-motion。",
+    "capabilities": [
+      "ui"
+    ],
+    "status": "active",
+    "verified": true,
+    "stars": 0,
+    "_updated": "2026-08-16",
+    "subcategory": "generative-ui"
   }
 ]

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "Top 10 and full list of 193 curated plugins for DeepSeek Harness (dsh)."
+description: "Top 10 and full list of 194 curated plugins for DeepSeek Harness (dsh)."
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,10 +30,10 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [dsh-ads](resources/dsh-ads.md) | ⭐396 | Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. | ✅ active |
 | 10 | [dsh-market](resources/dsh-market.md) | ⭐218 | Visual plugin market inside DeepSeek Harness: browse, search and one-click install. | ✅ active |
 
-## Complete list (193)
+## Complete list (194)
 
 
-**UI & experience (46)**
+**UI & experience (47)**
 
 *🎨 Skins & themes (9)*
 
@@ -61,6 +61,18 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-ultra-ui](resources/dsh-ultra-ui.md) | ⭐3 | Ultra UI plugin (cordis). | ✅ active |
 | [dsh-plugin-description](resources/dsh-plugin-description.md) | ⭐2 | mount one row in the composition and every plugin card on the Web Settings plugin list page gets a bilingual (zh/en) description; it also publishes the pluginDescriptions service so other plugins can register their own descriptions. | ✅ active |
 | [dsh-view-modes](resources/dsh-view-modes.md) | ⭐1 | Output modes with Verbose, Normal and Summary views plus semantic grouping for tool calls and thinking. | ✅ active |
+*💡 Generative UI (8)*
+
+| Project | Stars | Description | Status |
+|---|---|---|---|
+| [DSH Better Sidebar](resources/dsh-better-sidebar.md) | ⭐1,065 | Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. | ✅ active |
+| [dsh-visualize](resources/dsh-visualize.md) | ⭐100 | Interactive HTML UI rendered directly in conversation with streaming preview and sandbox rendering. | ✅ active |
+| [dsh-genui](resources/dsh-genui.md) | ⭐99 | Generative UI inside conversations: layouts, charts, forms, quizzes, Mermaid and interactive events rendered inline. | ✅ active |
+| [deepseek-harness-skin](resources/deepseek-harness-skin.md) | ⭐34 | Skin system with 21 built-in themes plus one-image custom skin generation, contrast-validated at build time. | ✅ active |
+| [dsh-web-review](resources/dsh-web-review.md) | ⭐15 | DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。 | ✅ active |
+| [dsh-plugin-aigc-canvas](resources/dsh-plugin-aigc-canvas.md) | ⭐6 | provider-agnostic AIGC HTTP 桥 + 无限画布 + ffmpeg 后处理，13 个工具含画布连边/reroll/媒体编辑 | Provider-agnostic AIGC HTTP bridge + infinite canvas + ffmpeg post-processing; 13 tools incl. canvas linking/reroll/media-edit | ✅ active |
+| [dsh-suggested-replies](resources/dsh-suggested-replies.md) | ⭐3 | Predicted next-message candidates above the DSH Web composer, one click to fill the draft. | ✅ active |
+| [dsh-smooth-stream](resources/dsh-smooth-stream.md) | – | Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and respects prefers-reduced-motion. | ✅ active |
 *🖥️ Sidebars & panels (8)*
 
 | Project | Stars | Description | Status |
@@ -73,17 +85,6 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-workspace-search](resources/dsh-workspace-search.md) | ⭐4 | VS Code-style workspace keyword search: a Search tab for the Better Sidebar ecosystem. | ✅ active |
 | [dsh-turn-index](resources/dsh-turn-index.md) | ⭐1 | Turn-index sidebar: one entry per user turn, click to jump with scroll-spy highlighting. | ✅ active |
 | [dsh-plugin-cost](resources/dsh-plugin-cost.md) | – | Session cost estimate in the DSH Web composer dock (tokenUsage × configurable price table, one-click official-price refresh). | ✅ active |
-*💡 Generative UI (7)*
-
-| Project | Stars | Description | Status |
-|---|---|---|---|
-| [DSH Better Sidebar](resources/dsh-better-sidebar.md) | ⭐1,065 | Workbench-style sidebar: file viewer/editor, terminal, Git, subagents and plugin-extensible tabs. | ✅ active |
-| [dsh-visualize](resources/dsh-visualize.md) | ⭐100 | Interactive HTML UI rendered directly in conversation with streaming preview and sandbox rendering. | ✅ active |
-| [dsh-genui](resources/dsh-genui.md) | ⭐99 | Generative UI inside conversations: layouts, charts, forms, quizzes, Mermaid and interactive events rendered inline. | ✅ active |
-| [deepseek-harness-skin](resources/deepseek-harness-skin.md) | ⭐34 | Skin system with 21 built-in themes plus one-image custom skin generation, contrast-validated at build time. | ✅ active |
-| [dsh-web-review](resources/dsh-web-review.md) | ⭐15 | DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。 | ✅ active |
-| [dsh-plugin-aigc-canvas](resources/dsh-plugin-aigc-canvas.md) | ⭐6 | provider-agnostic AIGC HTTP 桥 + 无限画布 + ffmpeg 后处理，13 个工具含画布连边/reroll/媒体编辑 | Provider-agnostic AIGC HTTP bridge + infinite canvas + ffmpeg post-processing; 13 tools incl. canvas linking/reroll/media-edit | ✅ active |
-| [dsh-suggested-replies](resources/dsh-suggested-replies.md) | ⭐3 | Predicted next-message candidates above the DSH Web composer, one click to fill the draft. | ✅ active |
 *🐋 Desktop pets (5)*
 
 | Project | Stars | Description | Status |

--- a/docs/en/resources/dsh-smooth-stream.md
+++ b/docs/en/resources/dsh-smooth-stream.md
@@ -1,0 +1,25 @@
+---
+title: "dsh-smooth-stream"
+description: "Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and respects prefers-reduced-motion."
+keywords: "dsh-smooth-stream, ui, plugin, deepseek harness, dsh"
+---
+# dsh-smooth-stream
+
+> ⭐ 0 · ✅ active · plugin
+
+## One-liner
+
+Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and respects prefers-reduced-motion.
+
+## About
+
+Silky streaming reveal for the Web UI: text appears at the model's arrival rate, new lines glide in, no flicker; follow stays with the user and respects prefers-reduced-motion.
+
+## Author
+**[Laplace-bit](https://github.com/Laplace-bit)**
+
+## Links
+
+- [GitHub Repository](https://github.com/Laplace-bit/dsh-smooth-stream)
+- [Full README](https://github.com/Laplace-bit/dsh-smooth-stream#readme)
+- [Back to the Plugins list](../plugins.md)

--- a/docs/zh/plugins.md
+++ b/docs/zh/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（193 条）。"
+description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（194 条）。"
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,10 +30,10 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [dsh-ads](resources/dsh-ads.md) | ⭐396 | 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。 | ✅ 活跃 |
 | 10 | [dsh-market](resources/dsh-market.md) | ⭐218 | DSH 内置可视化插件市场：浏览、搜索、一键安装。 | ✅ 活跃 |
 
-## 完整列表（193）
+## 完整列表（194）
 
 
-**界面与体验（46）**
+**界面与体验（47）**
 
 *🎨 皮肤与主题（9）*
 
@@ -61,6 +61,18 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-ultra-ui](resources/dsh-ultra-ui.md) | ⭐3 | Ultra UI plugin (cordis). | ✅ 活跃 |
 | [dsh-plugin-description](resources/dsh-plugin-description.md) | ⭐2 | mount one row in the composition and every plugin card on the Web Settings plugin list page gets a bilingual (zh/en) description; it also publishes the pluginDescriptions service so other plugins can register their own descriptions. | ✅ 活跃 |
 | [dsh-view-modes](resources/dsh-view-modes.md) | ⭐1 | Verbose/Normal/Summary 三种输出模式，工具调用与思考语义分组。 | ✅ 活跃 |
+*💡 生成式界面（8）*
+
+| 项目 | 星数 | 说明 | 状态 |
+|---|---|---|---|
+| [DSH Better Sidebar](resources/dsh-better-sidebar.md) | ⭐1,065 | 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。 | ✅ 活跃 |
+| [dsh-visualize](resources/dsh-visualize.md) | ⭐100 | 对话内交互式 HTML UI：流式预览与沙箱渲染。 | ✅ 活跃 |
+| [dsh-genui](resources/dsh-genui.md) | ⭐99 | 对话内生成式 UI：布局、图表、表单、测验、Mermaid 与交互事件内联渲染。 | ✅ 活跃 |
+| [deepseek-harness-skin](resources/deepseek-harness-skin.md) | ⭐34 | 换肤系统：21 套内置皮肤 + 一张图生成整套配色，构建期校验可读性。 | ✅ 活跃 |
+| [dsh-web-review](resources/dsh-web-review.md) | ⭐15 | DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。 | ✅ 活跃 |
+| [dsh-plugin-aigc-canvas](resources/dsh-plugin-aigc-canvas.md) | ⭐6 | provider-agnostic AIGC HTTP 桥 + 无限画布 + ffmpeg 后处理，13 个工具含画布连边/reroll/媒体编辑 | Provider-agnostic AIGC HTTP bridge + infinite canvas + ffmpeg post-processing; 13 tools incl. canvas linking/reroll/media-edit | ✅ 活跃 |
+| [dsh-suggested-replies](resources/dsh-suggested-replies.md) | ⭐3 | DSH Web 预测回复插件：AI 回复后在输入框上方生成可点击填入草稿的候选。 | ✅ 活跃 |
+| [dsh-smooth-stream](resources/dsh-smooth-stream.md) | – | 丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 prefers-reduced-motion。 | ✅ 活跃 |
 *🖥️ 侧边栏与面板（8）*
 
 | 项目 | 星数 | 说明 | 状态 |
@@ -73,17 +85,6 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-workspace-search](resources/dsh-workspace-search.md) | ⭐4 | VS Code 风格工作区关键词搜索：Better Sidebar 生态的搜索 Tab。 | ✅ 活跃 |
 | [dsh-turn-index](resources/dsh-turn-index.md) | ⭐1 | 回合索引侧栏：每个用户回合一条，点击跳转，滚动监听高亮。 | ✅ 活跃 |
 | [dsh-plugin-cost](resources/dsh-plugin-cost.md) | – | Session cost estimate in the DSH Web composer dock (tokenUsage × configurable price table, one-click official-price refresh). | ✅ 活跃 |
-*💡 生成式界面（7）*
-
-| 项目 | 星数 | 说明 | 状态 |
-|---|---|---|---|
-| [DSH Better Sidebar](resources/dsh-better-sidebar.md) | ⭐1,065 | 工作台式侧边栏：文件渲染/编辑、终端、Git、子代理，支持三方扩展 Tab。 | ✅ 活跃 |
-| [dsh-visualize](resources/dsh-visualize.md) | ⭐100 | 对话内交互式 HTML UI：流式预览与沙箱渲染。 | ✅ 活跃 |
-| [dsh-genui](resources/dsh-genui.md) | ⭐99 | 对话内生成式 UI：布局、图表、表单、测验、Mermaid 与交互事件内联渲染。 | ✅ 活跃 |
-| [deepseek-harness-skin](resources/deepseek-harness-skin.md) | ⭐34 | 换肤系统：21 套内置皮肤 + 一张图生成整套配色，构建期校验可读性。 | ✅ 活跃 |
-| [dsh-web-review](resources/dsh-web-review.md) | ⭐15 | DeepSeek Harness Web GUI 的网页预览与元素批注插件，让 AI 根据可视化反馈直接修改前端源码。 | ✅ 活跃 |
-| [dsh-plugin-aigc-canvas](resources/dsh-plugin-aigc-canvas.md) | ⭐6 | provider-agnostic AIGC HTTP 桥 + 无限画布 + ffmpeg 后处理，13 个工具含画布连边/reroll/媒体编辑 | Provider-agnostic AIGC HTTP bridge + infinite canvas + ffmpeg post-processing; 13 tools incl. canvas linking/reroll/media-edit | ✅ 活跃 |
-| [dsh-suggested-replies](resources/dsh-suggested-replies.md) | ⭐3 | DSH Web 预测回复插件：AI 回复后在输入框上方生成可点击填入草稿的候选。 | ✅ 活跃 |
 *🐋 桌面宠物（5）*
 
 | 项目 | 星数 | 说明 | 状态 |

--- a/docs/zh/resources/dsh-smooth-stream.md
+++ b/docs/zh/resources/dsh-smooth-stream.md
@@ -1,0 +1,25 @@
+---
+title: "dsh-smooth-stream"
+description: "丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 prefers-reduced-motion。"
+keywords: "dsh-smooth-stream, ui, plugin, deepseek harness, dsh"
+---
+# dsh-smooth-stream
+
+> ⭐ 0 · ✅ 活跃 · 插件
+
+## 一句话介绍
+
+丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 prefers-reduced-motion。
+
+## 详细介绍
+
+丝滑流式渲染：字跟着模型到达走、换行滑入、不闪，滚动归用户，尊重 prefers-reduced-motion。
+
+## 作者
+**[Laplace-bit](https://github.com/Laplace-bit)**
+
+## 链接
+
+- [GitHub 仓库](https://github.com/Laplace-bit/dsh-smooth-stream)
+- [完整 README](https://github.com/Laplace-bit/dsh-smooth-stream#readme)
+- [返回dsh-smooth-stream所在分类](../plugins.md)


### PR DESCRIPTION
Add [dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) as a `ui` plugin entry in `data/plugins.json`.

- `package.json` declares `dsh.bundle.patch` (`cordis.patch.yml`) and `dsh.client.platform: web`.
- `validate.py`, `generate-readme.py`, and `generate-docs.py` all pass.
- Both READMEs and `docs/` regenerated and committed per CONTRIBUTING.