### PR TITLE
Add Open Sea Skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 | 9 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐496 | Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. | ✅ active |
 | 10 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐447 | Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. | ✅ active |
 
-#### Complete list (198)
+#### Complete list (199)
 
 - [petdex](https://github.com/crafter-station/petdex) ⭐3,848 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. (✅ active)
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐3,249 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
@@ -370,6 +370,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-repo-setup](https://github.com/gongyijie85/dsh-repo-setup)  — Read-only repo bootstrap scanner (repo_setup_scan tool): detects stack/tests/docs/git/db and recommends plugins, MCP servers and hygiene files (claude-code-setup counterpart). (✅ active)
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces. (✅ active)
 - [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech)  — Browser Web Speech API voice input for DSH: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech). (✅ active)
+- [Open Sea Skin](https://github.com/d-dev0101/open-sea-skin)  — Realtime WebGPU ocean skin with controls for waves, daylight, glass opacity and automatic day cycling. (✅ active)
 
 ### Skills
 
@@ -885,7 +886,7 @@ awesome-deepseek-harness/
 | 9 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐496 | Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. | ✅ active |
 | 10 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐447 | Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. | ✅ active |
 
-#### Complete list (198)
+#### Complete list (199)
 
 - [petdex](https://github.com/crafter-station/petdex) ⭐3,848 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more. (✅ active)
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐3,249 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
@@ -1085,6 +1086,7 @@ awesome-deepseek-harness/
 - [dsh-repo-setup](https://github.com/gongyijie85/dsh-repo-setup)  — Read-only repo bootstrap scanner (repo_setup_scan tool): detects stack/tests/docs/git/db and recommends plugins, MCP servers and hygiene files (claude-code-setup counterpart). (✅ active)
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces. (✅ active)
 - [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech)  — Browser Web Speech API voice input for DSH: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech). (✅ active)
+- [Open Sea Skin](https://github.com/d-dev0101/open-sea-skin)  — Realtime WebGPU ocean skin with controls for waves, daylight, glass opacity and automatic day cycling. (✅ active)
 
 ### Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,7 +171,7 @@ dsh web
 | 9 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐496 | 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。 | ✅ 活跃 |
 | 10 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐447 | 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。 | ✅ 活跃 |
 
-#### 完整列表（198）
+#### 完整列表（199）
 
 - [petdex](https://github.com/crafter-station/petdex) ⭐3,848 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more.（✅ 活跃）
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐3,249 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
@@ -371,6 +371,7 @@ dsh web
 - [dsh-repo-setup](https://github.com/gongyijie85/dsh-repo-setup)  — 只读仓库体检引导工具（repo_setup_scan）：识别技术栈/测试/文档/git/数据库线索，给出插件、MCP 与卫生文件的安装建议（claude-code-setup 对应版）。（✅ 活跃）
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces.（✅ 活跃）
 - [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech)  — Browser Web Speech API voice input for DSH: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).（✅ 活跃）
+- [Open Sea Skin](https://github.com/d-dev0101/open-sea-skin)  — 实时 WebGPU 海洋皮肤，可调节波浪、日光、玻璃不透明度和自动昼夜循环。（✅ 活跃）
 
 ### Skills
 
@@ -886,7 +887,7 @@ awesome-deepseek-harness/
 | 9 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | ⭐496 | 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。 | ✅ 活跃 |
 | 10 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | ⭐447 | 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。 | ✅ 活跃 |
 
-#### 完整列表（198）
+#### 完整列表（199）
 
 - [petdex](https://github.com/crafter-station/petdex) ⭐3,848 — A public gallery of animated pets for Codex, Claude Code, DeepSeek Harness, Hermes, OpenCode, Gemini CLI, and more.（✅ 活跃）
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐3,249 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
@@ -1086,6 +1087,7 @@ awesome-deepseek-harness/
 - [dsh-repo-setup](https://github.com/gongyijie85/dsh-repo-setup)  — 只读仓库体检引导工具（repo_setup_scan）：识别技术栈/测试/文档/git/数据库线索，给出插件、MCP 与卫生文件的安装建议（claude-code-setup 对应版）。（✅ 活跃）
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces.（✅ 活跃）
 - [dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech)  — Browser Web Speech API voice input for DSH: zero server, zero keys, zero model downloads (Edge=Azure, Chrome=Google speech).（✅ 活跃）
+- [Open Sea Skin](https://github.com/d-dev0101/open-sea-skin)  — 实时 WebGPU 海洋皮肤，可调节波浪、日光、玻璃不透明度和自动昼夜循环。（✅ 活跃）
 
 ### Skills
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -3829,5 +3829,23 @@
     "_stars_prev": 0,
     "growth": 8,
     "_source_description": "DeepSeek Harness (dsh) plugin: silky streaming reveal, no flicker. dsh 丝滑流式渲染插件。"
+  },
+  {
+    "id": "open-sea-skin",
+    "name": "Open Sea Skin",
+    "type": "plugin",
+    "category": "ui",
+    "subcategory": "skins-themes",
+    "repository": "https://github.com/d-dev0101/open-sea-skin",
+    "description": "Realtime WebGPU ocean skin with controls for waves, daylight, glass opacity and automatic day cycling.",
+    "description_zh": "实时 WebGPU 海洋皮肤，可调节波浪、日光、玻璃不透明度和自动昼夜循环。",
+    "capabilities": [
+      "ui"
+    ],
+    "status": "active",
+    "verified": false,
+    "stars": 0,
+    "install": "dsh plugin --profile web add 'github:d-dev0101/open-sea-skin#v1.2.0'",
+    "license": "MIT"
   }
 ]

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "Top 10 and full list of 198 curated plugins for DeepSeek Harness (dsh)."
+description: "Top 10 and full list of 199 curated plugins for DeepSeek Harness (dsh)."
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,12 +30,12 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [dsh-vision-toolkit](resources/dsh-vision-toolkit.md) | ⭐496 | Vision toolkit for text-only models: intent-aware image Q&A, long-screenshot OCR, UI restoration, grounding and pixel diff. | ✅ active |
 | 10 | [dsh-ads](resources/dsh-ads.md) | ⭐447 | Joke plugin: 2005 Chinese-web-style ad layer with sidebar banners, in-chat feed ads and corner popups. | ✅ active |
 
-## Complete list (198)
+## Complete list (199)
 
 
-**UI & experience (47)**
+**UI & experience (48)**
 
-*🎨 Skins & themes (9)*
+*🎨 Skins & themes (10)*
 
 | Project | Stars | Description | Status |
 |---|---|---|---|
@@ -48,6 +48,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-skin](resources/dsh-skin.md) | ⭐16 | Codex-style skin switcher plus custom translucent wallpaper with opacity/blur controls. | ✅ active |
 | [dsh-deepcel](resources/dsh-deepcel.md) | ⭐9 | Spreadsheet-style skin for DSH, mimicking Excel. | ✅ active |
 | [dsh-ui-appearance](resources/dsh-ui-appearance.md) | ⭐6 | Appearance customization plugin for DeepSeek Harness: theme color palette, background image, opacity/blur, glass effect | ✅ active |
+| [Open Sea Skin](resources/open-sea-skin.md) | – | Realtime WebGPU ocean skin with controls for waves, daylight, glass opacity and automatic day cycling. | ✅ active |
 *Other (9)*
 
 | Project | Stars | Description | Status |

--- a/docs/en/resources/open-sea-skin.md
+++ b/docs/en/resources/open-sea-skin.md
@@ -1,0 +1,25 @@
+---
+title: "Open Sea Skin"
+description: "Realtime WebGPU ocean skin with controls for waves, daylight, glass opacity and automatic day cycling."
+keywords: "Open Sea Skin, ui, plugin, deepseek harness, dsh"
+---
+# Open Sea Skin
+
+> ⭐ 0 · ✅ active · plugin
+
+## One-liner
+
+Realtime WebGPU ocean skin with controls for waves, daylight, glass opacity and automatic day cycling.
+
+## About
+
+Realtime WebGPU ocean skin with controls for waves, daylight, glass opacity and automatic day cycling.
+
+## Author
+**[d-dev0101](https://github.com/d-dev0101)**
+
+## Links
+
+- [GitHub Repository](https://github.com/d-dev0101/open-sea-skin)
+- [Full README](https://github.com/d-dev0101/open-sea-skin#readme)
+- [Back to the Plugins list](../plugins.md)

--- a/docs/zh/plugins.md
+++ b/docs/zh/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（198 条）。"
+description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（199 条）。"
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,12 +30,12 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [dsh-vision-toolkit](resources/dsh-vision-toolkit.md) | ⭐496 | 让纯文本模型更好的视觉工具箱：带意图图片问答、长截图 OCR、UI 还原、grounding、像素 diff。 | ✅ 活跃 |
 | 10 | [dsh-ads](resources/dsh-ads.md) | ⭐447 | 整活插件：2005 中文站点风格广告层，侧栏广告/对话内信息流/角落弹窗。 | ✅ 活跃 |
 
-## 完整列表（198）
+## 完整列表（199）
 
 
-**界面与体验（47）**
+**界面与体验（48）**
 
-*🎨 皮肤与主题（9）*
+*🎨 皮肤与主题（10）*
 
 | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|
@@ -48,6 +48,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-skin](resources/dsh-skin.md) | ⭐16 | Codex 风格皮肤切换器 + 自定义半透明壁纸，支持透明度/模糊控制。 | ✅ 活跃 |
 | [dsh-deepcel](resources/dsh-deepcel.md) | ⭐9 | Excel 风格电子表格皮肤。 | ✅ 活跃 |
 | [dsh-ui-appearance](resources/dsh-ui-appearance.md) | ⭐6 | Appearance customization plugin for DeepSeek Harness: theme color palette, background image, opacity/blur, glass effect | ✅ 活跃 |
+| [Open Sea Skin](resources/open-sea-skin.md) | – | 实时 WebGPU 海洋皮肤，可调节波浪、日光、玻璃不透明度和自动昼夜循环。 | ✅ 活跃 |
 *其他（9）*
 
 | 项目 | 星数 | 说明 | 状态 |

--- a/docs/zh/resources/open-sea-skin.md
+++ b/docs/zh/resources/open-sea-skin.md
@@ -1,0 +1,25 @@
+---
+title: "Open Sea Skin"
+description: "实时 WebGPU 海洋皮肤，可调节波浪、日光、玻璃不透明度和自动昼夜循环。"
+keywords: "Open Sea Skin, ui, plugin, deepseek harness, dsh"
+---
+# Open Sea Skin
+
+> ⭐ 0 · ✅ 活跃 · 插件
+
+## 一句话介绍
+
+实时 WebGPU 海洋皮肤，可调节波浪、日光、玻璃不透明度和自动昼夜循环。
+
+## 详细介绍
+
+实时 WebGPU 海洋皮肤，可调节波浪、日光、玻璃不透明度和自动昼夜循环。
+
+## 作者
+**[d-dev0101](https://github.com/d-dev0101)**
+
+## 链接
+
+- [GitHub 仓库](https://github.com/d-dev0101/open-sea-skin)
+- [完整 README](https://github.com/d-dev0101/open-sea-skin#readme)
+- [返回Open Sea Skin所在分类](../plugins.md)


### PR DESCRIPTION
Adds Open Sea Skin as an active UI / skins-themes plugin with bilingual descriptions, a fixed release install command, and generated bilingual documentation pages.

Repository: https://github.com/d-dev0101/open-sea-skin
Release: https://github.com/d-dev0101/open-sea-skin/releases/tag/v1.2.0

Per the contribution policy, `verified` remains `false` for maintainer review even though the author-side checks include an isolated DSH `0.1.0-rc.6` installation, persistence and stacking regression testing, 12 repository tests, and browser acceptance.

Checks run:
- `python3 scripts/validate.py` — 415 entries, 0 errors, 0 warnings
- `python3 scripts/generate-readme.py`
- `python3 scripts/generate-docs.py`