### PR TITLE
feat: add Living-Dream-DSH to Examples & Starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 ### Examples & Starters
 
 
-#### 🔥 Top 7
+#### 🔥 Top 8
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
@@ -691,8 +691,9 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 | 5 | [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) | ⭐4 | Template for DeepSeek Harness plugin development. | ✅ active |
 | 6 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐3 | Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. | ✅ active |
 | 7 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world style starter plugin for DSH. | ✅ active |
+| 8 | [Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) |  | Complete DSH desktop config framework: 8+ MCP servers, free model channels, mobile remote, one-click installer. MIT. | ✅ active |
 
-#### Complete list (7)
+#### Complete list (8)
 
 - [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐67 — Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. (✅ active)
 - [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) ⭐10 — Plugin template repository derived from the original turtle-ui official repo. (✅ active)
@@ -701,6 +702,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) ⭐4 — Template for DeepSeek Harness plugin development. (✅ active)
 - [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐3 — Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. (✅ active)
 - [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello)  — Hello-world style starter plugin for DSH. (✅ active)
+- [Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) ⭐ — Complete DSH desktop config framework: 8+ MCP servers, free model channels (CNB proxy, AMD Radeon Cloud), mobile remote via Tailscale, vision patches, one-click installer. MIT. (✅ active)
 
 ### Tutorials & Learning
 
@@ -1450,7 +1452,7 @@ awesome-deepseek-harness/
 ### Examples & Starters
 
 
-#### 🔥 Top 7
+#### 🔥 Top 8
 
 | # | Project | Stars | Description | Status |
 |---|---|---|---|---|
@@ -1461,8 +1463,9 @@ awesome-deepseek-harness/
 | 5 | [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) | ⭐4 | Template for DeepSeek Harness plugin development. | ✅ active |
 | 6 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐3 | Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. | ✅ active |
 | 7 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world style starter plugin for DSH. | ✅ active |
+| 8 | [Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) |  | Complete DSH desktop config framework: 8+ MCP servers, free model channels, mobile remote, one-click installer. MIT. | ✅ active |
 
-#### Complete list (7)
+#### Complete list (8)
 
 - [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐67 — Zero-to-plugin tutorial: understand 'everything is a plugin' with 22 Chinese skill examples. (✅ active)
 - [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) ⭐10 — Plugin template repository derived from the original turtle-ui official repo. (✅ active)
@@ -1471,6 +1474,7 @@ awesome-deepseek-harness/
 - [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) ⭐4 — Template for DeepSeek Harness plugin development. (✅ active)
 - [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐3 — Ready-to-publish plugin skeleton: bundle format, tool DSL, config and tests. (✅ active)
 - [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello)  — Hello-world style starter plugin for DSH. (✅ active)
+- [Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) ⭐ — Complete DSH desktop config framework: 8+ MCP servers, free model channels (CNB proxy, AMD Radeon Cloud), mobile remote via Tailscale, vision patches, one-click installer. MIT. (✅ active)
 
 ### Tutorials & Learning
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -681,7 +681,7 @@ dsh web
 ### Examples & Starters
 
 
-#### 🔥 Top 7
+#### 🔥 Top 8
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
@@ -692,8 +692,9 @@ dsh web
 | 5 | [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) | ⭐4 | DeepSeek Harness 插件开发模板。 | ✅ 活跃 |
 | 6 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐3 | 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。 | ✅ 活跃 |
 | 7 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world 风格 DSH 起步插件。 | ✅ 活跃 |
+| 8 | [Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) |  | 完整 DSH 桌面配置框架：8+ MCP 服务器、免费模型渠道、手机远程、一键安装。MIT。 | ✅ 活跃 |
 
-#### 完整列表（7）
+#### 完整列表（8）
 
 - [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐67 — 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。（✅ 活跃）
 - [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) ⭐10 — 基于原 turtle-ui 官方仓库创建的插件模板。（✅ 活跃）
@@ -702,6 +703,7 @@ dsh web
 - [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) ⭐4 — DeepSeek Harness 插件开发模板。（✅ 活跃）
 - [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐3 — 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。（✅ 活跃）
 - [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello)  — Hello-world 风格 DSH 起步插件。（✅ 活跃）
+- [Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) ⭐ — 完整 DSH 桌面配置框架：8+ MCP 服务器、免费模型渠道（CNB 代理、AMD Radeon Cloud）、Tailscale 手机远程、视觉补丁、一键安装脚本。MIT。（✅ 活跃）
 
 ### Tutorials & Learning
 
@@ -1451,7 +1453,7 @@ awesome-deepseek-harness/
 ### Examples & Starters
 
 
-#### 🔥 Top 7
+#### 🔥 Top 8
 
 | # | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|---|
@@ -1462,8 +1464,9 @@ awesome-deepseek-harness/
 | 5 | [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) | ⭐4 | DeepSeek Harness 插件开发模板。 | ✅ 活跃 |
 | 6 | [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) | ⭐3 | 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。 | ✅ 活跃 |
 | 7 | [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello) |  | Hello-world 风格 DSH 起步插件。 | ✅ 活跃 |
+| 8 | [Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) |  | 完整 DSH 桌面配置框架：8+ MCP 服务器、免费模型渠道、手机远程、一键安装。MIT。 | ✅ 活跃 |
 
-#### 完整列表（7）
+#### 完整列表（8）
 
 - [hello-dsh](https://github.com/pingfanfan/hello-dsh) ⭐67 — 从零开始看懂「万物皆可插件」：零基础插件开发教程，含 22 个中文技能实例。（✅ 活跃）
 - [plugin-template (omdsh-dev)](https://github.com/omdsh-dev/plugin-template) ⭐10 — 基于原 turtle-ui 官方仓库创建的插件模板。（✅ 活跃）
@@ -1472,6 +1475,7 @@ awesome-deepseek-harness/
 - [dsh-plugin-template](https://github.com/bugmaker2/dsh-plugin-template) ⭐4 — DeepSeek Harness 插件开发模板。（✅ 活跃）
 - [dsh-plugin-template (sunshine-lang)](https://github.com/sunshine-lang/dsh-plugin-template) ⭐3 — 可直接发布的插件骨架：bundle 格式、工具 DSL、配置与测试。（✅ 活跃）
 - [dsh-plugin-hello](https://github.com/xu1132/dsh-plugin-hello)  — Hello-world 风格 DSH 起步插件。（✅ 活跃）
+- [Living-Dream-DSH](https://github.com/alllllllllli/Living-Dream-DSH) ⭐ — 完整 DSH 桌面配置框架：8+ MCP 服务器、免费模型渠道（CNB 代理、AMD Radeon Cloud）、Tailscale 手机远程、视觉补丁、一键安装脚本。MIT。（✅ 活跃）
 
 ### Tutorials & Learning
 


### PR DESCRIPTION
Add Living-Dream-DSH to Examples & Starters section (EN + ZH-CN).

- Complete DSH desktop config framework
- 8+ MCP servers (computer-use, browser, memory, OCR, vision, history, markitdown, os-copilot)
- Free model channels (CNB proxy, AMD Radeon Cloud)
- Mobile remote via Tailscale
- Vision patches (GLM-4V-Flash to Ollama fallback)
- One-click PowerShell installer + offline 120MB SFX
- License: MIT