### PR TITLE
Add DeepSeek Harness Brain to tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 | 9 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | DeepSeek Harness prompts for different modes. | ✅ active |
 | 10 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐6 | 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. | ✅ active |
 
-#### Complete list (13)
+#### Complete list (14)
 
 - [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐1,118 — Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. (✅ active)
 - [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐604 — From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). (✅ active)
@@ -803,6 +803,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐5 — Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. (✅ active)
 - [gitlearnos](https://github.com/Guojiz/gitlearnos) ⭐4 — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory. (✅ active)
 - [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐2 — Checks DeepSeek tool loops, reasoning_content, strict schemas and captured SSE; also works as a DSH plugin. (✅ active)
+- [DeepSeek Harness Brain](https://github.com/AgriciDaniel/deepseek-harness-brain)  — Source-cited Obsidian knowledge base with a plain-English guide, architecture notes, an installable assistant skill, and portability guidance for DeepSeek Harness. (✅ active)
 
 ### Awesome Lists & Registries
 
@@ -1660,7 +1661,7 @@ awesome-deepseek-harness/
 | 9 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | DeepSeek Harness prompts for different modes. | ✅ active |
 | 10 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐6 | 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. | ✅ active |
 
-#### Complete list (13)
+#### Complete list (14)
 
 - [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐1,118 — Community Orange Book: complete system prompts, a 129-line startup checklist and three raw session logs — first-hand testing the official docs lack. Free PDF/EPUB/HTML. (✅ active)
 - [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐604 — From 0 to 1 handbook: installation, plugin development, performance tuning, real-world cases and same-model multi-agent comparisons (CN + EN PDF). (✅ active)
@@ -1675,6 +1676,7 @@ awesome-deepseek-harness/
 - [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐5 — Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. (✅ active)
 - [gitlearnos](https://github.com/Guojiz/gitlearnos) ⭐4 — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory. (✅ active)
 - [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐2 — Checks DeepSeek tool loops, reasoning_content, strict schemas and captured SSE; also works as a DSH plugin. (✅ active)
+- [DeepSeek Harness Brain](https://github.com/AgriciDaniel/deepseek-harness-brain)  — Source-cited Obsidian knowledge base with a plain-English guide, architecture notes, an installable assistant skill, and portability guidance for DeepSeek Harness. (✅ active)
 
 ### Awesome Lists & Registries
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -789,7 +789,7 @@ dsh web
 | 9 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | 不同模式下的 DeepSeek Harness 提示词集。 | ✅ 活跃 |
 | 10 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐6 | 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。 | ✅ 活跃 |
 
-#### 完整列表（13）
+#### 完整列表（14）
 
 - [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐1,118 — 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。（✅ 活跃）
 - [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐604 — 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。（✅ 活跃）
@@ -804,6 +804,7 @@ dsh web
 - [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐5 — 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。（✅ 活跃）
 - [gitlearnos](https://github.com/Guojiz/gitlearnos) ⭐4 — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory.（✅ 活跃）
 - [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐2 — 检查 DeepSeek 工具循环、reasoning_content、严格 schema 与捕获的 SSE，也可作为 DSH 插件。（✅ 活跃）
+- [DeepSeek Harness Brain](https://github.com/AgriciDaniel/deepseek-harness-brain)  — 带来源引用的 Obsidian 知识库，包含浅显指南、架构笔记、可安装助手技能，以及 DeepSeek Harness 可移植性指南。（✅ 活跃）
 
 ### Awesome Lists & Registries
 
@@ -1661,7 +1662,7 @@ awesome-deepseek-harness/
 | 9 | [deepseek-harness-prompts](https://github.com/demouo/deepseek-harness-prompts) | ⭐6 | 不同模式下的 DeepSeek Harness 提示词集。 | ✅ 活跃 |
 | 10 | [dsh-book-deepseek-harness](https://github.com/LaplaceYoung/dsh-book-deepseek-harness) | ⭐6 | 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。 | ✅ 活跃 |
 
-#### 完整列表（13）
+#### 完整列表（14）
 
 - [DeepSeek Harness Orange Book](https://github.com/alchaincyf/deepseek-harness-orange-book) ⭐1,118 — 《DeepSeek Harness 橙皮书》：完整系统提示词、129 行启动清单、三份原始会话日志——官方文档没有的一手实测。PDF/EPUB/HTML 免费下载。（✅ 活跃）
 - [dsh-handbook](https://github.com/Electricitysheep/dsh-handbook) ⭐604 — 从 0 到 1 深度手册：安装/插件开发/性能调优/实测案例/同模型多 Agent 实测对比（中文 + 英文 PDF）。（✅ 活跃）
@@ -1676,6 +1677,7 @@ awesome-deepseek-harness/
 - [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) ⭐5 — 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。（✅ 活跃）
 - [gitlearnos](https://github.com/Guojiz/gitlearnos) ⭐4 — Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory.（✅ 活跃）
 - [deepseek-protocol-doctor](https://github.com/Whning0513/deepseek-protocol-doctor) ⭐2 — 检查 DeepSeek 工具循环、reasoning_content、严格 schema 与捕获的 SSE，也可作为 DSH 插件。（✅ 活跃）
+- [DeepSeek Harness Brain](https://github.com/AgriciDaniel/deepseek-harness-brain)  — 带来源引用的 Obsidian 知识库，包含浅显指南、架构笔记、可安装助手技能，以及 DeepSeek Harness 可移植性指南。（✅ 活跃）
 
 ### Awesome Lists & Registries
 

--- a/data/tutorials.json
+++ b/data/tutorials.json
@@ -246,5 +246,22 @@
     "stars": 2,
     "_source_description": "Checks DeepSeek tool loops, reasoning_content, strict schemas, and captured SSE. Also works as a DSH plugin.",
     "_updated": "2026-08-18"
+  },
+  {
+    "id": "deepseek-harness-brain",
+    "name": "DeepSeek Harness Brain",
+    "type": "tutorial",
+    "category": "learning",
+    "repository": "https://github.com/AgriciDaniel/deepseek-harness-brain",
+    "description": "Source-cited Obsidian knowledge base with a plain-English guide, architecture notes, an installable assistant skill, and portability guidance for DeepSeek Harness.",
+    "description_zh": "带来源引用的 Obsidian 知识库，包含浅显指南、架构笔记、可安装助手技能，以及 DeepSeek Harness 可移植性指南。",
+    "capabilities": [
+      "learning",
+      "research",
+      "memory"
+    ],
+    "status": "active",
+    "verified": false,
+    "stars": 0
   }
 ]

--- a/docs/en/resources/deepseek-harness-brain.md
+++ b/docs/en/resources/deepseek-harness-brain.md
@@ -1,0 +1,25 @@
+---
+title: "DeepSeek Harness Brain"
+description: "Source-cited Obsidian knowledge base with a plain-English guide, architecture notes, an installable assistant skill, and portability guidance for DeepSeek Harness."
+keywords: "DeepSeek Harness Brain, learning, tutorial, research, memory, deepseek harness, dsh"
+---
+# DeepSeek Harness Brain
+
+> ⭐ 0 · ✅ active · tutorial
+
+## One-liner
+
+Source-cited Obsidian knowledge base with a plain-English guide, architecture notes, an installable assistant skill, and portability guidance for DeepSeek Harness.
+
+## About
+
+Source-cited Obsidian knowledge base with a plain-English guide, architecture notes, an installable assistant skill, and portability guidance for DeepSeek Harness.
+
+## Author
+**[AgriciDaniel](https://github.com/AgriciDaniel)**
+
+## Links
+
+- [GitHub Repository](https://github.com/AgriciDaniel/deepseek-harness-brain)
+- [Full README](https://github.com/AgriciDaniel/deepseek-harness-brain#readme)
+- [Back to the Tutorials & Learning list](../tutorials.md)

--- a/docs/en/tutorials.md
+++ b/docs/en/tutorials.md
@@ -1,6 +1,6 @@
 ---
 title: "Tutorials & Learning"
-description: "Top 10 and full list of 13 curated tutorials & learning for DeepSeek Harness (dsh)."
+description: "Top 10 and full list of 14 curated tutorials & learning for DeepSeek Harness (dsh)."
 keywords: "deepseek harness, dsh, tutorials learning, plugin, awesome"
 ---
 # Tutorials & Learning
@@ -30,10 +30,10 @@ keywords: "deepseek harness, dsh, tutorials learning, plugin, awesome"
 | 9 | [deepseek-harness-prompts](resources/deepseek-harness-prompts.md) | ⭐6 | DeepSeek Harness prompts for different modes. | ✅ active |
 | 10 | [dsh-book-deepseek-harness](resources/dsh-book-deepseek-harness.md) | ⭐6 | 'Deep Dive into DeepSeek Harness' — source-level architecture book: 37 chapter files, PDF, Mermaid diagrams and writing conventions. | ✅ active |
 
-## Complete list (13)
+## Complete list (14)
 
 
-**Learning (13)**
+**Learning (14)**
 
 | Project | Stars | Description | Status |
 |---|---|---|---|
@@ -50,3 +50,4 @@ keywords: "deepseek harness, dsh, tutorials learning, plugin, awesome"
 | [dsh-learn-everything](resources/dsh-learn-everything.md) | ⭐5 | Feynman learning-mode plugin: teach → teach-back → judge → re-explain loop rendered as rich HTML lesson cards. | ✅ active |
 | [gitlearnos](resources/gitlearnos.md) | ⭐4 | Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory. | ✅ active |
 | [deepseek-protocol-doctor](resources/deepseek-protocol-doctor.md) | ⭐2 | Checks DeepSeek tool loops, reasoning_content, strict schemas and captured SSE; also works as a DSH plugin. | ✅ active |
+| [DeepSeek Harness Brain](resources/deepseek-harness-brain.md) | – | Source-cited Obsidian knowledge base with a plain-English guide, architecture notes, an installable assistant skill, and portability guidance for DeepSeek Harness. | ✅ active |

--- a/docs/zh/resources/deepseek-harness-brain.md
+++ b/docs/zh/resources/deepseek-harness-brain.md
@@ -1,0 +1,25 @@
+---
+title: "DeepSeek Harness Brain"
+description: "带来源引用的 Obsidian 知识库，包含浅显指南、架构笔记、可安装助手技能，以及 DeepSeek Harness 可移植性指南。"
+keywords: "DeepSeek Harness Brain, learning, tutorial, research, memory, deepseek harness, dsh"
+---
+# DeepSeek Harness Brain
+
+> ⭐ 0 · ✅ 活跃 · 教程
+
+## 一句话介绍
+
+带来源引用的 Obsidian 知识库，包含浅显指南、架构笔记、可安装助手技能，以及 DeepSeek Harness 可移植性指南。
+
+## 详细介绍
+
+带来源引用的 Obsidian 知识库，包含浅显指南、架构笔记、可安装助手技能，以及 DeepSeek Harness 可移植性指南。
+
+## 作者
+**[AgriciDaniel](https://github.com/AgriciDaniel)**
+
+## 链接
+
+- [GitHub 仓库](https://github.com/AgriciDaniel/deepseek-harness-brain)
+- [完整 README](https://github.com/AgriciDaniel/deepseek-harness-brain#readme)
+- [返回DeepSeek Harness Brain所在分类](../tutorials.md)

--- a/docs/zh/tutorials.md
+++ b/docs/zh/tutorials.md
@@ -1,6 +1,6 @@
 ---
 title: "Tutorials & Learning"
-description: "DeepSeek Harness (dsh) 精选 tutorials & learning：🔥 Top 10 与完整列表（13 条）。"
+description: "DeepSeek Harness (dsh) 精选 tutorials & learning：🔥 Top 10 与完整列表（14 条）。"
 keywords: "deepseek harness, dsh, tutorials learning, plugin, awesome"
 ---
 # Tutorials & Learning
@@ -30,10 +30,10 @@ keywords: "deepseek harness, dsh, tutorials learning, plugin, awesome"
 | 9 | [deepseek-harness-prompts](resources/deepseek-harness-prompts.md) | ⭐6 | 不同模式下的 DeepSeek Harness 提示词集。 | ✅ 活跃 |
 | 10 | [dsh-book-deepseek-harness](resources/dsh-book-deepseek-harness.md) | ⭐6 | 《深入理解 DeepSeek Harness：一切皆插件的 Agent 架构》——源码级架构拆解科普书：37 个章节文件、PDF、Mermaid 图。 | ✅ 活跃 |
 
-## 完整列表（13）
+## 完整列表（14）
 
 
-**学习（13）**
+**学习（14）**
 
 | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|
@@ -50,3 +50,4 @@ keywords: "deepseek harness, dsh, tutorials learning, plugin, awesome"
 | [dsh-learn-everything](resources/dsh-learn-everything.md) | ⭐5 | 费曼学习模式：教→复述→评判→重讲循环，渲染为富 HTML 课程卡片。 | ✅ 活跃 |
 | [gitlearnos](resources/gitlearnos.md) | ⭐4 | Git-native AI learning OS with a GitLearnOS-exclusive DeepSeek Harness panel, targeted practice, local RAG, and learner-owned memory. | ✅ 活跃 |
 | [deepseek-protocol-doctor](resources/deepseek-protocol-doctor.md) | ⭐2 | 检查 DeepSeek 工具循环、reasoning_content、严格 schema 与捕获的 SSE，也可作为 DSH 插件。 | ✅ 活跃 |
+| [DeepSeek Harness Brain](resources/deepseek-harness-brain.md) | – | 带来源引用的 Obsidian 知识库，包含浅显指南、架构笔记、可安装助手技能，以及 DeepSeek Harness 可移植性指南。 | ✅ 活跃 |


### PR DESCRIPTION
<a href="https://github.com/AgriciDaniel/deepseek-harness-brain"><img src="https://raw.githubusercontent.com/AgriciDaniel/deepseek-harness-brain/main/assets/images/deepseek-harness-second-brain-cover.jpg" alt="DeepSeek Harness Second Brain" width="720"></a>

## Summary

- Adds DeepSeek Harness Brain as a learning resource.
- Describes it as an independent, source-cited Obsidian knowledge base.
- Regenerates the English and Chinese indexes and resource pages.

## Checks

- `python3 scripts/validate.py`
- `python3 scripts/generate-readme.py`
- `python3 scripts/generate-docs.py`
- `git diff --check`
