### PR TITLE
Add dsh-desktop-pet (FenyxHuang): whale desktop pet with balance sea level

### DIFF
--- a/data/plugins.json
+++ b/data/plugins.json
@@ -5156,5 +5156,20 @@
     "stars": 0,
     "_source_description": "Fork any DeepSeek Harness session into a different agent preset — a UI button with preset picker in the conversation header.",
     "_updated": "2026-08-21"
+  },
+  {
+    "id": "dsh-desktop-pet",
+    "name": "dsh-desktop-pet",
+    "type": "plugin",
+    "category": "ui",
+    "repository": "https://github.com/FenyxHuang/dsh-desktop-pet",
+    "description": "Whale desktop pet for DeepSeek Harness: the whale mirrors live agent status (thinking bubbles, working tool, error) and the API balance is rendered as a circular sea level; click to jump or 40% charged 360° dive with chatter.",
+    "description_zh": "DeepSeek Harness 桌面宠物:鲸鱼实时反应 agent 状态(思考冒泡/工作中工具/出错),API 余额渲染为圆形海平面,点击触发跳跃或 40% 转体跳水,带随机台词。",
+    "capabilities": [
+      "ui"
+    ],
+    "status": "experimental",
+    "verified": false,
+    "stars": 5
   }
 ]


### PR DESCRIPTION
Adds the whale desktop pet for DeepSeek Harness to data/plugins.json:

- **repo**: https://github.com/FenyxHuang/dsh-desktop-pet (tagged dsh-plugin, MIT)
- **what it is**: shell-overlay whale widget mirroring live agent status (thinking bubbles / working tool / error) with the DeepSeek API balance rendered as a circular sea level (¥100 = full, linear); click to jump or a 40% charged 360° dive; per-state chatter zh/en, hearts, drag, minimize
- **zero runtime deps**: prebuilt artifacts committed, installs via `dsh plugin add github:FenyxHuang/dsh-desktop-pet` with no build authorization
- **note**: same short name as xiaoshihou514/dsh-desktop-pet (whale-girl skin) — this entry is the FenyxHuang repo (status/balance pet)
- 5 stars, demo GIF in README, promoted via Douyin video