### PR TITLE
Add dsh-better-stats plugin

### DIFF
--- a/data/plugins.json
+++ b/data/plugins.json
@@ -5156,5 +5156,20 @@
     "stars": 0,
     "_source_description": "Fork any DeepSeek Harness session into a different agent preset — a UI button with preset picker in the conversation header.",
     "_updated": "2026-08-21"
+  },
+
+  {
+    "id": "dsh-better-stats",
+    "name": "dsh-better-stats",
+    "type": "plugin",
+    "category": "developer",
+    "repository": "https://github.com/null5069/dsh-better-stats",
+    "description": "Enhanced stats strip for the DeepSeek Harness Web UI: official CNY pricing (peak/off-peak tiers, auto price sync), per-model accounting, live timers, agent-team tree merging, direct balance, budget alerts and streaming cost estimation.",
+    "description_zh": "DSH Web 输入框下方的增强统计条：官方人民币计价（峰谷分时、价目自动同步）、多模型分账、实时计时、子代理树合并、余额直连、预算预警与流式成本估算。",
+    "capabilities": [
+      "observability",
+      "ui"
+    ],
+    "status": "active"
   }
 ]


### PR DESCRIPTION
## 新增插件：dsh-better-stats

提交 `data/plugins.json` 新增条目（README 由脚本生成，未改动）。

**字段：** id/name/type/category/repository/description/description_zh/capabilities/status
- category: `developer`（与 tokentracker、dsh-usage-stats、dsh-balance 同类）
- capabilities: `observability` + `ui`（Token/费用统计 + Web UI 渲染）

**插件简介：** DSH Web 输入框下方增强统计条（host + client web bundle）——官方 CNY 计价（峰谷分时、价目 6h 自动同步、按模型分账）、实时 LLM/工具计时、agent-team 子代理树合并、DeepSeek 余额直连（凭据走 host）、预算/余额预警、流式成本估算。npm `dsh-better-stats` v0.1.15 发布，MIT，零运行时依赖，仓库已打 `dsh-plugin` topic。