### PR TITLE
Add dsh-think-translate (UI translation plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 | 9 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | ⭐1,395 | Local-first AI token usage & cost tracker for 31 coding tools including Claude Code, Codex, Cursor, Gemini & DeepSeek Harness. | ✅ active |
 | 10 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | ⭐927 | Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). | ✅ active |
 
-#### Complete list (262)
+#### Complete list (263)
 
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。 (✅ active)
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐5,349 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
@@ -434,6 +434,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-precedent](https://github.com/dshplugin-me/dsh-precedent)  — Evidence-backed working memory for DeepSeek Harness: a cited ledger of what already worked in this workspace, built from the session log you already have. No index, no model, no capture step. (✅ active)
 - [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent)  — Run a one-shot subagent fully mounted on any agent preset from any session, with per-call model/provider override, a model-availability pre-check, and external CLI engines (codex / claude / codebuddy) with background jobs, live progress, kill, and continuable sessions. (✅ active)
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces. (✅ active)
+- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback. (🧪 experimental)
 
 ### Skills
 
@@ -1042,7 +1043,7 @@ awesome-deepseek-harness/
 | 9 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | ⭐1,395 | Local-first AI token usage & cost tracker for 31 coding tools including Claude Code, Codex, Cursor, Gemini & DeepSeek Harness. | ✅ active |
 | 10 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | ⭐927 | Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). | ✅ active |
 
-#### Complete list (262)
+#### Complete list (263)
 
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。 (✅ active)
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐5,349 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
@@ -1306,6 +1307,7 @@ awesome-deepseek-harness/
 - [dsh-precedent](https://github.com/dshplugin-me/dsh-precedent)  — Evidence-backed working memory for DeepSeek Harness: a cited ledger of what already worked in this workspace, built from the session log you already have. No index, no model, no capture step. (✅ active)
 - [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent)  — Run a one-shot subagent fully mounted on any agent preset from any session, with per-call model/provider override, a model-availability pre-check, and external CLI engines (codex / claude / codebuddy) with background jobs, live progress, kill, and continuable sessions. (✅ active)
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces. (✅ active)
+- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback. (🧪 experimental)
 
 ### Skills
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-precedent](https://github.com/dshplugin-me/dsh-precedent)  — Evidence-backed working memory for DeepSeek Harness: a cited ledger of what already worked in this workspace, built from the session log you already have. No index, no model, no capture step. (✅ active)
 - [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent)  — Run a one-shot subagent fully mounted on any agent preset from any session, with per-call model/provider override, a model-availability pre-check, and external CLI engines (codex / claude / codebuddy) with background jobs, live progress, kill, and continuable sessions. (✅ active)
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces. (✅ active)
-- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback. (🧪 experimental)
+- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback. (✅ active)
 
 ### Skills
 
@@ -1307,7 +1307,7 @@ awesome-deepseek-harness/
 - [dsh-precedent](https://github.com/dshplugin-me/dsh-precedent)  — Evidence-backed working memory for DeepSeek Harness: a cited ledger of what already worked in this workspace, built from the session log you already have. No index, no model, no capture step. (✅ active)
 - [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent)  — Run a one-shot subagent fully mounted on any agent preset from any session, with per-call model/provider override, a model-availability pre-check, and external CLI engines (codex / claude / codebuddy) with background jobs, live progress, kill, and continuable sessions. (✅ active)
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces. (✅ active)
-- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback. (🧪 experimental)
+- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback. (✅ active)
 
 ### Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -435,7 +435,7 @@ dsh web
 - [dsh-precedent](https://github.com/dshplugin-me/dsh-precedent)  — Evidence-backed working memory for DeepSeek Harness: a cited ledger of what already worked in this workspace, built from the session log you already have. No index, no model, no capture step.（✅ 活跃）
 - [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent)  — 从任意会话派发一个完整挂载到任意 agent preset 的一次性子代理，支持按次指定模型/provider、模型可用性预检，以及外部 CLI 引擎（codex / claude / codebuddy），支持后台任务、实时进度、终止与可续会话。（✅ 活跃）
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces.（✅ 活跃）
-- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。（🧪 实验性）
+- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — DSH Web 界面显示层翻译：思考链、任务卡片与回答正文翻译为 8 种目标语言；本地 Ollama 为主力（面板内下载），Google/Bing 兜底。（✅ 活跃）
 
 ### Skills
 
@@ -1308,7 +1308,7 @@ awesome-deepseek-harness/
 - [dsh-precedent](https://github.com/dshplugin-me/dsh-precedent)  — Evidence-backed working memory for DeepSeek Harness: a cited ledger of what already worked in this workspace, built from the session log you already have. No index, no model, no capture step.（✅ 活跃）
 - [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent)  — 从任意会话派发一个完整挂载到任意 agent preset 的一次性子代理，支持按次指定模型/provider、模型可用性预检，以及外部 CLI 引擎（codex / claude / codebuddy），支持后台任务、实时进度、终止与可续会话。（✅ 活跃）
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces.（✅ 活跃）
-- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。（🧪 实验性）
+- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — DSH Web 界面显示层翻译：思考链、任务卡片与回答正文翻译为 8 种目标语言；本地 Ollama 为主力（面板内下载），Google/Bing 兜底。（✅ 活跃）
 
 ### Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,7 +171,7 @@ dsh web
 | 9 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | ⭐1,395 | 本地优先的 AI Token 用量与费用追踪器，支持 31 款编码工具（含 Claude Code、Codex、Cursor、Gemini 与 DeepSeek Harness）。 | ✅ 活跃 |
 | 10 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | ⭐927 | 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。 | ✅ 活跃 |
 
-#### 完整列表（262）
+#### 完整列表（263）
 
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。（✅ 活跃）
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐5,349 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
@@ -435,6 +435,7 @@ dsh web
 - [dsh-precedent](https://github.com/dshplugin-me/dsh-precedent)  — Evidence-backed working memory for DeepSeek Harness: a cited ledger of what already worked in this workspace, built from the session log you already have. No index, no model, no capture step.（✅ 活跃）
 - [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent)  — 从任意会话派发一个完整挂载到任意 agent preset 的一次性子代理，支持按次指定模型/provider、模型可用性预检，以及外部 CLI 引擎（codex / claude / codebuddy），支持后台任务、实时进度、终止与可续会话。（✅ 活跃）
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces.（✅ 活跃）
+- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。（🧪 实验性）
 
 ### Skills
 
@@ -1043,7 +1044,7 @@ awesome-deepseek-harness/
 | 9 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | ⭐1,395 | 本地优先的 AI Token 用量与费用追踪器，支持 31 款编码工具（含 Claude Code、Codex、Cursor、Gemini 与 DeepSeek Harness）。 | ✅ 活跃 |
 | 10 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | ⭐927 | 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。 | ✅ 活跃 |
 
-#### 完整列表（262）
+#### 完整列表（263）
 
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。（✅ 活跃）
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐5,349 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
@@ -1307,6 +1308,7 @@ awesome-deepseek-harness/
 - [dsh-precedent](https://github.com/dshplugin-me/dsh-precedent)  — Evidence-backed working memory for DeepSeek Harness: a cited ledger of what already worked in this workspace, built from the session log you already have. No index, no model, no capture step.（✅ 活跃）
 - [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent)  — 从任意会话派发一个完整挂载到任意 agent preset 的一次性子代理，支持按次指定模型/provider、模型可用性预检，以及外部 CLI 引擎（codex / claude / codebuddy），支持后台任务、实时进度、终止与可续会话。（✅ 活跃）
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli)  — 深度清理 DeepSeek Harness (DSH) 工作区会话的离线 CLI：按工作区列出/删除/恢复会话，自动同步工作区账目与投影缓存。Offline session cleaner for DeepSeek Harness: list, delete (trash+restore) and prune ghost sessions across workspaces.（✅ 活跃）
+- [dsh-think-translate](https://github.com/UncleK/dsh-think-translate)  — DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。（🧪 实验性）
 
 ### Skills
 

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -5164,11 +5164,11 @@
     "category": "ui",
     "repository": "https://github.com/UncleK/dsh-think-translate",
     "description": "Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback.",
-    "description_zh": "DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。",
+    "description_zh": "DSH Web 界面显示层翻译：思考链、任务卡片与回答正文翻译为 8 种目标语言；本地 Ollama 为主力（面板内下载），Google/Bing 兜底。",
     "capabilities": [
       "ui"
     ],
-    "status": "experimental",
+    "status": "active",
     "verified": false,
     "stars": 0
   }

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -5156,5 +5156,20 @@
     "stars": 0,
     "_source_description": "Fork any DeepSeek Harness session into a different agent preset — a UI button with preset picker in the conversation header.",
     "_updated": "2026-08-21"
+  },
+  {
+    "id": "dsh-think-translate",
+    "name": "dsh-think-translate",
+    "type": "plugin",
+    "category": "ui",
+    "repository": "https://github.com/UncleK/dsh-think-translate",
+    "description": "Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback.",
+    "description_zh": "DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。",
+    "capabilities": [
+      "ui"
+    ],
+    "status": "experimental",
+    "verified": false,
+    "stars": 0
   }
 ]

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -52,7 +52,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-view-modes](resources/dsh-view-modes.md) | ⭐2 | Output modes with Verbose, Normal and Summary views plus semantic grouping for tool calls and thinking. | ✅ active |
 | [dsh-fork-to-preset](resources/dsh-fork-to-preset.md) | – | Fork any session into a different agent preset from the conversation header: a preset-picker button that creates a new child session mounted on the chosen preset, inheriting the source session completed turns. | ✅ active |
 | [dsh-plugin](resources/dsh-plugin.md) | – | Build your own coding agent with Pi dsh-plugin | ✅ active |
-| [dsh-think-translate](resources/dsh-think-translate.md) | – | Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback. | 🧪 experimental |
+| [dsh-think-translate](resources/dsh-think-translate.md) | – | Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback. | ✅ active |
 *🎨 Skins & themes (12)*
 
 | Project | Stars | Description | Status |

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "Top 10 and full list of 262 curated plugins for DeepSeek Harness (dsh)."
+description: "Top 10 and full list of 263 curated plugins for DeepSeek Harness (dsh)."
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,12 +30,12 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [TokenTracker](resources/tokentracker.md) | ⭐1,395 | Local-first AI token usage & cost tracker for 31 coding tools including Claude Code, Codex, Cursor, Gemini & DeepSeek Harness. | ✅ active |
 | 10 | [dsh-vision-router](resources/dsh-vision-router.md) | ⭐927 | Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). | ✅ active |
 
-## Complete list (262)
+## Complete list (263)
 
 
-**UI & experience (56)**
+**UI & experience (57)**
 
-*Other (13)*
+*Other (14)*
 
 | Project | Stars | Description | Status |
 |---|---|---|---|
@@ -52,6 +52,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-view-modes](resources/dsh-view-modes.md) | ⭐2 | Output modes with Verbose, Normal and Summary views plus semantic grouping for tool calls and thinking. | ✅ active |
 | [dsh-fork-to-preset](resources/dsh-fork-to-preset.md) | – | Fork any session into a different agent preset from the conversation header: a preset-picker button that creates a new child session mounted on the chosen preset, inheriting the source session completed turns. | ✅ active |
 | [dsh-plugin](resources/dsh-plugin.md) | – | Build your own coding agent with Pi dsh-plugin | ✅ active |
+| [dsh-think-translate](resources/dsh-think-translate.md) | – | Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback. | 🧪 experimental |
 *🎨 Skins & themes (12)*
 
 | Project | Stars | Description | Status |

--- a/docs/en/resources/dsh-think-translate.md
+++ b/docs/en/resources/dsh-think-translate.md
@@ -5,7 +5,7 @@ keywords: "dsh-think-translate, ui, plugin, deepseek harness, dsh"
 ---
 # dsh-think-translate
 
-> ⭐ 0 · 🧪 experimental · plugin
+> ⭐ 0 · ✅ active · plugin
 
 ## One-liner
 

--- a/docs/en/resources/dsh-think-translate.md
+++ b/docs/en/resources/dsh-think-translate.md
@@ -1,0 +1,25 @@
+---
+title: "dsh-think-translate"
+description: "Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback."
+keywords: "dsh-think-translate, ui, plugin, deepseek harness, dsh"
+---
+# dsh-think-translate
+
+> ⭐ 0 · 🧪 experimental · plugin
+
+## One-liner
+
+Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback.
+
+## About
+
+Display-layer UI translation for DSH Web: thinking chain, task cards and answer text in 8 target languages; local Ollama primary with in-panel model download, Google/Bing fallback.
+
+## Author
+**[UncleK](https://github.com/UncleK)**
+
+## Links
+
+- [GitHub Repository](https://github.com/UncleK/dsh-think-translate)
+- [Full README](https://github.com/UncleK/dsh-think-translate#readme)
+- [Back to the Plugins list](../plugins.md)

--- a/docs/zh/plugins.md
+++ b/docs/zh/plugins.md
@@ -52,7 +52,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-view-modes](resources/dsh-view-modes.md) | ⭐2 | Verbose/Normal/Summary 三种输出模式，工具调用与思考语义分组。 | ✅ 活跃 |
 | [dsh-fork-to-preset](resources/dsh-fork-to-preset.md) | – | 在会话 Header 上一键把当前会话分叉到任意 agent preset：选择 preset 后创建挂载到该 preset 的新子会话，并继承源会话的已完成轮次。 | ✅ 活跃 |
 | [dsh-plugin](resources/dsh-plugin.md) | – | Build your own coding agent with Pi dsh-plugin | ✅ 活跃 |
-| [dsh-think-translate](resources/dsh-think-translate.md) | – | DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。 | 🧪 实验性 |
+| [dsh-think-translate](resources/dsh-think-translate.md) | – | DSH Web 界面显示层翻译：思考链、任务卡片与回答正文翻译为 8 种目标语言；本地 Ollama 为主力（面板内下载），Google/Bing 兜底。 | ✅ 活跃 |
 *🎨 皮肤与主题（12）*
 
 | 项目 | 星数 | 说明 | 状态 |

--- a/docs/zh/plugins.md
+++ b/docs/zh/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（262 条）。"
+description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（263 条）。"
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,12 +30,12 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [TokenTracker](resources/tokentracker.md) | ⭐1,395 | 本地优先的 AI Token 用量与费用追踪器，支持 31 款编码工具（含 Claude Code、Codex、Cursor、Gemini 与 DeepSeek Harness）。 | ✅ 活跃 |
 | 10 | [dsh-vision-router](resources/dsh-vision-router.md) | ⭐927 | 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。 | ✅ 活跃 |
 
-## 完整列表（262）
+## 完整列表（263）
 
 
-**界面与体验（56）**
+**界面与体验（57）**
 
-*其他（13）*
+*其他（14）*
 
 | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|
@@ -52,6 +52,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-view-modes](resources/dsh-view-modes.md) | ⭐2 | Verbose/Normal/Summary 三种输出模式，工具调用与思考语义分组。 | ✅ 活跃 |
 | [dsh-fork-to-preset](resources/dsh-fork-to-preset.md) | – | 在会话 Header 上一键把当前会话分叉到任意 agent preset：选择 preset 后创建挂载到该 preset 的新子会话，并继承源会话的已完成轮次。 | ✅ 活跃 |
 | [dsh-plugin](resources/dsh-plugin.md) | – | Build your own coding agent with Pi dsh-plugin | ✅ 活跃 |
+| [dsh-think-translate](resources/dsh-think-translate.md) | – | DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。 | 🧪 实验性 |
 *🎨 皮肤与主题（12）*
 
 | 项目 | 星数 | 说明 | 状态 |

--- a/docs/zh/resources/dsh-think-translate.md
+++ b/docs/zh/resources/dsh-think-translate.md
@@ -1,19 +1,19 @@
 ---
 title: "dsh-think-translate"
-description: "DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。"
+description: "DSH Web 界面显示层翻译：思考链、任务卡片与回答正文翻译为 8 种目标语言；本地 Ollama 为主力（面板内下载），Google/Bing 兜底。"
 keywords: "dsh-think-translate, ui, plugin, deepseek harness, dsh"
 ---
 # dsh-think-translate
 
-> ⭐ 0 · 🧪 实验性 · 插件
+> ⭐ 0 · ✅ 活跃 · 插件
 
 ## 一句话介绍
 
-DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。
+DSH Web 界面显示层翻译：思考链、任务卡片与回答正文翻译为 8 种目标语言；本地 Ollama 为主力（面板内下载），Google/Bing 兜底。
 
 ## 详细介绍
 
-DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。
+DSH Web 界面显示层翻译：思考链、任务卡片与回答正文翻译为 8 种目标语言；本地 Ollama 为主力（面板内下载），Google/Bing 兜底。
 
 ## 作者
 **[UncleK](https://github.com/UncleK)**

--- a/docs/zh/resources/dsh-think-translate.md
+++ b/docs/zh/resources/dsh-think-translate.md
@@ -1,0 +1,25 @@
+---
+title: "dsh-think-translate"
+description: "DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。"
+keywords: "dsh-think-translate, ui, plugin, deepseek harness, dsh"
+---
+# dsh-think-translate
+
+> ⭐ 0 · 🧪 实验性 · 插件
+
+## 一句话介绍
+
+DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。
+
+## 详细介绍
+
+DSH Web 界面显示层翻译：思考链、任务卡片、回答正文翻译为 8 种目标语言；本地 Ollama 模型为主力（面板内下载），Google/Bing 兜底。
+
+## 作者
+**[UncleK](https://github.com/UncleK)**
+
+## 链接
+
+- [GitHub 仓库](https://github.com/UncleK/dsh-think-translate)
+- [完整 README](https://github.com/UncleK/dsh-think-translate#readme)
+- [返回dsh-think-translate所在分类](../plugins.md)


### PR DESCRIPTION
Adds **dsh-think-translate** to the UI category.

Display-layer UI translation for DeepSeek Harness Web: thinking chain, task cards and answer text in 8 target languages (zh/en/ja/ko/es/fr/de/ru). Local Ollama model primary with in-panel download flow, Google/Bing fallback. Official bundle format (dsh.bundle.patch), installable via \dsh plugin add\ or npm.

Validated with scripts/validate.py (0 errors) and regenerated README/docs.