### PR TITLE
Add dsh-solution-explorer plugin to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 | 9 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | ⭐1,395 | Local-first AI token usage & cost tracker for 31 coding tools including Claude Code, Codex, Cursor, Gemini & DeepSeek Harness. | ✅ active |
 | 10 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | ⭐927 | Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). | ✅ active |
 
-#### Complete list (262)
+#### Complete list (263)
 
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。 (✅ active)
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐5,349 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
@@ -366,6 +366,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-plugin-deepeye](https://github.com/Favio8/dsh-plugin-deepeye) ⭐4 — DeepEye vision plugin for DeepSeek Harness (DSH): image description, OCR, VQA, UI layout, and clipboard analysis. (✅ active)
 - [dsh-rss](https://github.com/STARDUSTLC666/dsh-rss) ⭐4 — DeepSeek Harness RSS 订阅插件：rss_list/add/remove/fetch/check 五工具，RSS 0.9x/1.0/2.0 与 Atom 归一化解析，订阅列表持久化到 settings，proxyUrl 特殊代理支持；纯 Node 全平台。· RSS/Atom subscription tools for DeepSeek Harness agents. (✅ active)
 - [dsh-skill-hub](https://github.com/cheshireez/dsh-skill-hub) ⭐4 — In-GUI skill manager for DeepSeek Harness: browse, search, toggle, inspect, diagnose and scaffold local skills from the official ctx.skills registry, plus a skill market with tracked source sync and one-click update-all. (✅ active)
+- [dsh-solution-explorer](https://github.com/xiaoksio/dsh-solution-explorer) ⭐4 — VS Code-style right sidebar for the DSH Web GUI: file explorer plus source control (git status, stage/unstage/discard, commit, diff, commit graph, sync, branch/remote management) with an editable diff view, a syntax-highlighted editor (15 languages) and a multi-tab ConPTY terminal. (✅ active)
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) ⭐4 — Structured safe Git tools: status/diff/log/branch/stage/commit/stash/show with a destructive-command guard. (✅ active)
 - [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) ⭐4 — Privacy-minimal heuristic per-turn verification summaries for DeepSeek Harness (✅ active)
 - [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐4 — Persistent common-word panel beside the composer with global/project buckets and one-click insert. (✅ active)
@@ -1042,7 +1043,7 @@ awesome-deepseek-harness/
 | 9 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | ⭐1,395 | Local-first AI token usage & cost tracker for 31 coding tools including Claude Code, Codex, Cursor, Gemini & DeepSeek Harness. | ✅ active |
 | 10 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | ⭐927 | Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). | ✅ active |
 
-#### Complete list (262)
+#### Complete list (263)
 
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。 (✅ active)
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐5,349 — Large plugin and skin collection for DSH Web: task board, git graph, side panels, remote/mobile UI, pets, token stats and themes. (✅ active)
@@ -1238,6 +1239,7 @@ awesome-deepseek-harness/
 - [dsh-plugin-deepeye](https://github.com/Favio8/dsh-plugin-deepeye) ⭐4 — DeepEye vision plugin for DeepSeek Harness (DSH): image description, OCR, VQA, UI layout, and clipboard analysis. (✅ active)
 - [dsh-rss](https://github.com/STARDUSTLC666/dsh-rss) ⭐4 — DeepSeek Harness RSS 订阅插件：rss_list/add/remove/fetch/check 五工具，RSS 0.9x/1.0/2.0 与 Atom 归一化解析，订阅列表持久化到 settings，proxyUrl 特殊代理支持；纯 Node 全平台。· RSS/Atom subscription tools for DeepSeek Harness agents. (✅ active)
 - [dsh-skill-hub](https://github.com/cheshireez/dsh-skill-hub) ⭐4 — In-GUI skill manager for DeepSeek Harness: browse, search, toggle, inspect, diagnose and scaffold local skills from the official ctx.skills registry, plus a skill market with tracked source sync and one-click update-all. (✅ active)
+- [dsh-solution-explorer](https://github.com/xiaoksio/dsh-solution-explorer) ⭐4 — VS Code-style right sidebar for the DSH Web GUI: file explorer plus source control (git status, stage/unstage/discard, commit, diff, commit graph, sync, branch/remote management) with an editable diff view, a syntax-highlighted editor (15 languages) and a multi-tab ConPTY terminal. (✅ active)
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) ⭐4 — Structured safe Git tools: status/diff/log/branch/stage/commit/stash/show with a destructive-command guard. (✅ active)
 - [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) ⭐4 — Privacy-minimal heuristic per-turn verification summaries for DeepSeek Harness (✅ active)
 - [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐4 — Persistent common-word panel beside the composer with global/project buckets and one-click insert. (✅ active)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,7 +171,7 @@ dsh web
 | 9 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | ⭐1,395 | 本地优先的 AI Token 用量与费用追踪器，支持 31 款编码工具（含 Claude Code、Codex、Cursor、Gemini 与 DeepSeek Harness）。 | ✅ 活跃 |
 | 10 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | ⭐927 | 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。 | ✅ 活跃 |
 
-#### 完整列表（262）
+#### 完整列表（263）
 
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。（✅ 活跃）
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐5,349 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
@@ -367,6 +367,7 @@ dsh web
 - [dsh-plugin-deepeye](https://github.com/Favio8/dsh-plugin-deepeye) ⭐4 — DeepEye vision plugin for DeepSeek Harness (DSH): image description, OCR, VQA, UI layout, and clipboard analysis.（✅ 活跃）
 - [dsh-rss](https://github.com/STARDUSTLC666/dsh-rss) ⭐4 — DeepSeek Harness RSS 订阅插件：rss_list/add/remove/fetch/check 五工具，RSS 0.9x/1.0/2.0 与 Atom 归一化解析，订阅列表持久化到 settings，proxyUrl 特殊代理支持；纯 Node 全平台。· RSS/Atom subscription tools for DeepSeek Harness agents.（✅ 活跃）
 - [dsh-skill-hub](https://github.com/cheshireez/dsh-skill-hub) ⭐4 — DSH Web GUI 技能中枢：基于官方 ctx.skills 注册表浏览、搜索、启停、查看、诊断并新建本地技能，附技能市场：来源快照跟踪、一键全量更新。（✅ 活跃）
+- [dsh-solution-explorer](https://github.com/xiaoksio/dsh-solution-explorer) ⭐4 — DSH Web GUI 右侧边栏：VS Code 风格文件浏览器 + 源代码管理（git 状态、暂存/取消暂存/丢弃、提交、diff、提交图、同步、分支/远程管理）+ 可编辑 diff 视图 + 语法高亮编辑器（15 种语言）+ 多标签终端（ConPTY）。（✅ 活跃）
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) ⭐4 — 结构化安全 Git 工具：status/diff/log/branch/stage/commit/stash/show，带破坏性命令防护。（✅ 活跃）
 - [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) ⭐4 — Privacy-minimal heuristic per-turn verification summaries for DeepSeek Harness（✅ 活跃）
 - [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐4 — 输入框旁常用词箱：全局/项目词桶，一键插入。（✅ 活跃）
@@ -1043,7 +1044,7 @@ awesome-deepseek-harness/
 | 9 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | ⭐1,395 | 本地优先的 AI Token 用量与费用追踪器，支持 31 款编码工具（含 Claude Code、Codex、Cursor、Gemini 与 DeepSeek Harness）。 | ✅ 活跃 |
 | 10 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | ⭐927 | 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。 | ✅ 活跃 |
 
-#### 完整列表（262）
+#### 完整列表（263）
 
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。（✅ 活跃）
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) ⭐5,349 — DSH Web 大型插件与皮肤集合：任务看板、Git 图、侧栏、远程/移动 UI、宠物、Token 统计与主题。（✅ 活跃）
@@ -1239,6 +1240,7 @@ awesome-deepseek-harness/
 - [dsh-plugin-deepeye](https://github.com/Favio8/dsh-plugin-deepeye) ⭐4 — DeepEye vision plugin for DeepSeek Harness (DSH): image description, OCR, VQA, UI layout, and clipboard analysis.（✅ 活跃）
 - [dsh-rss](https://github.com/STARDUSTLC666/dsh-rss) ⭐4 — DeepSeek Harness RSS 订阅插件：rss_list/add/remove/fetch/check 五工具，RSS 0.9x/1.0/2.0 与 Atom 归一化解析，订阅列表持久化到 settings，proxyUrl 特殊代理支持；纯 Node 全平台。· RSS/Atom subscription tools for DeepSeek Harness agents.（✅ 活跃）
 - [dsh-skill-hub](https://github.com/cheshireez/dsh-skill-hub) ⭐4 — DSH Web GUI 技能中枢：基于官方 ctx.skills 注册表浏览、搜索、启停、查看、诊断并新建本地技能，附技能市场：来源快照跟踪、一键全量更新。（✅ 活跃）
+- [dsh-solution-explorer](https://github.com/xiaoksio/dsh-solution-explorer) ⭐4 — DSH Web GUI 右侧边栏：VS Code 风格文件浏览器 + 源代码管理（git 状态、暂存/取消暂存/丢弃、提交、diff、提交图、同步、分支/远程管理）+ 可编辑 diff 视图 + 语法高亮编辑器（15 种语言）+ 多标签终端（ConPTY）。（✅ 活跃）
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) ⭐4 — 结构化安全 Git 工具：status/diff/log/branch/stage/commit/stash/show，带破坏性命令防护。（✅ 活跃）
 - [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) ⭐4 — Privacy-minimal heuristic per-turn verification summaries for DeepSeek Harness（✅ 活跃）
 - [dsh-wordbox](https://github.com/arcmosin/dsh-wordbox) ⭐4 — 输入框旁常用词箱：全局/项目词桶，一键插入。（✅ 活跃）

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -3575,6 +3575,25 @@
     "growth": 1
   },
   {
+    "id": "dsh-solution-explorer",
+    "name": "dsh-solution-explorer",
+    "type": "plugin",
+    "category": "ui",
+    "repository": "https://github.com/xiaoksio/dsh-solution-explorer",
+    "description": "VS Code-style right sidebar for the DSH Web GUI: file explorer plus source control (git status, stage/unstage/discard, commit, diff, commit graph, sync, branch/remote management) with an editable diff view, a syntax-highlighted editor (15 languages) and a multi-tab ConPTY terminal.",
+    "description_zh": "DSH Web GUI 右侧边栏：VS Code 风格文件浏览器 + 源代码管理（git 状态、暂存/取消暂存/丢弃、提交、diff、提交图、同步、分支/远程管理）+ 可编辑 diff 视图 + 语法高亮编辑器（15 种语言）+ 多标签终端（ConPTY）。",
+    "capabilities": [
+      "ui",
+      "files",
+      "git",
+      "terminal"
+    ],
+    "status": "active",
+    "verified": false,
+    "stars": 4,
+    "license": "MIT"
+  },
+  {
     "id": "dsh-verification-receipt",
     "name": "dsh-verification-receipt",
     "type": "plugin",

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "Top 10 and full list of 262 curated plugins for DeepSeek Harness (dsh)."
+description: "Top 10 and full list of 263 curated plugins for DeepSeek Harness (dsh)."
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,12 +30,12 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [TokenTracker](resources/tokentracker.md) | ⭐1,395 | Local-first AI token usage & cost tracker for 31 coding tools including Claude Code, Codex, Cursor, Gemini & DeepSeek Harness. | ✅ active |
 | 10 | [dsh-vision-router](resources/dsh-vision-router.md) | ⭐927 | Eyes for text-only agents: built-in free keyless vision chain plus pixel-level tools (Q&A, grounding, crop, OCR, SVG trace). | ✅ active |
 
-## Complete list (262)
+## Complete list (263)
 
 
-**UI & experience (56)**
+**UI & experience (57)**
 
-*Other (13)*
+*Other (14)*
 
 | Project | Stars | Description | Status |
 |---|---|---|---|
@@ -46,6 +46,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-plugin-anti-ads](resources/dsh-plugin-anti-ads.md) | ⭐10 | DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin | ✅ active |
 | [dsh-builtin-toggles](resources/dsh-builtin-toggles.md) | ⭐7 | Human-readable catalog of official DSH Web built-ins with safe GUI toggles. | ✅ active |
 | [dsh-split-panes](resources/dsh-split-panes.md) | ⭐5 | Split panes. | ✅ active |
+| [dsh-solution-explorer](resources/dsh-solution-explorer.md) | ⭐4 | VS Code-style right sidebar for the DSH Web GUI: file explorer plus source control (git status, stage/unstage/discard, commit, diff, commit graph, sync, branch/remote management) with an editable diff view, a syntax-highlighted editor (15 languages) and a multi-tab ConPTY terminal. | ✅ active |
 | [dsh-ultra-ui](resources/dsh-ultra-ui.md) | ⭐3 | Ultra UI plugin (cordis). | ✅ active |
 | [dsh-plugin-description](resources/dsh-plugin-description.md) | ⭐2 | mount one row in the composition and every plugin card on the Web Settings plugin list page gets a bilingual (zh/en) description; it also publishes the pluginDescriptions service so other plugins can register their own descriptions. | ✅ active |
 | [dsh-plugin-radar](resources/dsh-plugin-radar-bf2.md) | ⭐2 | Find DSH plugins by asking in plain language, then security-scan them before install | ✅ active |

--- a/docs/en/resources/dsh-solution-explorer.md
+++ b/docs/en/resources/dsh-solution-explorer.md
@@ -1,0 +1,25 @@
+---
+title: "dsh-solution-explorer"
+description: "VS Code-style right sidebar for the DSH Web GUI: file explorer plus source control (git status, stage/unstage/discard, commit, diff, commit graph, sync, branch/remote management) with an editable diff view, a syntax-highlighted editor (15 languages) and a multi-tab ConPTY terminal."
+keywords: "dsh-solution-explorer, ui, plugin, files, git, terminal, deepseek harness, dsh"
+---
+# dsh-solution-explorer
+
+> ⭐ 4 · ✅ active · plugin
+
+## One-liner
+
+VS Code-style right sidebar for the DSH Web GUI: file explorer plus source control (git status, stage/unstage/discard, commit, diff, commit graph, sync, branch/remote management) with an editable diff view, a syntax-highlighted editor (15 languages) and a multi-tab ConPTY terminal.
+
+## About
+
+VS Code-style right sidebar for the DSH Web GUI: file explorer plus source control (git status, stage/unstage/discard, commit, diff, commit graph, sync, branch/remote management) with an editable diff view, a syntax-highlighted editor (15 languages) and a multi-tab ConPTY terminal.
+
+## Author
+**[xiaoksio](https://github.com/xiaoksio)**
+
+## Links
+
+- [GitHub Repository](https://github.com/xiaoksio/dsh-solution-explorer)
+- [Full README](https://github.com/xiaoksio/dsh-solution-explorer#readme)
+- [Back to the Plugins list](../plugins.md)

--- a/docs/zh/plugins.md
+++ b/docs/zh/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（262 条）。"
+description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（263 条）。"
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,12 +30,12 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [TokenTracker](resources/tokentracker.md) | ⭐1,395 | 本地优先的 AI Token 用量与费用追踪器，支持 31 款编码工具（含 Claude Code、Codex、Cursor、Gemini 与 DeepSeek Harness）。 | ✅ 活跃 |
 | 10 | [dsh-vision-router](resources/dsh-vision-router.md) | ⭐927 | 纯文本 Agent 的眼睛：内置免费免密钥视觉链路 + 像素级工具（问答、grounding、裁剪、OCR、SVG 描摹）。 | ✅ 活跃 |
 
-## 完整列表（262）
+## 完整列表（263）
 
 
-**界面与体验（56）**
+**界面与体验（57）**
 
-*其他（13）*
+*其他（14）*
 
 | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|
@@ -46,6 +46,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-plugin-anti-ads](resources/dsh-plugin-anti-ads.md) | ⭐10 | DSH Web 广告拦截器，四层独立防御拦截 dsh-ads 插件的所有广告位 | DSH Web ad blocker with four independent defense layers targeting the dsh-ads plugin | ✅ 活跃 |
 | [dsh-builtin-toggles](resources/dsh-builtin-toggles.md) | ⭐7 | 官方 DSH Web 内置功能可读目录 + 安全 UI 开关。 | ✅ 活跃 |
 | [dsh-split-panes](resources/dsh-split-panes.md) | ⭐5 | Split panes. | ✅ 活跃 |
+| [dsh-solution-explorer](resources/dsh-solution-explorer.md) | ⭐4 | DSH Web GUI 右侧边栏：VS Code 风格文件浏览器 + 源代码管理（git 状态、暂存/取消暂存/丢弃、提交、diff、提交图、同步、分支/远程管理）+ 可编辑 diff 视图 + 语法高亮编辑器（15 种语言）+ 多标签终端（ConPTY）。 | ✅ 活跃 |
 | [dsh-ultra-ui](resources/dsh-ultra-ui.md) | ⭐3 | Ultra UI plugin (cordis). | ✅ 活跃 |
 | [dsh-plugin-description](resources/dsh-plugin-description.md) | ⭐2 | mount one row in the composition and every plugin card on the Web Settings plugin list page gets a bilingual (zh/en) description; it also publishes the pluginDescriptions service so other plugins can register their own descriptions. | ✅ 活跃 |
 | [dsh-plugin-radar](resources/dsh-plugin-radar-bf2.md) | ⭐2 | Find DSH plugins by asking in plain language, then security-scan them before install | ✅ 活跃 |

--- a/docs/zh/resources/dsh-solution-explorer.md
+++ b/docs/zh/resources/dsh-solution-explorer.md
@@ -1,0 +1,25 @@
+---
+title: "dsh-solution-explorer"
+description: "DSH Web GUI 右侧边栏：VS Code 风格文件浏览器 + 源代码管理（git 状态、暂存/取消暂存/丢弃、提交、diff、提交图、同步、分支/远程管理）+ 可编辑 diff 视图 + 语法高亮编辑器（15 种语言）+ 多标签终端（ConPTY）。"
+keywords: "dsh-solution-explorer, ui, plugin, files, git, terminal, deepseek harness, dsh"
+---
+# dsh-solution-explorer
+
+> ⭐ 4 · ✅ 活跃 · 插件
+
+## 一句话介绍
+
+DSH Web GUI 右侧边栏：VS Code 风格文件浏览器 + 源代码管理（git 状态、暂存/取消暂存/丢弃、提交、diff、提交图、同步、分支/远程管理）+ 可编辑 diff 视图 + 语法高亮编辑器（15 种语言）+ 多标签终端（ConPTY）。
+
+## 详细介绍
+
+DSH Web GUI 右侧边栏：VS Code 风格文件浏览器 + 源代码管理（git 状态、暂存/取消暂存/丢弃、提交、diff、提交图、同步、分支/远程管理）+ 可编辑 diff 视图 + 语法高亮编辑器（15 种语言）+ 多标签终端（ConPTY）。
+
+## 作者
+**[xiaoksio](https://github.com/xiaoksio)**
+
+## 链接
+
+- [GitHub 仓库](https://github.com/xiaoksio/dsh-solution-explorer)
+- [完整 README](https://github.com/xiaoksio/dsh-solution-explorer#readme)
+- [返回dsh-solution-explorer所在分类](../plugins.md)


### PR DESCRIPTION
## What

Add [xiaoksio/dsh-solution-explorer](https://github.com/xiaoksio/dsh-solution-explorer) to data/plugins.json (category: ui) and regenerate README/docs via the repo scripts.

## Changes

- data/plugins.json: new dsh-solution-explorer entry (id dsh-solution-explorer, type plugin, category ui, capabilities [ui, files, git, terminal], status active, stars 4, MIT)
- README.md / README.zh-CN.md: regenerated (plugins count 262 → 263)
- docs/en/plugins.md / docs/zh/plugins.md: regenerated category pages
- docs/en/resources/dsh-solution-explorer.md + docs/zh/resources/dsh-solution-explorer.md: new resource pages

scripts/validate.py --strict passes locally.

## About the plugin

VS Code-style right sidebar for the DSH Web GUI: file explorer + source control (status/stage/discard/commit/diff/graph/sync/branches/remotes), editable diff view, syntax-highlighted editor (15 languages) and a multi-tab ConPTY terminal. Repo carries the dsh-plugin topic.