### PR TITLE
Add dsh-whale-musume to data/plugins.json

### DIFF
--- a/data/plugins.json
+++ b/data/plugins.json
@@ -5156,5 +5156,24 @@
     "stars": 0,
     "_source_description": "Fork any DeepSeek Harness session into a different agent preset — a UI button with preset picker in the conversation header.",
     "_updated": "2026-08-21"
+  },
+  {
+    "id": "dsh-whale-musume",
+    "name": "dsh-whale-musume",
+    "type": "plugin",
+    "category": "fun",
+    "repository": "https://github.com/Sutera-Diffusus/dsh-whale-musume",
+    "description": "Whale-girl desktop pet for the DSH web UI: pat-to-raise growth, work-state poses, 494 dialogue lines, 30 achievements, drag physics, theme sync and a built-in settings panel; local-first, zero telemetry (MIT, 102 unit tests). / 元气鲸鱼娘桌宠：摸头养成、工作状态联动、494 条台词与 30 项成就；全本地零遥测。",
+    "description_zh": "元气鲸鱼娘桌宠：摸头养成、工作状态联动、494 条台词与 30 项成就，支持拖拽物理、主题适配与内置设置面板；全本地、零遥测（MIT，102 项单测）。",
+    "capabilities": [
+      "ui",
+      "fun"
+    ],
+    "status": "active",
+    "verified": false,
+    "stars": 42,
+    "_source_description": "Whale-girl desktop pet for the DSH web UI: pat-to-raise growth, work-state poses, 494 dialogue lines, 30 achievements, drag physics, theme sync and a built-in settings panel; local-first, zero telemetry (MIT, 102 unit tests). / 元气鲸鱼娘桌宠：摸头养成、工作状态联动、494 条台词与 30 项成就；全本地零遥测。",
+    "_updated": "2026-08-28",
+    "subcategory": "desktop-pet"
   }
 ]


### PR DESCRIPTION
Add [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) to data/plugins.json: whale-girl desktop pet for the DSH web UI (pat-to-raise growth, work-state poses, 494 dialogue lines, 30 achievements, built-in settings panel; local-first, zero telemetry; MIT; 102 unit tests). Repo tagged dsh-plugin.