### PR TITLE
docs: refresh handbook entry and resource links

### DIFF
--- a/docs/zh/resources/deepseek-harness-handbook.md
+++ b/docs/zh/resources/deepseek-harness-handbook.md
@@ -5,7 +5,7 @@ keywords: "deepseek-harness-handbook, learning, tutorial, coding, multi-agent, d
 ---
 # deepseek-harness-handbook
 
-> ⭐ 36 · ✅ 活跃 · 教程
+> ⭐ 78 · ✅ 活跃 · 教程 · v0.5.322
 
 ## 一句话介绍
 
@@ -13,7 +13,9 @@ Independent, source-backed handbook for DeepSeek AI's official DeepSeek Harness 
 
 ## 详细介绍
 
-[English](README.md) · [简体中文](docs/zh-CN/README.md) · [日本語](docs/ja/README.md) · [한국어](docs/ko/README.md) · [Español](docs/es/README.md) If this handbook saves you time, **star the repository** and watch releases. That signal helps more Agent builders find source-backed DeepSeek Harness guidance. **[Fix Windows picker crashes and truncation](https://sandbaseai.github.io/deepseek-harness-handbook/windows-folder-picker-crash.html)** · **[Fix API fetch failures](https://sandbaseai.github.io/deepsee
+[English](README.md) · [简体中文](docs/zh-CN/README.md) · [日本語](docs/ja/README.md) · [한국어](docs/ko/README.md) · [Español](docs/es/README.md)
+
+If this handbook saves you time, **star the repository** and watch releases. That signal helps more Agent builders find source-backed DeepSeek Harness guidance. **[Browse the 31-resource Agent-first map](https://sandbaseai.github.io/deepseek-harness-handbook/awesome-deepseek-harness-resources.html)** · **[Download the JSON index](https://sandbaseai.github.io/deepseek-harness-handbook/awesome-deepseek-harness-resources.json)** · **[Fix Windows picker crashes and truncation](https://sandbaseai.github.io/deepseek-harness-handbook/windows-folder-picker-crash.html)**
 
 ## 作者
 **[sandbaseai](https://github.com/sandbaseai)**


### PR DESCRIPTION
Refresh the handbook listing from the current public repository: 78 stars, v0.5.322, and the current 31-resource Agent-first map. Also repair the truncated API link and keep the listing useful for Chinese readers.