### PR TITLE
Add seo-audit: local & technical SEO audit skill for DeepSeek Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 | 9 | [dsh-skill-picker](https://github.com/a735624258/dsh-skill-picker) | ⭐25 | DSH 实现 workbuddy 同款选择 skill 功能 | WorkBuddy-style skill picker for DeepSeek Harness: pick a skill in the composer, insert the official /skill-name gesture, and DSH loads it with your message. | ✅ active |
 | 10 | [dsh-science](https://github.com/biociao/dsh-science) | ⭐24 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ active |
 
-#### Complete list (44)
+#### Complete list (45)
 
 - [memos](https://github.com/MemTensor/MemOS) ⭐10,873 — Self-evolving memory OS for LLM & AI Agents: ultra-persistent memory, hybrid-retrieval, and cross-task skill reuse, with 35.24% token savings and DeepSeek Harness support. (✅ active)
 - [dsh-routing-suite](https://github.com/yjh051108/dsh-routing-suite) ⭐6,940 — dsh-routing-suite — injector + router-standard kit: install the runtime injector first, then the task-aware reasoning-mode router preset (measured P1-P23). (✅ active)
@@ -670,6 +670,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [mattpocock-skills-dsh-zh](https://github.com/gongyijie85/mattpocock-skills-dsh-zh) ⭐1 — Matt Pocock's 25 skills fully translated to Chinese (technical terms kept in English with glosses). (✅ active)
 - [dsh-news-briefing](https://github.com/canghai666x/dsh-news-briefing)  — News briefing skill: multi-dimensional story scoring, anti-clickbait rules, content prioritization and Chinese editorial style. (✅ active)
 - [mstar-workflow](https://github.com/btspoony/mstar-workflow)  — A Skill-driven Harness/Loop Engineering Workflow Agent Plugin (💤 inactive)
+- [seo-audit](https://github.com/Haniubub/seo-toolkit)  — Full local & technical SEO audit toolkit for DeepSeek Harness: deterministic Python measurement (53 scripts) + LLM judgment (24 sub-skills, 18 agents), weighted scoring, gated multi-agent fan-out, schema.org, E-E-A-T, GBP, GEO/AI Overviews. (✅ active)
 
 ### Workflows & Automation
 
@@ -1748,7 +1749,7 @@ awesome-deepseek-harness/
 | 9 | [dsh-skill-picker](https://github.com/a735624258/dsh-skill-picker) | ⭐25 | DSH 实现 workbuddy 同款选择 skill 功能 | WorkBuddy-style skill picker for DeepSeek Harness: pick a skill in the composer, insert the official /skill-name gesture, and DSH loads it with your message. | ✅ active |
 | 10 | [dsh-science](https://github.com/biociao/dsh-science) | ⭐24 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ active |
 
-#### Complete list (44)
+#### Complete list (45)
 
 - [memos](https://github.com/MemTensor/MemOS) ⭐10,873 — Self-evolving memory OS for LLM & AI Agents: ultra-persistent memory, hybrid-retrieval, and cross-task skill reuse, with 35.24% token savings and DeepSeek Harness support. (✅ active)
 - [dsh-routing-suite](https://github.com/yjh051108/dsh-routing-suite) ⭐6,940 — dsh-routing-suite — injector + router-standard kit: install the runtime injector first, then the task-aware reasoning-mode router preset (measured P1-P23). (✅ active)
@@ -1794,6 +1795,7 @@ awesome-deepseek-harness/
 - [mattpocock-skills-dsh-zh](https://github.com/gongyijie85/mattpocock-skills-dsh-zh) ⭐1 — Matt Pocock's 25 skills fully translated to Chinese (technical terms kept in English with glosses). (✅ active)
 - [dsh-news-briefing](https://github.com/canghai666x/dsh-news-briefing)  — News briefing skill: multi-dimensional story scoring, anti-clickbait rules, content prioritization and Chinese editorial style. (✅ active)
 - [mstar-workflow](https://github.com/btspoony/mstar-workflow)  — A Skill-driven Harness/Loop Engineering Workflow Agent Plugin (💤 inactive)
+- [seo-audit](https://github.com/Haniubub/seo-toolkit)  — Full local & technical SEO audit toolkit for DeepSeek Harness: deterministic Python measurement (53 scripts) + LLM judgment (24 sub-skills, 18 agents), weighted scoring, gated multi-agent fan-out, schema.org, E-E-A-T, GBP, GEO/AI Overviews. (✅ active)
 
 ### Workflows & Automation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -625,7 +625,7 @@ dsh web
 | 9 | [dsh-skill-picker](https://github.com/a735624258/dsh-skill-picker) | ⭐25 | DSH 实现 workbuddy 同款选择 skill 功能 | WorkBuddy-style skill picker for DeepSeek Harness: pick a skill in the composer, insert the official /skill-name gesture, and DSH loads it with your message. | ✅ 活跃 |
 | 10 | [dsh-science](https://github.com/biociao/dsh-science) | ⭐24 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ 活跃 |
 
-#### 完整列表（44）
+#### 完整列表（45）
 
 - [memos](https://github.com/MemTensor/MemOS) ⭐10,873 — Self-evolving memory OS for LLM & AI Agents: ultra-persistent memory, hybrid-retrieval, and cross-task skill reuse, with 35.24% token savings and DeepSeek Harness support.（✅ 活跃）
 - [dsh-routing-suite](https://github.com/yjh051108/dsh-routing-suite) ⭐6,940 — dsh-routing-suite — injector + router-standard kit: install the runtime injector first, then the task-aware reasoning-mode router preset (measured P1-P23).（✅ 活跃）
@@ -671,6 +671,7 @@ dsh web
 - [mattpocock-skills-dsh-zh](https://github.com/gongyijie85/mattpocock-skills-dsh-zh) ⭐1 — Matt Pocock 25 个技能正文全译中文（技术术语保留英文并附注释）。（✅ 活跃）
 - [dsh-news-briefing](https://github.com/canghai666x/dsh-news-briefing)  — 新闻简报技能：多维故事评分、反标题党规则、内容优先级与中文编辑风格。（✅ 活跃）
 - [mstar-workflow](https://github.com/btspoony/mstar-workflow)  — A Skill-driven Harness/Loop Engineering Workflow Agent Plugin（💤 停更）
+- [seo-audit](https://github.com/Haniubub/seo-toolkit)  — 面向 DeepSeek Harness 的本地化与技术 SEO 审计工具包：确定性 Python 测量（53 个脚本）+ LLM 判断（24 个子技能、18 个代理）、加权评分、按业务类型门控的多代理扇出、schema.org、E-E-A-T、GBP、GEO/AI Overviews。（✅ 活跃）
 
 ### Workflows & Automation
 
@@ -1749,7 +1750,7 @@ awesome-deepseek-harness/
 | 9 | [dsh-skill-picker](https://github.com/a735624258/dsh-skill-picker) | ⭐25 | DSH 实现 workbuddy 同款选择 skill 功能 | WorkBuddy-style skill picker for DeepSeek Harness: pick a skill in the composer, insert the official /skill-name gesture, and DSH loads it with your message. | ✅ 活跃 |
 | 10 | [dsh-science](https://github.com/biociao/dsh-science) | ⭐24 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ 活跃 |
 
-#### 完整列表（44）
+#### 完整列表（45）
 
 - [memos](https://github.com/MemTensor/MemOS) ⭐10,873 — Self-evolving memory OS for LLM & AI Agents: ultra-persistent memory, hybrid-retrieval, and cross-task skill reuse, with 35.24% token savings and DeepSeek Harness support.（✅ 活跃）
 - [dsh-routing-suite](https://github.com/yjh051108/dsh-routing-suite) ⭐6,940 — dsh-routing-suite — injector + router-standard kit: install the runtime injector first, then the task-aware reasoning-mode router preset (measured P1-P23).（✅ 活跃）
@@ -1795,6 +1796,7 @@ awesome-deepseek-harness/
 - [mattpocock-skills-dsh-zh](https://github.com/gongyijie85/mattpocock-skills-dsh-zh) ⭐1 — Matt Pocock 25 个技能正文全译中文（技术术语保留英文并附注释）。（✅ 活跃）
 - [dsh-news-briefing](https://github.com/canghai666x/dsh-news-briefing)  — 新闻简报技能：多维故事评分、反标题党规则、内容优先级与中文编辑风格。（✅ 活跃）
 - [mstar-workflow](https://github.com/btspoony/mstar-workflow)  — A Skill-driven Harness/Loop Engineering Workflow Agent Plugin（💤 停更）
+- [seo-audit](https://github.com/Haniubub/seo-toolkit)  — 面向 DeepSeek Harness 的本地化与技术 SEO 审计工具包：确定性 Python 测量（53 个脚本）+ LLM 判断（24 个子技能、18 个代理）、加权评分、按业务类型门控的多代理扇出、schema.org、E-E-A-T、GBP、GEO/AI Overviews。（✅ 活跃）
 
 ### Workflows & Automation
 

--- a/data/skills.json
+++ b/data/skills.json
@@ -773,5 +773,22 @@
     "stars": 0,
     "_source_description": "A Skill-driven Harness/Loop Engineering Workflow Agent Plugin",
     "_updated": "2026-08-14"
+  },
+  {
+    "id": "seo-audit",
+    "name": "seo-audit",
+    "type": "skill",
+    "category": "research",
+    "repository": "https://github.com/Haniubub/seo-toolkit",
+    "description": "Full local & technical SEO audit toolkit for DeepSeek Harness: deterministic Python measurement (53 scripts) + LLM judgment (24 sub-skills, 18 agents), weighted scoring, gated multi-agent fan-out, schema.org, E-E-A-T, GBP, GEO/AI Overviews.",
+    "description_zh": "面向 DeepSeek Harness 的本地化与技术 SEO 审计工具包：确定性 Python 测量（53 个脚本）+ LLM 判断（24 个子技能、18 个代理）、加权评分、按业务类型门控的多代理扇出、schema.org、E-E-A-T、GBP、GEO/AI Overviews。",
+    "capabilities": [
+      "search",
+      "research",
+      "multi-agent"
+    ],
+    "status": "active",
+    "verified": false,
+    "stars": 0
   }
 ]

--- a/docs/en/resources/seo-audit.md
+++ b/docs/en/resources/seo-audit.md
@@ -1,0 +1,25 @@
+---
+title: "seo-audit"
+description: "Full local & technical SEO audit toolkit for DeepSeek Harness: deterministic Python measurement (53 scripts) + LLM judgment (24 sub-skills, 18 agents), weighted scoring, gated multi-agent fan-out, schema.org, E-E-A-T, GBP, GEO/AI Overviews."
+keywords: "seo-audit, research, skill, search, multi-agent, deepseek harness, dsh"
+---
+# seo-audit
+
+> ⭐ 0 · ✅ active · skill
+
+## One-liner
+
+Full local & technical SEO audit toolkit for DeepSeek Harness: deterministic Python measurement (53 scripts) + LLM judgment (24 sub-skills, 18 agents), weighted scoring, gated multi-agent fan-out, schema.org, E-E-A-T, GBP, GEO/AI Overviews.
+
+## About
+
+Full local & technical SEO audit toolkit for DeepSeek Harness: deterministic Python measurement (53 scripts) + LLM judgment (24 sub-skills, 18 agents), weighted scoring, gated multi-agent fan-out, schema.org, E-E-A-T, GBP, GEO/AI Overviews.
+
+## Author
+**[Haniubub](https://github.com/Haniubub)**
+
+## Links
+
+- [GitHub Repository](https://github.com/Haniubub/seo-toolkit)
+- [Full README](https://github.com/Haniubub/seo-toolkit#readme)
+- [Back to the Skills list](../skills.md)

--- a/docs/en/skills.md
+++ b/docs/en/skills.md
@@ -1,6 +1,6 @@
 ---
 title: "Skills"
-description: "Top 10 and full list of 44 curated skills for DeepSeek Harness (dsh)."
+description: "Top 10 and full list of 45 curated skills for DeepSeek Harness (dsh)."
 keywords: "deepseek harness, dsh, skills, plugin, awesome"
 ---
 # Skills
@@ -30,7 +30,7 @@ keywords: "deepseek harness, dsh, skills, plugin, awesome"
 | 9 | [dsh-skill-picker](resources/dsh-skill-picker.md) | ⭐25 | DSH 实现 workbuddy 同款选择 skill 功能 | WorkBuddy-style skill picker for DeepSeek Harness: pick a skill in the composer, insert the official /skill-name gesture, and DSH loads it with your message. | ✅ active |
 | 10 | [dsh-science](resources/dsh-science.md) | ⭐24 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ active |
 
-## Complete list (44)
+## Complete list (45)
 
 
 **Learning (32)**
@@ -82,13 +82,14 @@ keywords: "deepseek harness, dsh, skills, plugin, awesome"
 | [mattpocock-skills-dsh](resources/mattpocock-skills-dsh.md) | ⭐2 | Matt Pocock full promoted skill set (25 SKILL.md: grilling, writing-for-agents, wait-what, TDD, code review, wayfinder, ask-matt router) ported to DSH. | ✅ active |
 | [mattpocock-skills-dsh-zh](resources/mattpocock-skills-dsh-zh.md) | ⭐1 | Matt Pocock's 25 skills fully translated to Chinese (technical terms kept in English with glosses). | ✅ active |
 
-**Research (3)**
+**Research (4)**
 
 | Project | Stars | Description | Status |
 |---|---|---|---|
 | [dsh-book2skill](resources/dsh-book2skill.md) | ⭐4 | Book-to-skill plugin: a 5-stage long task that fetches, parses, understands, generates and installs a skill. | ✅ active |
 | [dsh-web-novel-research](resources/dsh-web-novel-research.md) | ⭐3 | Chinese web-novel plot lookup skill: free mirror-site workflow with GBK decoding and duplicate-chapter disambiguation. | ✅ active |
 | [dsh-news-briefing](resources/dsh-news-briefing.md) | – | News briefing skill: multi-dimensional story scoring, anti-clickbait rules, content prioritization and Chinese editorial style. | ✅ active |
+| [seo-audit](resources/seo-audit.md) | – | Full local & technical SEO audit toolkit for DeepSeek Harness: deterministic Python measurement (53 scripts) + LLM judgment (24 sub-skills, 18 agents), weighted scoring, gated multi-agent fan-out, schema.org, E-E-A-T, GBP, GEO/AI Overviews. | ✅ active |
 
 **UI & experience (1)**
 

--- a/docs/zh/resources/seo-audit.md
+++ b/docs/zh/resources/seo-audit.md
@@ -1,0 +1,25 @@
+---
+title: "seo-audit"
+description: "面向 DeepSeek Harness 的本地化与技术 SEO 审计工具包：确定性 Python 测量（53 个脚本）+ LLM 判断（24 个子技能、18 个代理）、加权评分、按业务类型门控的多代理扇出、schema.org、E-E-A-T、GBP、GEO/AI Overviews。"
+keywords: "seo-audit, research, skill, search, multi-agent, deepseek harness, dsh"
+---
+# seo-audit
+
+> ⭐ 0 · ✅ 活跃 · 技能
+
+## 一句话介绍
+
+面向 DeepSeek Harness 的本地化与技术 SEO 审计工具包：确定性 Python 测量（53 个脚本）+ LLM 判断（24 个子技能、18 个代理）、加权评分、按业务类型门控的多代理扇出、schema.org、E-E-A-T、GBP、GEO/AI Overviews。
+
+## 详细介绍
+
+面向 DeepSeek Harness 的本地化与技术 SEO 审计工具包：确定性 Python 测量（53 个脚本）+ LLM 判断（24 个子技能、18 个代理）、加权评分、按业务类型门控的多代理扇出、schema.org、E-E-A-T、GBP、GEO/AI Overviews。
+
+## 作者
+**[Haniubub](https://github.com/Haniubub)**
+
+## 链接
+
+- [GitHub 仓库](https://github.com/Haniubub/seo-toolkit)
+- [完整 README](https://github.com/Haniubub/seo-toolkit#readme)
+- [返回seo-audit所在分类](../skills.md)

--- a/docs/zh/skills.md
+++ b/docs/zh/skills.md
@@ -1,6 +1,6 @@
 ---
 title: "Skills"
-description: "DeepSeek Harness (dsh) 精选 skills：🔥 Top 10 与完整列表（44 条）。"
+description: "DeepSeek Harness (dsh) 精选 skills：🔥 Top 10 与完整列表（45 条）。"
 keywords: "deepseek harness, dsh, skills, plugin, awesome"
 ---
 # Skills
@@ -30,7 +30,7 @@ keywords: "deepseek harness, dsh, skills, plugin, awesome"
 | 9 | [dsh-skill-picker](resources/dsh-skill-picker.md) | ⭐25 | DSH 实现 workbuddy 同款选择 skill 功能 | WorkBuddy-style skill picker for DeepSeek Harness: pick a skill in the composer, insert the official /skill-name gesture, and DSH loads it with your message. | ✅ 活跃 |
 | 10 | [dsh-science](resources/dsh-science.md) | ⭐24 | Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics. | ✅ 活跃 |
 
-## 完整列表（44）
+## 完整列表（45）
 
 
 **学习（32）**
@@ -82,13 +82,14 @@ keywords: "deepseek harness, dsh, skills, plugin, awesome"
 | [mattpocock-skills-dsh](resources/mattpocock-skills-dsh.md) | ⭐2 | Matt Pocock 完整发布技能集（25 个 SKILL.md：grilling、writing-for-agents、wait-what、TDD、code-review、wayfinder、ask-matt 路由等）的 DSH 移植。 | ✅ 活跃 |
 | [mattpocock-skills-dsh-zh](resources/mattpocock-skills-dsh-zh.md) | ⭐1 | Matt Pocock 25 个技能正文全译中文（技术术语保留英文并附注释）。 | ✅ 活跃 |
 
-**研究（3）**
+**研究（4）**
 
 | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|
 | [dsh-book2skill](resources/dsh-book2skill.md) | ⭐4 | 书转技能插件：获取→解析→理解→生成→安装的五阶段长任务。 | ✅ 活跃 |
 | [dsh-web-novel-research](resources/dsh-web-novel-research.md) | ⭐3 | 中文网文情节查证技能：免费镜像站流程，GBK 解码与跨卷重复章节消歧。 | ✅ 活跃 |
 | [dsh-news-briefing](resources/dsh-news-briefing.md) | – | 新闻简报技能：多维故事评分、反标题党规则、内容优先级与中文编辑风格。 | ✅ 活跃 |
+| [seo-audit](resources/seo-audit.md) | – | 面向 DeepSeek Harness 的本地化与技术 SEO 审计工具包：确定性 Python 测量（53 个脚本）+ LLM 判断（24 个子技能、18 个代理）、加权评分、按业务类型门控的多代理扇出、schema.org、E-E-A-T、GBP、GEO/AI Overviews。 | ✅ 活跃 |
 
 **界面与体验（1）**
 


### PR DESCRIPTION
## What

Add [`seo-audit`](https://github.com/Haniubub/seo-toolkit) to `data/skills.json` (type `skill`).

A full local & technical SEO audit toolkit for DeepSeek Harness:
- **Deterministic measurement layer** — local Python CLI (53 scripts, $0 in LLM tokens) for technical, on-page, schema.org/JSON-LD, local/GBP, Core Web Vitals, content/E-E-A-T, sitemap, hreflang.
- **LLM judgment layer** — 24 sub-skills + 18 agents (E-E-A-T, GEO/AI Overviews, Local/GBP, SXO, programmatic, competitor pages, e-commerce, image SEO).
- **Weighted, Google-aligned scoring** across 7 categories; primary-source Google guidance.
- **Gated multi-agent fan-out** by business type (never runs all agents), plus credentials gating.
- Runs locally, no SaaS, no per-site pricing.

## Checklist

- [x] Entry added to `data/skills.json` following `schemas/resource.schema.json`
- [x] `python3 scripts/validate.py` → **PASS (0 errors, 0 warnings)**
- [x] `python3 scripts/generate-readme.py` -> regenerated `README.md` + `README.zh-CN.md`

## Files changed

- `data/skills.json` (+1 entry)
- `README.md` 
- `README.zh-CN.md` 