### PR TITLE
Add moguiyu/dsh-tavily (search · web-search plugin)

### DIFF
--- a/data/plugins.json
+++ b/data/plugins.json
@@ -8220,5 +8220,20 @@
     "stars": 0,
     "install": "dsh plugin --profile web add github:zhengjy01/dsh-qqbot-panel",
     "license": "MIT"
+  },
+  {
+    "id": "dsh-tavily",
+    "name": "dsh-tavily",
+    "type": "plugin",
+    "category": "search",
+    "subcategory": "web-search",
+    "repository": "https://github.com/moguiyu/dsh-tavily",
+    "description": "Opt-in advanced Tavily search for DeepSeek Harness: tavily_search plus extract/map/crawl model tools with multi-key rotation and 401/429 failover, a live usage gauge, and a keyed settings card; one version serves DSH 0.1.0-rc.7 - 0.1.1-rc.x and 0.1.2-alpha.x hosts (seam detected at runtime); the built-in web_search is never replaced.",
+    "description_zh": "面向 DeepSeek Harness 的可选 Tavily 搜索增强：tavily_search 及 extract/map/crawl 模型工具，多密钥轮换与 401/429 故障转移、实时用量仪表盘与 keyed 设置卡片；同一版本覆盖 DSH 0.1.0-rc.7 - 0.1.1-rc.x 与 0.1.2-alpha.x 宿主（运行时自动探测）；绝不替换内置 web_search。",
+    "capabilities": [
+      "search"
+    ],
+    "status": "active",
+    "verified": false
   }
 ]


### PR DESCRIPTION
Per CONTRIBUTING: adds one entry to `data/plugins.json` (category `search`, subcategory `web-search`, capabilities `["search"]`, status `active`).

**Repo:** https://github.com/moguiyu/dsh-tavily (MIT)
**npm:** [@moguiyu/dsh-tavily](https://www.npmjs.com/package/@moguiyu/dsh-tavily) — latest 0.2.1 · install: `dsh plugin add @moguiyu/dsh-tavily`
**Release:** [v0.2.1](https://github.com/moguiyu/dsh-tavily/releases/tag/v0.2.1) (Latest)

What it does: opt-in advanced Tavily search — `tavily_search` plus extract/map/crawl model tools, multi-key rotation with 401/429 failover, a live usage gauge, and a keyed settings card. One version serves every current DSH host line (0.1.0-rc.7 – 0.1.1-rc.x and 0.1.2-alpha.x; seam detected at runtime), verified against real DSH providers on rc.8 and 0.1.2-alpha.2–alpha.4. The built-in `web_search` is never replaced (no provider seam; enforced by an in-repo verification suite).

Duplicate check: no existing entry for `moguiyu`/`dsh-tavily` in `data/plugins.json` (448 entries scanned). The `stars`/`_updated`/`growth` bookkeeping fields are intentionally omitted for your pipeline to fill.