### PR TITLE
Fix dsh-tool-policy category: tool policy, not vision

### DIFF
--- a/data/plugins.json
+++ b/data/plugins.json
@@ -18396,7 +18396,7 @@
     "id": "dsh-tool-policy",
     "name": "dsh-tool-policy",
     "type": "plugin",
-    "category": "vision",
+    "category": "security",
     "repository": "https://github.com/Drifter-yh/dsh-tool-policy",
     "description": "Declarative deny-by-default tool policy plugin for DeepSeek Harness",
     "description_zh": "Declarative deny-by-default tool policy plugin for DeepSeek Harness",
@@ -18413,8 +18413,7 @@
       "deepseek-harness",
       "dsh-plugin",
       "tool-policy"
-    ],
-    "subcategory": "vision-tools"
+    ]
   },
   {
     "id": "dsh-mobile-control",

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -33,9 +33,9 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ## Complete list (2814)
 
 
-**Vision & multimodal (1025)**
+**Vision & multimodal (1024)**
 
-*👁️ Vision tools (1025)*
+*👁️ Vision tools (1024)*
 
 | Project | Stars | Description | Status |
 |---|---|---|---|
@@ -368,7 +368,6 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-ssh-remote](resources/dsh-ssh-remote.md) | ⭐4 | SSH remote workspaces for DeepSeek Harness: browse/read/write remote files, run remote commands, with connection status dots. | ✅ active |
 | [dsh-survey](resources/dsh-survey.md) | ⭐4 | Questionnaire-style batch questioning plugin for DeepSeek Harness: 10+ questions at once (single/multi/yes-no toggle/compare/open), per-question skip, fullscreen overlay, two-column recap after submit | ✅ active |
 | [dsh-swarmdrop](resources/dsh-swarmdrop.md) | ⭐4 | Send files from your DeepSeek Harness agent straight to your phone, and reference what your phone sent back — no account, no public IP, end-to-end encrypted. | ✅ active |
-| [dsh-tool-policy](resources/dsh-tool-policy.md) | ⭐4 | Declarative deny-by-default tool policy plugin for DeepSeek Harness | ✅ active |
 | [dsh-traffic-light](resources/dsh-traffic-light.md) | ⭐4 | Multi-session agent status monitor for DeepSeek Harness. | ✅ active |
 | [dsh-usage-dashboard-plus](resources/dsh-usage-dashboard-plus.md) | ⭐4 | DeepSeek Harness usage dashboard with API balance, daily spend, external vision-call accounting, per-model stats, call logs, cache rate, TTFT, and CSV export. | ✅ active |
 | [dsh-usage-monitor](resources/dsh-usage-monitor.md) | ⭐4 | Session-log usage dashboard for DeepSeek Harness | ✅ active |
@@ -2975,6 +2974,14 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-fund-research](resources/dsh-fund-research.md) | ⭐18 | Chinese public mutual fund research: public-source data collection and deterministic manager/portfolio metrics. | ✅ active |
 | [dsh-trading](resources/dsh-trading.md) | ⭐12 | Research-only trading workbench for DSH: typed market-data seam (BYO provider), multi-timeframe indicator snapshots, interactive chart cards with provenance-gated annotations, and a risk-guard denying execution-shaped tool calls. No execution seam by construction. | ✅ active |
 
+**Security (3)**
+
+| Project | Stars | Description | Status |
+|---|---|---|---|
+| [xgone/dsh-remote](resources/xgone-dsh-remote.md) | ⭐41 | Remote access & authentication for DeepSeek Harness web UI: account/password login gate, MFA (TOTP), signed session cookies, role-based access, in-browser directory picker, and a Settings page for account management. | 🧪 experimental |
+| [dsh-guardian](resources/dsh-guardian.md) | ⭐4 | Agent security guardrail: intercepts and audits every tool call, requiring human confirmation on sensitive operations. | ✅ active |
+| [dsh-tool-policy](resources/dsh-tool-policy.md) | ⭐4 | Declarative deny-by-default tool policy plugin for DeepSeek Harness | ✅ active |
+
 **Automation (3)**
 
 | Project | Stars | Description | Status |
@@ -2982,13 +2989,6 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-click](resources/dsh-click.md) | ⭐4 | Cross-platform native desktop control (Windows first): screenshot, screen read, click/type/scroll/key, app list and launch. | ✅ active |
 | [dsh-qqbot-panel](resources/dsh-qqbot-panel.md) | – | Visual web settings panel for the official @tencent-connect/dsh-qqbot plugin: manage AppID/AppSecret, c2c & group access/allowlists, workspace picker, and scan-to-bind from the DSH web settings page. | ✅ active |
 | [dsh-task-dispatcher](resources/dsh-task-dispatcher.md) | – | TickTick (滴答清单) daily task dispatcher for DeepSeek Harness: interval-based pulls of today's due tasks, notify (flomo + macOS), optional auto-execute in headless DSH sessions, worker workspace selection, and a web task board. | ✅ active |
-
-**Security (2)**
-
-| Project | Stars | Description | Status |
-|---|---|---|---|
-| [xgone/dsh-remote](resources/xgone-dsh-remote.md) | ⭐41 | Remote access & authentication for DeepSeek Harness web UI: account/password login gate, MFA (TOTP), signed session cookies, role-based access, in-browser directory picker, and a Settings page for account management. | 🧪 experimental |
-| [dsh-guardian](resources/dsh-guardian.md) | ⭐4 | Agent security guardrail: intercepts and audits every tool call, requiring human confirmation on sensitive operations. | ✅ active |
 
 **Multi-agent (1)**
 

--- a/docs/en/resources/dsh-tool-policy.md
+++ b/docs/en/resources/dsh-tool-policy.md
@@ -1,7 +1,7 @@
 ---
 title: "dsh-tool-policy"
 description: "Declarative deny-by-default tool policy plugin for DeepSeek Harness"
-keywords: "dsh-tool-policy, vision, plugin, coding, deepseek harness, dsh"
+keywords: "dsh-tool-policy, security, plugin, coding, deepseek harness, dsh"
 ---
 # dsh-tool-policy
 
@@ -9,10 +9,9 @@ keywords: "dsh-tool-policy, vision, plugin, coding, deepseek harness, dsh"
 
 | | | | |
 |---|---|---|---|
-| Type | plugin | Category | Vision & multimodal |
+| Type | plugin | Category | Security |
 | Stars | ⭐ 4 | Status | ✅ active |
 | Author | [Drifter-yh](https://github.com/Drifter-yh) | Updated | — |
-| Subcategory | 👁️ Vision tools | Capabilities | coding |
 
 ## One-liner
 

--- a/docs/zh/plugins.md
+++ b/docs/zh/plugins.md
@@ -33,9 +33,9 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ## 完整列表（2814）
 
 
-**视觉与多模态（1025）**
+**视觉与多模态（1024）**
 
-*👁️ 视觉工具（1025）*
+*👁️ 视觉工具（1024）*
 
 | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|
@@ -368,7 +368,6 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-ssh-remote](resources/dsh-ssh-remote.md) | ⭐4 | SSH remote workspaces for DeepSeek Harness: browse/read/write remote files, run remote commands, with connection status dots. | ✅ 活跃 |
 | [dsh-survey](resources/dsh-survey.md) | ⭐4 | Questionnaire-style batch questioning plugin for DeepSeek Harness: 10+ questions at once (single/multi/yes-no toggle/compare/open), per-question skip, fullscreen overlay, two-column recap after submit | ✅ 活跃 |
 | [dsh-swarmdrop](resources/dsh-swarmdrop.md) | ⭐4 | Send files from your DeepSeek Harness agent straight to your phone, and reference what your phone sent back — no account, no public IP, end-to-end encrypted. | ✅ 活跃 |
-| [dsh-tool-policy](resources/dsh-tool-policy.md) | ⭐4 | Declarative deny-by-default tool policy plugin for DeepSeek Harness | ✅ 活跃 |
 | [dsh-traffic-light](resources/dsh-traffic-light.md) | ⭐4 | Multi-session agent status monitor for DeepSeek Harness. | ✅ 活跃 |
 | [dsh-usage-dashboard-plus](resources/dsh-usage-dashboard-plus.md) | ⭐4 | DeepSeek Harness usage dashboard with API balance, daily spend, external vision-call accounting, per-model stats, call logs, cache rate, TTFT, and CSV export. | ✅ 活跃 |
 | [dsh-usage-monitor](resources/dsh-usage-monitor.md) | ⭐4 | Session-log usage dashboard for DeepSeek Harness | ✅ 活跃 |
@@ -2975,6 +2974,14 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-fund-research](resources/dsh-fund-research.md) | ⭐18 | 中国公募基金研究：公开源数据采集 + 确定性经理/组合指标计算。 | ✅ 活跃 |
 | [dsh-trading](resources/dsh-trading.md) | ⭐12 | 纯研究型交易工作台插件：类型化行情数据缝（自带 provider）、多周期指标快照、带溯源门控标注的交互图表卡片，以及拒绝执行型工具调用的风险护栏——架构上不提供执行能力。 | ✅ 活跃 |
 
+**安全（3）**
+
+| 项目 | 星数 | 说明 | 状态 |
+|---|---|---|---|
+| [xgone/dsh-remote](resources/xgone-dsh-remote.md) | ⭐41 | 让 DeepSeek Harness 可以被安全地远程访问：账号密码认证 + MFA（TOTP）登录门禁、签名会话 Cookie、角色权限、浏览器内目录选择器、账号管理设置页。 | 🧪 实验性 |
+| [dsh-guardian](resources/dsh-guardian.md) | ⭐4 | Agent 安全护栏：拦截并审计所有工具调用，命中敏感操作就要求人工确认。 | ✅ 活跃 |
+| [dsh-tool-policy](resources/dsh-tool-policy.md) | ⭐4 | Declarative deny-by-default tool policy plugin for DeepSeek Harness | ✅ 活跃 |
+
 **自动化（3）**
 
 | 项目 | 星数 | 说明 | 状态 |
@@ -2982,13 +2989,6 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-click](resources/dsh-click.md) | ⭐4 | 跨平台原生桌面控制（Windows 优先）：截图、读屏、点击/输入/滚动/按键、应用列表与启动。 | ✅ 活跃 |
 | [dsh-qqbot-panel](resources/dsh-qqbot-panel.md) | – | 为官方 @tencent-connect/dsh-qqbot 提供的可视化配置面板：管理 AppID/AppSecret、私聊/群聊访问模式与白名单、工作区选择、扫码绑定（Web 设置页）。 | ✅ 活跃 |
 | [dsh-task-dispatcher](resources/dsh-task-dispatcher.md) | – | DeepSeek Harness 的滴答清单任务派发器：按间隔拉取今天到期任务，flomo+macOS 通知，可选自动执行（每任务一个 headless 会话）、执行会话工作区选择与 Web 任务看板。 | ✅ 活跃 |
-
-**安全（2）**
-
-| 项目 | 星数 | 说明 | 状态 |
-|---|---|---|---|
-| [xgone/dsh-remote](resources/xgone-dsh-remote.md) | ⭐41 | 让 DeepSeek Harness 可以被安全地远程访问：账号密码认证 + MFA（TOTP）登录门禁、签名会话 Cookie、角色权限、浏览器内目录选择器、账号管理设置页。 | 🧪 实验性 |
-| [dsh-guardian](resources/dsh-guardian.md) | ⭐4 | Agent 安全护栏：拦截并审计所有工具调用，命中敏感操作就要求人工确认。 | ✅ 活跃 |
 
 **多智能体（1）**
 

--- a/docs/zh/resources/dsh-tool-policy.md
+++ b/docs/zh/resources/dsh-tool-policy.md
@@ -1,7 +1,7 @@
 ---
 title: "dsh-tool-policy"
 description: "Declarative deny-by-default tool policy plugin for DeepSeek Harness"
-keywords: "dsh-tool-policy, vision, plugin, coding, deepseek harness, dsh"
+keywords: "dsh-tool-policy, security, plugin, coding, deepseek harness, dsh"
 ---
 # dsh-tool-policy
 
@@ -9,10 +9,9 @@ keywords: "dsh-tool-policy, vision, plugin, coding, deepseek harness, dsh"
 
 | | | | |
 |---|---|---|---|
-| 类型 | 插件 | 分类 | 视觉与多模态 |
+| 类型 | 插件 | 分类 | 安全 |
 | 星数 | ⭐ 4 | 状态 | ✅ 活跃 |
 | 作者 | [Drifter-yh](https://github.com/Drifter-yh) | 更新时间 | — |
-| 子分类 | 👁️ 视觉工具 | 能力 | coding |
 
 ## 一句话介绍
 


### PR DESCRIPTION
## Summary

- Reclassify `dsh-tool-policy` from `vision / vision-tools` to the existing `security` category.
- Remove the incorrect `vision-tools` subcategory.
- Regenerate the bilingual plugin indexes and detail pages.

## Why

`dsh-tool-policy` is a declarative deny-by-default tool-policy and access-control plugin for DeepSeek Harness. It is not a vision or multimodal tool.

The repository already uses `security` for similar security-oriented plugins, so this reuses the existing taxonomy rather than introducing a new category.

## Validation

- `python3 scripts/validate.py --strict`
- `python3 scripts/generate-readme.py`
- `python3 scripts/generate-docs.py`
- `git diff --check`

The generated indexes and detail pages contain no remaining `dsh-tool-policy` references classified as a vision tool.

`check-links.py` could not complete because the local environment had no usable network access and the GitHub API was rate-limited without authentication. No URLs were changed by this PR.
