### PR TITLE
Add dsh-reach, dsh-ticktick and dsh-cert-mcp to the directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 | 9 | [memsearch](https://github.com/zilliztech/memsearch) | ⭐2,538 | Persistent, unified memory layer for all your AI agents (e.g. Claude Code, Codex, DSH), backed by Markdown and Milvus. / 面向所有 AI Agent（如 Claude Code、Codex、DSH）的持久化统一记忆层，基于 Markdown 与 Milvus。 | ✅ active |
 | 10 | [dsh-market](https://github.com/dsh-market/dsh-market) | ⭐1,582 | Visual plugin market inside DeepSeek Harness: browse, search and one-click install. | ✅ active |
 
-#### Complete list (2814)
+#### Complete list (2815)
 
 - [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) ⭐210,647 — DeepSeek Harness: Everything is a Plugin. (✅ active)
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。 (✅ active)
@@ -2962,6 +2962,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-terminal](https://github.com/lanshuye123/DSH-Terminal)  — DSH WebUI 终端(Terminal)插件。可以在WebUI中获得终端模拟器。 (✅ active)
 - [dsh-think-chinese](https://github.com/lingtima/dsh-think-chinese)  — DSH 插件：让模型始终用中文进行内部推理与思考（think in Chinese）。 (✅ active)
 - [dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter)  — DeepSeek Harness（DSH）客户端插件：将聊天视图中流式的 Think 思考预览替换为 实时 Token 数量显示。 (✅ active)
+- [dsh-ticktick](https://github.com/PerryLink/dsh-ticktick)  — TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint (✅ active)
 - [dsh-tool-backtest](https://github.com/dmsobtl/dsh-tool-backtest)  — DSH 插件：策略回测引擎 — 定义买卖信号，跑历史数据，输出绩效指标。 (✅ active)
 - [dsh-tool-playwright](https://github.com/cheng-nan01/dsh-tool-playwright)  — 一个给 DeepSeek Harness 用的插件：让 AI 能真的打开浏览器上网——打开网页、点按钮、填表单、翻页、看页面内容，就像人一样操作浏览器。 (✅ active)
 - [dsh-trace-repeat](https://github.com/p2coder/dsh-trace-repeat)  — 会话任务 Trace 原子记录/回放：把每次推理完成与工具执行记为不可变版本（含可复现元数据），支持版本时间线回放与从任意版本经 git worktree 恢复执行。 (✅ active)
@@ -3934,7 +3935,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 | 9 | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | ⭐133 | Super-injector plugin (cordis) for context injection. | ✅ active |
 | 10 | [dsh-crew](https://github.com/ZSeven-W/dsh-crew) | ⭐119 | DeepSeek Harness (DSH) plugin: dispatch work to DSH agents from Claude Code / Codex — native subagent progress, in-host worker sessions with per-tier presets, and a multimodal bridge that lends the text-only harness vision and image generation. | ✅ active |
 
-#### Complete list (493)
+#### Complete list (495)
 
 - [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐846 — Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. (✅ active)
 - [memtrace-public](https://github.com/syncable-dev/memtrace-public) ⭐459 — Structural memory for AI coding agents. Bi-temporal graph, MCP-native, zero LLM calls. Cursor · Claude Code · Codex · DeepSeek Harness · Hermes · VS Code · Windsurf. (✅ active)
@@ -4397,6 +4398,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-zen](https://github.com/zealot00/dsh-zen) ⭐1 — Zen mode for DeepSeek Harness Web UI: one-click immersive focus (hide sidebar/topbar), Ctrl+Shift+Z, pet auto-hide linkage (✅ active)
 - [mcp_guard](https://github.com/dshoneys/mcp_guard) ⭐1 — 本机 MCP / Agent 口扫描、监视与审计（loopback 未鉴权 tools/list、CORS）。DeepSeek Honeys. (✅ active)
 - [dsh-bib](https://github.com/youyli03/dsh-bib)  — Embed a controllable real-browser viewport inside DeepSeek Harness — shared by humans and AI agents via an Edge extension + local relay bridge. (✅ active)
+- [dsh-cert-mcp](https://github.com/PerryLink/dsh-cert-mcp)  — MCP server exposing the DSH plugin certification registry: get a certification, list certified plugins, and read the certification spec (✅ active)
 - [dsh-chat-width](https://github.com/AnakinCao/dsh-chat-width)  — DSH Web GUI plugin: adaptive chat content width — the middle area expands with screen resolution (1080p/2K/4K) when side panels are collapsed (injects CSS overriding --dsh-chat-content-width) (✅ active)
 - [dsh-chat-window-fold](https://github.com/dove-a/dsh-chat-window-fold)  — DSH web GUI plugin: auto fold/expand the chat window — bottom checkpoints hide old pages, top-scroll expands earlier messages with the viewport anchored. (✅ active)
 - [dsh-codex-side-outline](https://github.com/EnkiduGilgamesh/dsh-codex-side-outline)  — Codex style side outline for Deepseek Harness (✅ active)
@@ -4416,6 +4418,7 @@ Plugins intended to become active DSH bundles should expose the corresponding `d
 - [dsh-plugin-web-notify](https://github.com/vilicvane/dsh-plugin-web-notify)  — Browser notifications for the DeepSeek Harness Web GUI. (✅ active)
 - [dsh-queue-director](https://github.com/loklamlok/dsh-queue-director)  — DSH web plugin: reorder queued messages (up / down / top / bottom) before the agent processes them. (✅ active)
 - [dsh-qwen-multimodal](https://github.com/wuwangmao/dsh-qwen-multimodal)  — DSH bundle: Qwen multimodal bridge — vision (qwen3-vl), speech-to-text (qwen3-asr), text-to-image (qwen-image), for DeepSeek Harness (✅ active)
+- [dsh-reach](https://github.com/PerryLink/dsh-reach)  — Pushes DSH approval and question cards to IM channels (WeChat first) and answers them from chat, with a session console, per-channel security, and an open push service (✅ active)
 - [dsh-realtime-voice](https://github.com/martinbear1/dsh-realtime-voice)  — Realtime full-duplex voice Agent plugin for DeepSeek Harness WebUI and future WeChat Mini Program clients (✅ active)
 - [dsh-session-bridge](https://github.com/FuWenLianggit/dsh-session-bridge)  — Session-level multi-thread orchestration for DeepSeek Harness: create ordinary sessions, send queued or interrupt prompts to any session by id, and enumerate sessions. Installs globally, independent of any agent preset. (✅ active)
 - [dsh-side-chat](https://github.com/willwang0098/dsh-side-chat)  — Codex-style independent side chat for DeepSeek Harness Better Sidebar (✅ active)
@@ -4876,7 +4879,7 @@ awesome-deepseek-harness/
 | 9 | [memsearch](https://github.com/zilliztech/memsearch) | ⭐2,538 | Persistent, unified memory layer for all your AI agents (e.g. Claude Code, Codex, DSH), backed by Markdown and Milvus. / 面向所有 AI Agent（如 Claude Code、Codex、DSH）的持久化统一记忆层，基于 Markdown 与 Milvus。 | ✅ active |
 | 10 | [dsh-market](https://github.com/dsh-market/dsh-market) | ⭐1,582 | Visual plugin market inside DeepSeek Harness: browse, search and one-click install. | ✅ active |
 
-#### Complete list (2814)
+#### Complete list (2815)
 
 - [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) ⭐210,647 — DeepSeek Harness: Everything is a Plugin. (✅ active)
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。 (✅ active)
@@ -7668,6 +7671,7 @@ awesome-deepseek-harness/
 - [dsh-terminal](https://github.com/lanshuye123/DSH-Terminal)  — DSH WebUI 终端(Terminal)插件。可以在WebUI中获得终端模拟器。 (✅ active)
 - [dsh-think-chinese](https://github.com/lingtima/dsh-think-chinese)  — DSH 插件：让模型始终用中文进行内部推理与思考（think in Chinese）。 (✅ active)
 - [dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter)  — DeepSeek Harness（DSH）客户端插件：将聊天视图中流式的 Think 思考预览替换为 实时 Token 数量显示。 (✅ active)
+- [dsh-ticktick](https://github.com/PerryLink/dsh-ticktick)  — TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint (✅ active)
 - [dsh-tool-backtest](https://github.com/dmsobtl/dsh-tool-backtest)  — DSH 插件：策略回测引擎 — 定义买卖信号，跑历史数据，输出绩效指标。 (✅ active)
 - [dsh-tool-playwright](https://github.com/cheng-nan01/dsh-tool-playwright)  — 一个给 DeepSeek Harness 用的插件：让 AI 能真的打开浏览器上网——打开网页、点按钮、填表单、翻页、看页面内容，就像人一样操作浏览器。 (✅ active)
 - [dsh-trace-repeat](https://github.com/p2coder/dsh-trace-repeat)  — 会话任务 Trace 原子记录/回放：把每次推理完成与工具执行记为不可变版本（含可复现元数据），支持版本时间线回放与从任意版本经 git worktree 恢复执行。 (✅ active)
@@ -8640,7 +8644,7 @@ awesome-deepseek-harness/
 | 9 | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | ⭐133 | Super-injector plugin (cordis) for context injection. | ✅ active |
 | 10 | [dsh-crew](https://github.com/ZSeven-W/dsh-crew) | ⭐119 | DeepSeek Harness (DSH) plugin: dispatch work to DSH agents from Claude Code / Codex — native subagent progress, in-host worker sessions with per-tier presets, and a multimodal bridge that lends the text-only harness vision and image generation. | ✅ active |
 
-#### Complete list (493)
+#### Complete list (495)
 
 - [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐846 — Coding-oriented MCP tool collection that appears in the emerging DSH ecosystem: give any AI agent the ability to code. (✅ active)
 - [memtrace-public](https://github.com/syncable-dev/memtrace-public) ⭐459 — Structural memory for AI coding agents. Bi-temporal graph, MCP-native, zero LLM calls. Cursor · Claude Code · Codex · DeepSeek Harness · Hermes · VS Code · Windsurf. (✅ active)
@@ -9103,6 +9107,7 @@ awesome-deepseek-harness/
 - [dsh-zen](https://github.com/zealot00/dsh-zen) ⭐1 — Zen mode for DeepSeek Harness Web UI: one-click immersive focus (hide sidebar/topbar), Ctrl+Shift+Z, pet auto-hide linkage (✅ active)
 - [mcp_guard](https://github.com/dshoneys/mcp_guard) ⭐1 — 本机 MCP / Agent 口扫描、监视与审计（loopback 未鉴权 tools/list、CORS）。DeepSeek Honeys. (✅ active)
 - [dsh-bib](https://github.com/youyli03/dsh-bib)  — Embed a controllable real-browser viewport inside DeepSeek Harness — shared by humans and AI agents via an Edge extension + local relay bridge. (✅ active)
+- [dsh-cert-mcp](https://github.com/PerryLink/dsh-cert-mcp)  — MCP server exposing the DSH plugin certification registry: get a certification, list certified plugins, and read the certification spec (✅ active)
 - [dsh-chat-width](https://github.com/AnakinCao/dsh-chat-width)  — DSH Web GUI plugin: adaptive chat content width — the middle area expands with screen resolution (1080p/2K/4K) when side panels are collapsed (injects CSS overriding --dsh-chat-content-width) (✅ active)
 - [dsh-chat-window-fold](https://github.com/dove-a/dsh-chat-window-fold)  — DSH web GUI plugin: auto fold/expand the chat window — bottom checkpoints hide old pages, top-scroll expands earlier messages with the viewport anchored. (✅ active)
 - [dsh-codex-side-outline](https://github.com/EnkiduGilgamesh/dsh-codex-side-outline)  — Codex style side outline for Deepseek Harness (✅ active)
@@ -9122,6 +9127,7 @@ awesome-deepseek-harness/
 - [dsh-plugin-web-notify](https://github.com/vilicvane/dsh-plugin-web-notify)  — Browser notifications for the DeepSeek Harness Web GUI. (✅ active)
 - [dsh-queue-director](https://github.com/loklamlok/dsh-queue-director)  — DSH web plugin: reorder queued messages (up / down / top / bottom) before the agent processes them. (✅ active)
 - [dsh-qwen-multimodal](https://github.com/wuwangmao/dsh-qwen-multimodal)  — DSH bundle: Qwen multimodal bridge — vision (qwen3-vl), speech-to-text (qwen3-asr), text-to-image (qwen-image), for DeepSeek Harness (✅ active)
+- [dsh-reach](https://github.com/PerryLink/dsh-reach)  — Pushes DSH approval and question cards to IM channels (WeChat first) and answers them from chat, with a session console, per-channel security, and an open push service (✅ active)
 - [dsh-realtime-voice](https://github.com/martinbear1/dsh-realtime-voice)  — Realtime full-duplex voice Agent plugin for DeepSeek Harness WebUI and future WeChat Mini Program clients (✅ active)
 - [dsh-session-bridge](https://github.com/FuWenLianggit/dsh-session-bridge)  — Session-level multi-thread orchestration for DeepSeek Harness: create ordinary sessions, send queued or interrupt prompts to any session by id, and enumerate sessions. Installs globally, independent of any agent preset. (✅ active)
 - [dsh-side-chat](https://github.com/willwang0098/dsh-side-chat)  — Codex-style independent side chat for DeepSeek Harness Better Sidebar (✅ active)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,7 +171,7 @@ dsh web
 | 9 | [memsearch](https://github.com/zilliztech/memsearch) | ⭐2,538 | 面向所有 AI Agent（如 Claude Code、Codex、DSH）的持久化统一记忆层，基于 Markdown 与 Milvus 构建。 | ✅ 活跃 |
 | 10 | [dsh-market](https://github.com/dsh-market/dsh-market) | ⭐1,582 | DSH 内置可视化插件市场：浏览、搜索、一键安装。 | ✅ 活跃 |
 
-#### 完整列表（2814）
+#### 完整列表（2815）
 
 - [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) ⭐210,647 — DeepSeek Harness: Everything is a Plugin.（✅ 活跃）
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。（✅ 活跃）
@@ -2963,6 +2963,7 @@ dsh web
 - [dsh-terminal](https://github.com/lanshuye123/DSH-Terminal)  — DSH WebUI 终端(Terminal)插件。可以在WebUI中获得终端模拟器。（✅ 活跃）
 - [dsh-think-chinese](https://github.com/lingtima/dsh-think-chinese)  — DSH 插件：让模型始终用中文进行内部推理与思考（think in Chinese）。（✅ 活跃）
 - [dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter)  — DeepSeek Harness（DSH）客户端插件：将聊天视图中流式的 Think 思考预览替换为 实时 Token 数量显示。（✅ 活跃）
+- [dsh-ticktick](https://github.com/PerryLink/dsh-ticktick)  — TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点（✅ 活跃）
 - [dsh-tool-backtest](https://github.com/dmsobtl/dsh-tool-backtest)  — DSH 插件：策略回测引擎 — 定义买卖信号，跑历史数据，输出绩效指标。（✅ 活跃）
 - [dsh-tool-playwright](https://github.com/cheng-nan01/dsh-tool-playwright)  — 一个给 DeepSeek Harness 用的插件：让 AI 能真的打开浏览器上网——打开网页、点按钮、填表单、翻页、看页面内容，就像人一样操作浏览器。（✅ 活跃）
 - [dsh-trace-repeat](https://github.com/p2coder/dsh-trace-repeat)  — 会话任务 Trace 原子记录/回放：把每次推理完成与工具执行记为不可变版本（含可复现元数据），支持版本时间线回放与从任意版本经 git worktree 恢复执行。（✅ 活跃）
@@ -3935,7 +3936,7 @@ dsh web
 | 9 | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | ⭐133 | 上下文注入增强插件（cordis）。 | ✅ 活跃 |
 | 10 | [dsh-crew](https://github.com/ZSeven-W/dsh-crew) | ⭐119 | DeepSeek Harness (DSH) plugin: dispatch work to DSH agents from Claude Code / Codex — native subagent progress, in-host worker sessions with per-tier presets, and a multimodal bridge that lends the text-only harness vision and image generation. | ✅ 活跃 |
 
-#### 完整列表（493）
+#### 完整列表（495）
 
 - [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐846 — 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。（✅ 活跃）
 - [memtrace-public](https://github.com/syncable-dev/memtrace-public) ⭐459 — Structural memory for AI coding agents. Bi-temporal graph, MCP-native, zero LLM calls. Cursor · Claude Code · Codex · DeepSeek Harness · Hermes · VS Code · Windsurf.（✅ 活跃）
@@ -4398,6 +4399,7 @@ dsh web
 - [dsh-zen](https://github.com/zealot00/dsh-zen) ⭐1 — Zen mode for DeepSeek Harness Web UI: one-click immersive focus (hide sidebar/topbar), Ctrl+Shift+Z, pet auto-hide linkage（✅ 活跃）
 - [mcp_guard](https://github.com/dshoneys/mcp_guard) ⭐1 — 本机 MCP / Agent 口扫描、监视与审计（loopback 未鉴权 tools/list、CORS）。DeepSeek Honeys.（✅ 活跃）
 - [dsh-bib](https://github.com/youyli03/dsh-bib)  — Embed a controllable real-browser viewport inside DeepSeek Harness — shared by humans and AI agents via an Edge extension + local relay bridge.（✅ 活跃）
+- [dsh-cert-mcp](https://github.com/PerryLink/dsh-cert-mcp)  — 暴露 DSH 插件认证注册表的 MCP 服务器：查询认证、列出已认证插件、读取认证规范（✅ 活跃）
 - [dsh-chat-width](https://github.com/AnakinCao/dsh-chat-width)  — DSH Web GUI plugin: adaptive chat content width — the middle area expands with screen resolution (1080p/2K/4K) when side panels are collapsed (injects CSS overriding --dsh-chat-content-width)（✅ 活跃）
 - [dsh-chat-window-fold](https://github.com/dove-a/dsh-chat-window-fold)  — DSH web GUI plugin: auto fold/expand the chat window — bottom checkpoints hide old pages, top-scroll expands earlier messages with the viewport anchored.（✅ 活跃）
 - [dsh-codex-side-outline](https://github.com/EnkiduGilgamesh/dsh-codex-side-outline)  — Codex style side outline for Deepseek Harness（✅ 活跃）
@@ -4417,6 +4419,7 @@ dsh web
 - [dsh-plugin-web-notify](https://github.com/vilicvane/dsh-plugin-web-notify)  — Browser notifications for the DeepSeek Harness Web GUI.（✅ 活跃）
 - [dsh-queue-director](https://github.com/loklamlok/dsh-queue-director)  — DSH web plugin: reorder queued messages (up / down / top / bottom) before the agent processes them.（✅ 活跃）
 - [dsh-qwen-multimodal](https://github.com/wuwangmao/dsh-qwen-multimodal)  — DSH bundle: Qwen multimodal bridge — vision (qwen3-vl), speech-to-text (qwen3-asr), text-to-image (qwen-image), for DeepSeek Harness（✅ 活跃）
+- [dsh-reach](https://github.com/PerryLink/dsh-reach)  — 把 DSH 的审批卡与提问卡推送到 IM 渠道（先微信），可在聊天中直接作答，带会话控制台、逐渠道安全与开放推送服务（✅ 活跃）
 - [dsh-realtime-voice](https://github.com/martinbear1/dsh-realtime-voice)  — Realtime full-duplex voice Agent plugin for DeepSeek Harness WebUI and future WeChat Mini Program clients（✅ 活跃）
 - [dsh-session-bridge](https://github.com/FuWenLianggit/dsh-session-bridge)  — Session-level multi-thread orchestration for DeepSeek Harness: create ordinary sessions, send queued or interrupt prompts to any session by id, and enumerate sessions. Installs globally, independent of any agent preset.（✅ 活跃）
 - [dsh-side-chat](https://github.com/willwang0098/dsh-side-chat)  — Codex-style independent side chat for DeepSeek Harness Better Sidebar（✅ 活跃）
@@ -4877,7 +4880,7 @@ awesome-deepseek-harness/
 | 9 | [memsearch](https://github.com/zilliztech/memsearch) | ⭐2,538 | 面向所有 AI Agent（如 Claude Code、Codex、DSH）的持久化统一记忆层，基于 Markdown 与 Milvus 构建。 | ✅ 活跃 |
 | 10 | [dsh-market](https://github.com/dsh-market/dsh-market) | ⭐1,582 | DSH 内置可视化插件市场：浏览、搜索、一键安装。 | ✅ 活跃 |
 
-#### 完整列表（2814）
+#### 完整列表（2815）
 
 - [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) ⭐210,647 — DeepSeek Harness: Everything is a Plugin.（✅ 活跃）
 - [voyager](https://github.com/Nagi-ovo/voyager) ⭐19,755 — Enhancement suite for Gemini, AI Studio, Claude & ChatGPT — plus a prompt manager for any web UI, DeepSeek Harness included. / 面向 Gemini、AI Studio、Claude 与 ChatGPT 的增强套件；提示词管理器可用于任意 Web UI，含 DeepSeek Harness。（✅ 活跃）
@@ -7669,6 +7672,7 @@ awesome-deepseek-harness/
 - [dsh-terminal](https://github.com/lanshuye123/DSH-Terminal)  — DSH WebUI 终端(Terminal)插件。可以在WebUI中获得终端模拟器。（✅ 活跃）
 - [dsh-think-chinese](https://github.com/lingtima/dsh-think-chinese)  — DSH 插件：让模型始终用中文进行内部推理与思考（think in Chinese）。（✅ 活跃）
 - [dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter)  — DeepSeek Harness（DSH）客户端插件：将聊天视图中流式的 Think 思考预览替换为 实时 Token 数量显示。（✅ 活跃）
+- [dsh-ticktick](https://github.com/PerryLink/dsh-ticktick)  — TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点（✅ 活跃）
 - [dsh-tool-backtest](https://github.com/dmsobtl/dsh-tool-backtest)  — DSH 插件：策略回测引擎 — 定义买卖信号，跑历史数据，输出绩效指标。（✅ 活跃）
 - [dsh-tool-playwright](https://github.com/cheng-nan01/dsh-tool-playwright)  — 一个给 DeepSeek Harness 用的插件：让 AI 能真的打开浏览器上网——打开网页、点按钮、填表单、翻页、看页面内容，就像人一样操作浏览器。（✅ 活跃）
 - [dsh-trace-repeat](https://github.com/p2coder/dsh-trace-repeat)  — 会话任务 Trace 原子记录/回放：把每次推理完成与工具执行记为不可变版本（含可复现元数据），支持版本时间线回放与从任意版本经 git worktree 恢复执行。（✅ 活跃）
@@ -8641,7 +8645,7 @@ awesome-deepseek-harness/
 | 9 | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | ⭐133 | 上下文注入增强插件（cordis）。 | ✅ 活跃 |
 | 10 | [dsh-crew](https://github.com/ZSeven-W/dsh-crew) | ⭐119 | DeepSeek Harness (DSH) plugin: dispatch work to DSH agents from Claude Code / Codex — native subagent progress, in-host worker sessions with per-tier presets, and a multimodal bridge that lends the text-only harness vision and image generation. | ✅ 活跃 |
 
-#### 完整列表（493）
+#### 完整列表（495）
 
 - [Coding Tools MCP](https://github.com/xyTom/coding-tools-mcp) ⭐846 — 面向编码的 MCP 工具集：让任何 AI Agent 获得编码能力。（✅ 活跃）
 - [memtrace-public](https://github.com/syncable-dev/memtrace-public) ⭐459 — Structural memory for AI coding agents. Bi-temporal graph, MCP-native, zero LLM calls. Cursor · Claude Code · Codex · DeepSeek Harness · Hermes · VS Code · Windsurf.（✅ 活跃）
@@ -9104,6 +9108,7 @@ awesome-deepseek-harness/
 - [dsh-zen](https://github.com/zealot00/dsh-zen) ⭐1 — Zen mode for DeepSeek Harness Web UI: one-click immersive focus (hide sidebar/topbar), Ctrl+Shift+Z, pet auto-hide linkage（✅ 活跃）
 - [mcp_guard](https://github.com/dshoneys/mcp_guard) ⭐1 — 本机 MCP / Agent 口扫描、监视与审计（loopback 未鉴权 tools/list、CORS）。DeepSeek Honeys.（✅ 活跃）
 - [dsh-bib](https://github.com/youyli03/dsh-bib)  — Embed a controllable real-browser viewport inside DeepSeek Harness — shared by humans and AI agents via an Edge extension + local relay bridge.（✅ 活跃）
+- [dsh-cert-mcp](https://github.com/PerryLink/dsh-cert-mcp)  — 暴露 DSH 插件认证注册表的 MCP 服务器：查询认证、列出已认证插件、读取认证规范（✅ 活跃）
 - [dsh-chat-width](https://github.com/AnakinCao/dsh-chat-width)  — DSH Web GUI plugin: adaptive chat content width — the middle area expands with screen resolution (1080p/2K/4K) when side panels are collapsed (injects CSS overriding --dsh-chat-content-width)（✅ 活跃）
 - [dsh-chat-window-fold](https://github.com/dove-a/dsh-chat-window-fold)  — DSH web GUI plugin: auto fold/expand the chat window — bottom checkpoints hide old pages, top-scroll expands earlier messages with the viewport anchored.（✅ 活跃）
 - [dsh-codex-side-outline](https://github.com/EnkiduGilgamesh/dsh-codex-side-outline)  — Codex style side outline for Deepseek Harness（✅ 活跃）
@@ -9123,6 +9128,7 @@ awesome-deepseek-harness/
 - [dsh-plugin-web-notify](https://github.com/vilicvane/dsh-plugin-web-notify)  — Browser notifications for the DeepSeek Harness Web GUI.（✅ 活跃）
 - [dsh-queue-director](https://github.com/loklamlok/dsh-queue-director)  — DSH web plugin: reorder queued messages (up / down / top / bottom) before the agent processes them.（✅ 活跃）
 - [dsh-qwen-multimodal](https://github.com/wuwangmao/dsh-qwen-multimodal)  — DSH bundle: Qwen multimodal bridge — vision (qwen3-vl), speech-to-text (qwen3-asr), text-to-image (qwen-image), for DeepSeek Harness（✅ 活跃）
+- [dsh-reach](https://github.com/PerryLink/dsh-reach)  — 把 DSH 的审批卡与提问卡推送到 IM 渠道（先微信），可在聊天中直接作答，带会话控制台、逐渠道安全与开放推送服务（✅ 活跃）
 - [dsh-realtime-voice](https://github.com/martinbear1/dsh-realtime-voice)  — Realtime full-duplex voice Agent plugin for DeepSeek Harness WebUI and future WeChat Mini Program clients（✅ 活跃）
 - [dsh-session-bridge](https://github.com/FuWenLianggit/dsh-session-bridge)  — Session-level multi-thread orchestration for DeepSeek Harness: create ordinary sessions, send queued or interrupt prompts to any session by id, and enumerate sessions. Installs globally, independent of any agent preset.（✅ 活跃）
 - [dsh-side-chat](https://github.com/willwang0098/dsh-side-chat)  — Codex-style independent side chat for DeepSeek Harness Better Sidebar（✅ 活跃）

--- a/data/integrations.json
+++ b/data/integrations.json
@@ -11363,5 +11363,37 @@
       "jujutsu",
       "mcp"
     ]
+  },
+  {
+    "id": "dsh-reach",
+    "name": "dsh-reach",
+    "type": "integration",
+    "category": "channel",
+    "repository": "https://github.com/PerryLink/dsh-reach",
+    "description": "Pushes DSH approval and question cards to IM channels (WeChat first) and answers them from chat, with a session console, per-channel security, and an open push service",
+    "description_zh": "把 DSH 的审批卡与提问卡推送到 IM 渠道（先微信），可在聊天中直接作答，带会话控制台、逐渠道安全与开放推送服务",
+    "capabilities": [
+      "channels",
+      "notifications"
+    ],
+    "status": "active",
+    "verified": false,
+    "stars": 0
+  },
+  {
+    "id": "dsh-cert-mcp",
+    "name": "dsh-cert-mcp",
+    "type": "integration",
+    "category": "mcp",
+    "repository": "https://github.com/PerryLink/dsh-cert-mcp",
+    "description": "MCP server exposing the DSH plugin certification registry: get a certification, list certified plugins, and read the certification spec",
+    "description_zh": "暴露 DSH 插件认证注册表的 MCP 服务器：查询认证、列出已认证插件、读取认证规范",
+    "capabilities": [
+      "mcp",
+      "security"
+    ],
+    "status": "active",
+    "verified": false,
+    "stars": 0
   }
 ]

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -64264,5 +64264,21 @@
     "_topics": [
       "dsh-plugin"
     ]
+  },
+  {
+    "id": "dsh-ticktick",
+    "name": "dsh-ticktick",
+    "type": "plugin",
+    "category": "automation",
+    "repository": "https://github.com/PerryLink/dsh-ticktick",
+    "description": "TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint",
+    "description_zh": "TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点",
+    "capabilities": [
+      "ui",
+      "automation"
+    ],
+    "status": "active",
+    "verified": false,
+    "stars": 0
   }
 ]

--- a/docs/en/integrations.md
+++ b/docs/en/integrations.md
@@ -1,6 +1,6 @@
 ---
 title: "MCP & Integrations"
-description: "Top 10 and full list of 493 curated mcp & integrations for DeepSeek Harness (dsh)."
+description: "Top 10 and full list of 495 curated mcp & integrations for DeepSeek Harness (dsh)."
 keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 ---
 # MCP & Integrations
@@ -30,10 +30,10 @@ keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 | 9 | [dsh-super-injector](resources/dsh-super-injector.md) | ⭐133 | Super-injector plugin (cordis) for context injection. | ✅ active |
 | 10 | [dsh-crew](resources/dsh-crew-1.md) | ⭐119 | DeepSeek Harness (DSH) plugin: dispatch work to DSH agents from Claude Code / Codex — native subagent progress, in-host worker sessions with per-tier presets, and a multimodal bridge that lends the text-only harness vision and image generation. | ✅ active |
 
-## Complete list (493)
+## Complete list (495)
 
 
-**MCP (121)**
+**MCP (122)**
 
 | Project | Stars | Description | Status |
 |---|---|---|---|
@@ -151,6 +151,7 @@ keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 | [dsh-plugins](resources/dsh-plugins-22.md) | ⭐1 | DeepSeek Harness (DSH) 插件合集：协作编排、跨会话、团队模式、计划引擎、话题时间轴、语音、MCP 管理、提示词增强 | ✅ active |
 | [dsh-upgrade-kit](resources/dsh-upgrade-kit.md) | ⭐1 | DSH 装备升级套件：看钱（dsh-cost 费用面板）、看文件（file-preview 预览）、搜外网（research-mcp）、看图片（vision-bridge）。一条命令全装。 | ✅ active |
 | [mcp_guard](resources/mcp-guard.md) | ⭐1 | 本机 MCP / Agent 口扫描、监视与审计（loopback 未鉴权 tools/list、CORS）。DeepSeek Honeys. | ✅ active |
+| [dsh-cert-mcp](resources/dsh-cert-mcp.md) | – | MCP server exposing the DSH plugin certification registry: get a certification, list certified plugins, and read the certification spec | ✅ active |
 | [dsh-docker](resources/dsh-docker-bf2.md) | – | 隔离的 DeepSeek Harness 插件安装沙箱，并对本机 MCP 口做防御性探测。 | ✅ active |
 | [dsh-feed](resources/dsh-feed.md) | – | Cross-ecosystem aggregation base (聚合的聚合): syncs GitHub dsh-plugin topic + npm into one open JSON index, queried by model tools, CLI (dsh-feed) and a minimal stdio MCP server | ✅ active |
 | [dsh-image-bridge](resources/dsh-image-bridge-2.md) | – | 让文本模型（如 DeepSeek）也能正常发送图片：图片落盘到工作区，消息转成仅模型可见的路径文本，由模型调用视觉/MCP 工具识别。 | ✅ active |
@@ -159,7 +160,7 @@ keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 | [dsh-streaming-mcp-bridge](resources/dsh-streaming-mcp-bridge.md) | – | DeepSeek Harness streaming MCP bridge: live session events as MCP progress, plus ACP adapter for cc-connect/Feishu. | ✅ active |
 | [URL Manager MCP](resources/url-manager-mcp.md) | – | MCP companion for URL Manager: 21 tools for save/search/categorize/share with magic-link delivery. | ✅ active |
 
-**Channels (115)**
+**Channels (116)**
 
 | Project | Stars | Description | Status |
 |---|---|---|---|
@@ -275,6 +276,7 @@ keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 | [dsh-chat-window-fold](resources/dsh-chat-window-fold.md) | – | DSH web GUI plugin: auto fold/expand the chat window — bottom checkpoints hide old pages, top-scroll expands earlier messages with the viewport anchored. | ✅ active |
 | [dsh-composer-fix](resources/dsh-composer-fix.md) | – | DSH Web GUI layout fix: composer (input bar + bottom status bar) leaves the scroll region — message scrolling stops above the input bar, the scrollbar no longer covers the input area | ✅ active |
 | [dsh-queue-director](resources/dsh-queue-director.md) | – | DSH web plugin: reorder queued messages (up / down / top / bottom) before the agent processes them. | ✅ active |
+| [dsh-reach](resources/dsh-reach.md) | – | Pushes DSH approval and question cards to IM channels (WeChat first) and answers them from chat, with a session console, per-channel security, and an open push service | ✅ active |
 | [dsh-realtime-voice](resources/dsh-realtime-voice.md) | – | Realtime full-duplex voice Agent plugin for DeepSeek Harness WebUI and future WeChat Mini Program clients | ✅ active |
 | [dsh-ssh-hub](resources/dsh-ssh-hub.md) | – | Multi-server SSH terminal panel for DeepSeek Harness Web GUI — multiple SSH terminals in a bottom panel | ✅ active |
 | [dsh-wechat-bridge](resources/dsh-wechat-bridge-2.md) | – | Personal WeChat bridge for DeepSeek Harness: scan QR to bind, then chat with your local DSH agent directly inside WeChat (text/image/voice/file, streamed replies, persisted sessions). | ✅ active |

--- a/docs/en/plugins.md
+++ b/docs/en/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "Top 10 and full list of 2814 curated plugins for DeepSeek Harness (dsh)."
+description: "Top 10 and full list of 2815 curated plugins for DeepSeek Harness (dsh)."
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,7 +30,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [memsearch](resources/memsearch.md) | ⭐2,538 | Persistent, unified memory layer for all your AI agents (e.g. Claude Code, Codex, DSH), backed by Markdown and Milvus. / 面向所有 AI Agent（如 Claude Code、Codex、DSH）的持久化统一记忆层，基于 Markdown 与 Milvus。 | ✅ active |
 | 10 | [dsh-market](resources/dsh-market.md) | ⭐1,582 | Visual plugin market inside DeepSeek Harness: browse, search and one-click install. | ✅ active |
 
-## Complete list (2814)
+## Complete list (2815)
 
 
 **Vision & multimodal (1025)**
@@ -2975,13 +2975,14 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-fund-research](resources/dsh-fund-research.md) | ⭐18 | Chinese public mutual fund research: public-source data collection and deterministic manager/portfolio metrics. | ✅ active |
 | [dsh-trading](resources/dsh-trading.md) | ⭐12 | Research-only trading workbench for DSH: typed market-data seam (BYO provider), multi-timeframe indicator snapshots, interactive chart cards with provenance-gated annotations, and a risk-guard denying execution-shaped tool calls. No execution seam by construction. | ✅ active |
 
-**Automation (3)**
+**Automation (4)**
 
 | Project | Stars | Description | Status |
 |---|---|---|---|
 | [dsh-click](resources/dsh-click.md) | ⭐4 | Cross-platform native desktop control (Windows first): screenshot, screen read, click/type/scroll/key, app list and launch. | ✅ active |
 | [dsh-qqbot-panel](resources/dsh-qqbot-panel.md) | – | Visual web settings panel for the official @tencent-connect/dsh-qqbot plugin: manage AppID/AppSecret, c2c & group access/allowlists, workspace picker, and scan-to-bind from the DSH web settings page. | ✅ active |
 | [dsh-task-dispatcher](resources/dsh-task-dispatcher.md) | – | TickTick (滴答清单) daily task dispatcher for DeepSeek Harness: interval-based pulls of today's due tasks, notify (flomo + macOS), optional auto-execute in headless DSH sessions, worker workspace selection, and a web task board. | ✅ active |
+| [dsh-ticktick](resources/dsh-ticktick.md) | – | TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint | ✅ active |
 
 **Security (2)**
 

--- a/docs/en/resources/dsh-cert-mcp.md
+++ b/docs/en/resources/dsh-cert-mcp.md
@@ -1,0 +1,28 @@
+---
+title: "dsh-cert-mcp"
+description: "MCP server exposing the DSH plugin certification registry: get a certification, list certified plugins, and read the certification spec"
+keywords: "dsh-cert-mcp, mcp, integration, security, deepseek harness, dsh"
+---
+# dsh-cert-mcp
+
+> ⭐ **0** · ✅ active · integration
+
+| | | | |
+|---|---|---|---|
+| Type | integration | Category | MCP |
+| Stars | ⭐ 0 | Status | ✅ active |
+| Author | [PerryLink](https://github.com/PerryLink) | Updated | — |
+
+## One-liner
+
+> MCP server exposing the DSH plugin certification registry: get a certification, list certified plugins, and read the certification spec
+
+## About
+
+MCP server exposing the DSH plugin certification registry: get a certification, list certified plugins, and read the certification spec
+
+## 🔗 Links
+
+- [GitHub Repository](https://github.com/PerryLink/dsh-cert-mcp)
+- [Full README](https://github.com/PerryLink/dsh-cert-mcp#readme)
+- [Back to the MCP & Integrations list](../integrations.md)

--- a/docs/en/resources/dsh-reach.md
+++ b/docs/en/resources/dsh-reach.md
@@ -1,0 +1,28 @@
+---
+title: "dsh-reach"
+description: "Pushes DSH approval and question cards to IM channels (WeChat first) and answers them from chat, with a session console, per-channel security, and an open push service"
+keywords: "dsh-reach, channel, integration, channels, notifications, deepseek harness, dsh"
+---
+# dsh-reach
+
+> ⭐ **0** · ✅ active · integration
+
+| | | | |
+|---|---|---|---|
+| Type | integration | Category | Channels |
+| Stars | ⭐ 0 | Status | ✅ active |
+| Author | [PerryLink](https://github.com/PerryLink) | Updated | — |
+
+## One-liner
+
+> Pushes DSH approval and question cards to IM channels (WeChat first) and answers them from chat, with a session console, per-channel security, and an open push service
+
+## About
+
+Pushes DSH approval and question cards to IM channels (WeChat first) and answers them from chat, with a session console, per-channel security, and an open push service
+
+## 🔗 Links
+
+- [GitHub Repository](https://github.com/PerryLink/dsh-reach)
+- [Full README](https://github.com/PerryLink/dsh-reach#readme)
+- [Back to the MCP & Integrations list](../integrations.md)

--- a/docs/en/resources/dsh-ticktick.md
+++ b/docs/en/resources/dsh-ticktick.md
@@ -1,0 +1,28 @@
+---
+title: "dsh-ticktick"
+description: "TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint"
+keywords: "dsh-ticktick, automation, plugin, ui, deepseek harness, dsh"
+---
+# dsh-ticktick
+
+> ⭐ **0** · ✅ active · plugin
+
+| | | | |
+|---|---|---|---|
+| Type | plugin | Category | Automation |
+| Stars | ⭐ 0 | Status | ✅ active |
+| Author | [PerryLink](https://github.com/PerryLink) | Updated | — |
+
+## One-liner
+
+> TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint
+
+## About
+
+TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint
+
+## 🔗 Links
+
+- [GitHub Repository](https://github.com/PerryLink/dsh-ticktick)
+- [Full README](https://github.com/PerryLink/dsh-ticktick#readme)
+- [Back to the Plugins list](../plugins.md)

--- a/docs/zh/integrations.md
+++ b/docs/zh/integrations.md
@@ -1,6 +1,6 @@
 ---
 title: "MCP & Integrations"
-description: "DeepSeek Harness (dsh) 精选 mcp & integrations：🔥 Top 10 与完整列表（493 条）。"
+description: "DeepSeek Harness (dsh) 精选 mcp & integrations：🔥 Top 10 与完整列表（495 条）。"
 keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 ---
 # MCP & Integrations
@@ -30,10 +30,10 @@ keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 | 9 | [dsh-super-injector](resources/dsh-super-injector.md) | ⭐133 | 上下文注入增强插件（cordis）。 | ✅ 活跃 |
 | 10 | [dsh-crew](resources/dsh-crew-1.md) | ⭐119 | DeepSeek Harness (DSH) plugin: dispatch work to DSH agents from Claude Code / Codex — native subagent progress, in-host worker sessions with per-tier presets, and a multimodal bridge that lends the text-only harness vision and image generation. | ✅ 活跃 |
 
-## 完整列表（493）
+## 完整列表（495）
 
 
-**MCP（121）**
+**MCP（122）**
 
 | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|
@@ -151,6 +151,7 @@ keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 | [dsh-plugins](resources/dsh-plugins-22.md) | ⭐1 | DeepSeek Harness (DSH) 插件合集：协作编排、跨会话、团队模式、计划引擎、话题时间轴、语音、MCP 管理、提示词增强 | ✅ 活跃 |
 | [dsh-upgrade-kit](resources/dsh-upgrade-kit.md) | ⭐1 | DSH 装备升级套件：看钱（dsh-cost 费用面板）、看文件（file-preview 预览）、搜外网（research-mcp）、看图片（vision-bridge）。一条命令全装。 | ✅ 活跃 |
 | [mcp_guard](resources/mcp-guard.md) | ⭐1 | 本机 MCP / Agent 口扫描、监视与审计（loopback 未鉴权 tools/list、CORS）。DeepSeek Honeys. | ✅ 活跃 |
+| [dsh-cert-mcp](resources/dsh-cert-mcp.md) | – | 暴露 DSH 插件认证注册表的 MCP 服务器：查询认证、列出已认证插件、读取认证规范 | ✅ 活跃 |
 | [dsh-docker](resources/dsh-docker-bf2.md) | – | 隔离的 DeepSeek Harness 插件安装沙箱，并对本机 MCP 口做防御性探测。 | ✅ 活跃 |
 | [dsh-feed](resources/dsh-feed.md) | – | Cross-ecosystem aggregation base (聚合的聚合): syncs GitHub dsh-plugin topic + npm into one open JSON index, queried by model tools, CLI (dsh-feed) and a minimal stdio MCP server | ✅ 活跃 |
 | [dsh-image-bridge](resources/dsh-image-bridge-2.md) | – | 让文本模型（如 DeepSeek）也能正常发送图片：图片落盘到工作区，消息转成仅模型可见的路径文本，由模型调用视觉/MCP 工具识别。 | ✅ 活跃 |
@@ -159,7 +160,7 @@ keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 | [dsh-streaming-mcp-bridge](resources/dsh-streaming-mcp-bridge.md) | – | DeepSeek Harness streaming MCP bridge: live session events as MCP progress, plus ACP adapter for cc-connect/Feishu. | ✅ 活跃 |
 | [URL Manager MCP](resources/url-manager-mcp.md) | – | URL Manager 的 MCP 伴生服务器：21 个工具用于保存/搜索/分类/共享与魔法链接投递。 | ✅ 活跃 |
 
-**渠道（115）**
+**渠道（116）**
 
 | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|
@@ -275,6 +276,7 @@ keywords: "deepseek harness, dsh, mcp integrations, plugin, awesome"
 | [dsh-chat-window-fold](resources/dsh-chat-window-fold.md) | – | DSH web GUI plugin: auto fold/expand the chat window — bottom checkpoints hide old pages, top-scroll expands earlier messages with the viewport anchored. | ✅ 活跃 |
 | [dsh-composer-fix](resources/dsh-composer-fix.md) | – | DSH Web GUI layout fix: composer (input bar + bottom status bar) leaves the scroll region — message scrolling stops above the input bar, the scrollbar no longer covers the input area | ✅ 活跃 |
 | [dsh-queue-director](resources/dsh-queue-director.md) | – | DSH web plugin: reorder queued messages (up / down / top / bottom) before the agent processes them. | ✅ 活跃 |
+| [dsh-reach](resources/dsh-reach.md) | – | 把 DSH 的审批卡与提问卡推送到 IM 渠道（先微信），可在聊天中直接作答，带会话控制台、逐渠道安全与开放推送服务 | ✅ 活跃 |
 | [dsh-realtime-voice](resources/dsh-realtime-voice.md) | – | Realtime full-duplex voice Agent plugin for DeepSeek Harness WebUI and future WeChat Mini Program clients | ✅ 活跃 |
 | [dsh-ssh-hub](resources/dsh-ssh-hub.md) | – | Multi-server SSH terminal panel for DeepSeek Harness Web GUI — multiple SSH terminals in a bottom panel | ✅ 活跃 |
 | [dsh-wechat-bridge](resources/dsh-wechat-bridge-2.md) | – | 个人微信桥接插件：扫码绑定后直接在微信里与本机 DeepSeek Harness Agent 对话（文字/图片/语音/文件、流式回复、会话持久化、三端通用）。 | ✅ 活跃 |

--- a/docs/zh/plugins.md
+++ b/docs/zh/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: "Plugins"
-description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（2814 条）。"
+description: "DeepSeek Harness (dsh) 精选 plugins：🔥 Top 10 与完整列表（2815 条）。"
 keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 ---
 # Plugins
@@ -30,7 +30,7 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | 9 | [memsearch](resources/memsearch.md) | ⭐2,538 | 面向所有 AI Agent（如 Claude Code、Codex、DSH）的持久化统一记忆层，基于 Markdown 与 Milvus 构建。 | ✅ 活跃 |
 | 10 | [dsh-market](resources/dsh-market.md) | ⭐1,582 | DSH 内置可视化插件市场：浏览、搜索、一键安装。 | ✅ 活跃 |
 
-## 完整列表（2814）
+## 完整列表（2815）
 
 
 **视觉与多模态（1025）**
@@ -2975,13 +2975,14 @@ keywords: "deepseek harness, dsh, plugins, plugin, awesome"
 | [dsh-fund-research](resources/dsh-fund-research.md) | ⭐18 | 中国公募基金研究：公开源数据采集 + 确定性经理/组合指标计算。 | ✅ 活跃 |
 | [dsh-trading](resources/dsh-trading.md) | ⭐12 | 纯研究型交易工作台插件：类型化行情数据缝（自带 provider）、多周期指标快照、带溯源门控标注的交互图表卡片，以及拒绝执行型工具调用的风险护栏——架构上不提供执行能力。 | ✅ 活跃 |
 
-**自动化（3）**
+**自动化（4）**
 
 | 项目 | 星数 | 说明 | 状态 |
 |---|---|---|---|
 | [dsh-click](resources/dsh-click.md) | ⭐4 | 跨平台原生桌面控制（Windows 优先）：截图、读屏、点击/输入/滚动/按键、应用列表与启动。 | ✅ 活跃 |
 | [dsh-qqbot-panel](resources/dsh-qqbot-panel.md) | – | 为官方 @tencent-connect/dsh-qqbot 提供的可视化配置面板：管理 AppID/AppSecret、私聊/群聊访问模式与白名单、工作区选择、扫码绑定（Web 设置页）。 | ✅ 活跃 |
 | [dsh-task-dispatcher](resources/dsh-task-dispatcher.md) | – | DeepSeek Harness 的滴答清单任务派发器：按间隔拉取今天到期任务，flomo+macOS 通知，可选自动执行（每任务一个 headless 会话）、执行会话工作区选择与 Web 任务看板。 | ✅ 活跃 |
+| [dsh-ticktick](resources/dsh-ticktick.md) | – | TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点 | ✅ 活跃 |
 
 **安全（2）**
 

--- a/docs/zh/resources/dsh-cert-mcp.md
+++ b/docs/zh/resources/dsh-cert-mcp.md
@@ -1,0 +1,28 @@
+---
+title: "dsh-cert-mcp"
+description: "暴露 DSH 插件认证注册表的 MCP 服务器：查询认证、列出已认证插件、读取认证规范"
+keywords: "dsh-cert-mcp, mcp, integration, security, deepseek harness, dsh"
+---
+# dsh-cert-mcp
+
+> ⭐ **0** · ✅ 活跃 · 集成
+
+| | | | |
+|---|---|---|---|
+| 类型 | 集成 | 分类 | MCP |
+| 星数 | ⭐ 0 | 状态 | ✅ 活跃 |
+| 作者 | [PerryLink](https://github.com/PerryLink) | 更新时间 | — |
+
+## 一句话介绍
+
+> 暴露 DSH 插件认证注册表的 MCP 服务器：查询认证、列出已认证插件、读取认证规范
+
+## 详细介绍
+
+暴露 DSH 插件认证注册表的 MCP 服务器：查询认证、列出已认证插件、读取认证规范
+
+## 🔗 链接
+
+- [GitHub 仓库](https://github.com/PerryLink/dsh-cert-mcp)
+- [完整 README](https://github.com/PerryLink/dsh-cert-mcp#readme)
+- [返回dsh-cert-mcp所在分类](../integrations.md)

--- a/docs/zh/resources/dsh-reach.md
+++ b/docs/zh/resources/dsh-reach.md
@@ -1,0 +1,28 @@
+---
+title: "dsh-reach"
+description: "把 DSH 的审批卡与提问卡推送到 IM 渠道（先微信），可在聊天中直接作答，带会话控制台、逐渠道安全与开放推送服务"
+keywords: "dsh-reach, channel, integration, channels, notifications, deepseek harness, dsh"
+---
+# dsh-reach
+
+> ⭐ **0** · ✅ 活跃 · 集成
+
+| | | | |
+|---|---|---|---|
+| 类型 | 集成 | 分类 | 渠道 |
+| 星数 | ⭐ 0 | 状态 | ✅ 活跃 |
+| 作者 | [PerryLink](https://github.com/PerryLink) | 更新时间 | — |
+
+## 一句话介绍
+
+> 把 DSH 的审批卡与提问卡推送到 IM 渠道（先微信），可在聊天中直接作答，带会话控制台、逐渠道安全与开放推送服务
+
+## 详细介绍
+
+把 DSH 的审批卡与提问卡推送到 IM 渠道（先微信），可在聊天中直接作答，带会话控制台、逐渠道安全与开放推送服务
+
+## 🔗 链接
+
+- [GitHub 仓库](https://github.com/PerryLink/dsh-reach)
+- [完整 README](https://github.com/PerryLink/dsh-reach#readme)
+- [返回dsh-reach所在分类](../integrations.md)

--- a/docs/zh/resources/dsh-ticktick.md
+++ b/docs/zh/resources/dsh-ticktick.md
@@ -1,0 +1,28 @@
+---
+title: "dsh-ticktick"
+description: "TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点"
+keywords: "dsh-ticktick, automation, plugin, ui, deepseek harness, dsh"
+---
+# dsh-ticktick
+
+> ⭐ **0** · ✅ 活跃 · 插件
+
+| | | | |
+|---|---|---|---|
+| 类型 | 插件 | 分类 | 自动化 |
+| 星数 | ⭐ 0 | 状态 | ✅ 活跃 |
+| 作者 | [PerryLink](https://github.com/PerryLink) | 更新时间 | — |
+
+## 一句话介绍
+
+> TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点
+
+## 详细介绍
+
+TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点
+
+## 🔗 链接
+
+- [GitHub 仓库](https://github.com/PerryLink/dsh-ticktick)
+- [完整 README](https://github.com/PerryLink/dsh-ticktick#readme)
+- [返回dsh-ticktick所在分类](../plugins.md)


### PR DESCRIPTION
Adds three PerryLink projects to the directory:

- `dsh-reach` (integrations, channel) — pushes DSH approval/question cards to IM channels (WeChat first) and answers them from chat.
- `dsh-ticktick` (plugins, automation) — TickTick (Dida365) task bridge: session-header task panel and curated agent tools over the official TickTick MCP endpoint.
- `dsh-cert-mcp` (integrations, mcp) — MCP server exposing the DSH plugin certification registry.

Notes:
- `scripts/validate.py --strict` passes: PASS (0 errors, 0 warnings).
- README.md / README.zh-CN.md and docs/ regenerated with `scripts/generate-readme.py` and `scripts/generate-docs.py` per CONTRIBUTING.md.
- `category` / `capabilities` values are taken from the current `schemas/resource.schema.json` enums.
- `dsh-wechat` is intentionally not added: `integrations.json` already lists upstream pan17/dsh-wechat, and PerryLink/dsh-wechat is a fork of it (one entry per project).